### PR TITLE
fix issue IOTDB-2, separate UTs and ITs

### DIFF
--- a/grafana/pom.xml
+++ b/grafana/pom.xml
@@ -42,6 +42,9 @@
         <start-class>org.apache.iotdb.web.grafana.TsfileWebDemoApplication</start-class>
         <spring-boot.version>1.5.4.RELEASE</spring-boot.version>
         <spring.version>4.3.9.RELEASE</spring.version>
+        <grafana.test.skip>false</grafana.test.skip>
+        <grafana.it.skip>${grafana.test.skip}</grafana.it.skip>
+        <grafana.ut.skip>${grafana.test.skip}</grafana.ut.skip>
     </properties>
     <!-- Import the dependency-management information from the spring-boot poms -->
     <dependencyManagement>
@@ -166,6 +169,33 @@
                         </execution>
                     </executions>
                 </plugin>
+                <!--using `mvn test` to run UT, `mvn verify` to run ITs
+                    Reference: https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/-->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <skipTests>${grafana.ut.skip}</skipTests>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>run-integration-tests</id>
+                            <phase>integration-test</phase>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <skipTests>${grafana.test.skip}</skipTests>
+                        <skipITs>${grafana.it.skip}</skipITs>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -187,4 +217,20 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>skipTsfileTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <grafana.test.skip>true</grafana.test.skip>
+                <grafana.ut.skip>true</grafana.ut.skip>
+                <grafana.it.skip>true</grafana.it.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/iotdb-cli/pom.xml
+++ b/iotdb-cli/pom.xml
@@ -32,9 +32,11 @@
     <name>IoTDB Cli</name>
     <description>A Client tool.</description>
     <properties>
-        <cli.test.skip>false</cli.test.skip>
         <common.cli.version>1.3.1</common.cli.version>
         <jline.version>2.14.5</jline.version>
+        <cli.test.skip>false</cli.test.skip>
+        <cli.it.skip>${cli.test.skip}</cli.it.skip>
+        <cli.ut.skip>${cli.test.skip}</cli.ut.skip>
     </properties>
     <dependencies>
         <dependency>
@@ -97,13 +99,49 @@
                     <outputDirectory>${project.basedir}/cli/lib</outputDirectory>
                 </configuration>
             </plugin>
+            <!--using `mvn test` to run UT, `mvn verify` to run ITs
+            Reference: https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <skipTests>${cli.ut.skip}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>run-integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
                     <skipTests>${cli.test.skip}</skipTests>
+                    <skipITs>${cli.it.skip}</skipITs>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>skipCliTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <cli.test.skip>true</cli.test.skip>
+                <cli.ut.skip>true</cli.ut.skip>
+                <cli.it.skip>true</cli.it.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/iotdb-cli/src/test/java/org/apache/iotdb/cli/client/AbstractClientIT.java
+++ b/iotdb-cli/src/test/java/org/apache/iotdb/cli/client/AbstractClientIT.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-public class AbstractClientTest {
+public class AbstractClientIT {
 
   @Mock
   private IoTDBConnection connection;

--- a/iotdb-cli/src/test/java/org/apache/iotdb/cli/client/StartClientScriptIT.java
+++ b/iotdb-cli/src/test/java/org/apache/iotdb/cli/client/StartClientScriptIT.java
@@ -31,7 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class StartClientScriptTest {
+public class StartClientScriptIT {
 
   @Before
   public void setUp() throws Exception {
@@ -43,6 +43,7 @@ public class StartClientScriptTest {
 
   @Test
   public void test() throws IOException, InterruptedException {
+
     String os = System.getProperty("os.name").toLowerCase();
     if (os.startsWith("windows")) {
       testStartClientOnWindows();

--- a/iotdb/pom.xml
+++ b/iotdb/pom.xml
@@ -34,8 +34,8 @@
         <antlr3.version>3.5.2</antlr3.version>
         <common.lang3.version>3.8.1</common.lang3.version>
         <iotdb.test.skip>false</iotdb.test.skip>
-        <it.test.includes>**/*Test.java</it.test.includes>
-        <it.test.excludes>**/NoTest.java</it.test.excludes>
+        <iotdb.it.skip>${iotdb.test.skip}</iotdb.it.skip>
+        <iotdb.ut.skip>${iotdb.test.skip}</iotdb.ut.skip>
     </properties>
     <dependencies>
         <dependency>
@@ -164,18 +164,31 @@
                     <outputDirectory>${project.basedir}/iotdb/lib</outputDirectory>
                 </configuration>
             </plugin>
+            <!--using `mvn test` to run UT, `mvn verify` to run ITs
+                        Reference: https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <runOrder>alphabetical</runOrder>
+                    <skipTests>${iotdb.ut.skip}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>run-integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
                     <skipTests>${iotdb.test.skip}</skipTests>
-                    <excludes>
-                        <exclude>${it.test.excludes}</exclude>
-                    </excludes>
-                    <includes>
-                        <include>${it.test.includes}</include>
-                    </includes>
+                    <skipITs>${iotdb.it.skip}</skipITs>
                 </configuration>
             </plugin>
             <!-- Might require this in Eclipse -->
@@ -199,4 +212,20 @@
 </plugin-->
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>skipTsfileTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <iotdb.test.skip>true</iotdb.test.skip>
+                <iotdb.ut.skip>true</iotdb.ut.skip>
+                <iotdb.it.skip>true</iotdb.it.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBAuthorizationIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBAuthorizationIT.java
@@ -38,13 +38,13 @@ import org.junit.Test;
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
  * defined as integration test.
  */
-public class IoTDBAuthorizationTest {
+public class IoTDBAuthorizationIT {
 
   private IoTDB deamon;
 
   public static void main(String[] args) throws Exception {
     for (int i = 0; i < 10; i++) {
-      IoTDBAuthorizationTest test = new IoTDBAuthorizationTest();
+      IoTDBAuthorizationIT test = new IoTDBAuthorizationIT();
       test.setUp();
       test.authPerformanceTest();
       test.tearDown();

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBCompleteIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBCompleteIT.java
@@ -38,7 +38,7 @@ import org.junit.Test;
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
  * defined as integration test.
  */
-public class IoTDBCompleteTest {
+public class IoTDBCompleteIT {
 
   private IoTDB deamon;
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBDaemonIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBDaemonIT.java
@@ -46,7 +46,7 @@ import org.junit.Test;
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
  * defined as integration test.
  */
-public class IoTDBDaemonTest {
+public class IoTDBDaemonIT {
 
   private static IoTDB deamon;
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
@@ -51,7 +51,7 @@ import org.junit.Test;
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
  * defined as integration test.
  */
-public class IoTDBEngineTimeGeneratorTest {
+public class IoTDBEngineTimeGeneratorIT {
 
   private static IoTDB daemon;
   private static TSFileConfig tsFileConfig = TSFileDescriptor.getInstance().getConfig();

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBLargeDataIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBLargeDataIT.java
@@ -42,7 +42,7 @@ import org.junit.Test;
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
  * defined as integration test.
  */
-public class IoTDBMultiSeriesTest {
+public class IoTDBLargeDataIT {
 
   private static IoTDB deamon;
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBLimitSlimitIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBLimitSlimitIT.java
@@ -41,7 +41,7 @@ import org.junit.Test;
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
  * defined as integration test.
  */
-public class IoTDBLimitSlimitTest {
+public class IoTDBLimitSlimitIT {
 
   private static IoTDB deamon;
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
@@ -42,7 +42,7 @@ import org.junit.Test;
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
  * defined as integration test.
  */
-public class IoTDBMetadataFetchTest {
+public class IoTDBMetadataFetchIT {
 
   private static IoTDB deamon;
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBMultiSeriesIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBMultiSeriesIT.java
@@ -42,7 +42,7 @@ import org.junit.Test;
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
  * defined as integration test.
  */
-public class IoTDBLargeDataTest {
+public class IoTDBMultiSeriesIT {
 
   private static IoTDB deamon;
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
@@ -51,7 +51,7 @@ import org.junit.Test;
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
  * defined as integration test. In this test case, no unseq insert data.
  */
-public class IoTDBSequenceDataQueryTest {
+public class IoTDBSequenceDataQueryIT {
 
   private static IoTDB daemon;
   private static TSFileConfig tsFileConfig = TSFileDescriptor.getInstance().getConfig();

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
@@ -50,7 +50,7 @@ import org.junit.Test;
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
  * defined as integration test.
  */
-public class IoTDBSeriesReaderTest {
+public class IoTDBSeriesReaderIT {
 
   private static IoTDB deamon;
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBTimeZoneIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBTimeZoneIT.java
@@ -36,7 +36,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class IoTDBTimeZoneTest {
+public class IoTDBTimeZoneIT {
 
   private static String[] insertSqls = new String[]{"SET STORAGE GROUP TO root.timezone",
       "CREATE TIMESERIES root.timezone.tz1 WITH DATATYPE = INT32, ENCODING = PLAIN",};

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -33,6 +33,8 @@
     <description>A jdbc driver for a time series database, IoTDB, which uses TsFile as its storage format on disk.</description>
     <properties>
         <jdbc.test.skip>false</jdbc.test.skip>
+        <jdbc.it.skip>${jdbc.test.skip}</jdbc.it.skip>
+        <jdbc.ut.skip>${jdbc.test.skip}</jdbc.ut.skip>
     </properties>
     <dependencies>
         <dependency>
@@ -68,11 +70,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--using `mvn test` to run UT, `mvn verify` to run ITs
+            Reference: https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <skipTests>${jdbc.ut.skip}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>run-integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
                     <skipTests>${jdbc.test.skip}</skipTests>
+                    <skipITs>${jdbc.it.skip}</skipITs>
                 </configuration>
             </plugin>
         </plugins>
@@ -115,6 +137,20 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <profile>
+            <id>skipTsfileTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <jdbc.test.skip>true</jdbc.test.skip>
+                <jdbc.ut.skip>true</jdbc.ut.skip>
+                <jdbc.it.skip>true</jdbc.it.skip>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/service-rpc/pom.xml
+++ b/service-rpc/pom.xml
@@ -31,12 +31,48 @@
     <artifactId>service-rpc</artifactId>
     <name>Service-rpc</name>
     <description>RPC framework for client and server.</description>
+    <properties>
+        <rpc.test.skip>false</rpc.test.skip>
+        <rpc.it.skip>${rpc.test.skip}</rpc.it.skip>
+        <rpc.ut.skip>${rpc.test.skip}</rpc.ut.skip>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <!--using `mvn test` to run UT, `mvn verify` to run ITs
+            Reference: https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${rpc.ut.skip}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>run-integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipTests>${rpc.test.skip}</skipTests>
+                    <skipITs>${rpc.it.skip}</skipITs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>only-eclipse</id>
@@ -90,6 +126,20 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <profile>
+            <id>skipTsfileTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <rpc.test.skip>true</rpc.test.skip>
+                <rpc.ut.skip>true</rpc.ut.skip>
+                <rpc.it.skip>true</rpc.it.skip>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/tsfile/pom.xml
+++ b/tsfile/pom.xml
@@ -34,6 +34,8 @@
     <url>https://github.com/thulab/iotdb/tree/master/tsfile</url>
     <properties>
         <tsfile.test.skip>false</tsfile.test.skip>
+        <tsfile.it.skip>${tsfile.test.skip}</tsfile.it.skip>
+        <tsfile.ut.skip>${tsfile.test.skip}</tsfile.ut.skip>
     </properties>
     <dependencies>
         <dependency>
@@ -65,12 +67,31 @@
     </dependencies>
     <build>
         <plugins>
+            <!--using `mvn test` to run UT, `mvn verify` to run ITs
+            Reference: https://antoniogoncalves.org/2012/12/13/lets-turn-integration-tests-with-maven-to-a-first-class-citizen/-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xmx1024m</argLine>
+                    <skipTests>${tsfile.ut.skip}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>run-integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
                     <skipTests>${tsfile.test.skip}</skipTests>
+                    <skipITs>${tsfile.it.skip}</skipITs>
                 </configuration>
             </plugin>
             <plugin>
@@ -95,4 +116,20 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>skipTsfileTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <tsfile.test.skip>true</tsfile.test.skip>
+                <tsfile.ut.skip>true</tsfile.ut.skip>
+                <tsfile.it.skip>true</tsfile.it.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Fix https://issues.apache.org/jira/browse/IOTDB-2
Now we can use :
* `mvn test` to run all UTs.
* `mvn package -DskipTests` to skip all UTs.
* `mvn package -Dtsfile.test.skip` to skip all UTs in Tsfile Module.
** `-Diotdb.test.skip`, `-Djdbc.test.skip`, `-Drpc.test.skip`, `-Dgrafana.test.skip` and  `-Dcli.test.skip` are similar.
* `mvn verify` to run all ITs.
* `mvn verify -Dtsfile.it.skip` to skip all ITs.
** similarly, you can use`-Diotdb.it.skip`, `-Djdbc.it.skip`, `-Drpc.it.skip`, `-Dgrafana.it.skip` and  `-Dcli.it.skip`
* `mvn install` to run all Tests (both UTs and ITs).

What are UTs: java files which are in `src/test/java/` and have suffix with `Test.java` 
What are ITs: java files which are in `src/test/java/` and have suffix with `IT.java` 
