### PR TITLE
set logback output on console as WARN level when running UTs and ITs

### DIFF
--- a/iotdb-cli/src/test/resources/logback.xml
+++ b/iotdb-cli/src/test/resources/logback.xml
@@ -97,18 +97,15 @@
             <onMismatch>DENY</onMismatch>
         </filter>
     </appender>
-    <appender class="ch.qos.logback.core.ConsoleAppender" name="stdout">
-        <Target>System.out</Target>
+    <appender class="ch.qos.logback.core.ConsoleAppender" name="stdout1">
         <encoder>
             <pattern>%-5p [%d] [%thread] %C:%L - %m %n</pattern>
             <charset>utf-8</charset>
         </encoder>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>DEBUG</level>
-        </filter>
     </appender>
     <!--<logger name="org.apache.iotdb.tsfile.write.chunk.ChunkWriterImpl level="debug" />-->
-    <root level="ERROR">
-        <appender-ref ref="FILEERROR"/>
+    <logger name="org.apache.iotdb" level="WARN"/>
+    <root level="WARN">
+        <appender-ref ref="stdout1"/>
     </root>
 </configuration>

--- a/iotdb/src/test/resources/logback.xml
+++ b/iotdb/src/test/resources/logback.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<configuration debug="false">
+    <property name="LOG_PATH" value="logs"/>
+    <!-- prevent logback from outputting its own status at the start of every log -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+    <appender class="ch.qos.logback.core.ConsoleAppender" name="stdout1">
+        <encoder>
+            <pattern>%-5p [%d] [%thread] %C:%L - %m %n</pattern>
+            <charset>utf-8</charset>
+        </encoder>
+    </appender>
+    <!--<logger name="org.apache.iotdb.tsfile.write.chunk.ChunkWriterImpl level="debug" />-->
+    <logger name="org.apache.iotdb" level="WARN"/>
+    <root level="WARN">
+        <appender-ref ref="stdout1"/>
+    </root>
+</configuration>

--- a/tsfile/src/test/resources/logback.xml
+++ b/tsfile/src/test/resources/logback.xml
@@ -99,18 +99,15 @@
             <onMismatch>DENY</onMismatch>
         </filter>
     </appender>
-    <appender class="ch.qos.logback.core.ConsoleAppender" name="stdout">
-        <Target>System.out</Target>
+    <appender class="ch.qos.logback.core.ConsoleAppender" name="stdout1">
         <encoder>
             <pattern>%-5p [%d] [%thread] %C:%L - %m %n</pattern>
             <charset>utf-8</charset>
         </encoder>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>DEBUG</level>
-        </filter>
     </appender>
     <!--<logger name="org.apache.iotdb.tsfile.write.chunk.ChunkWriterImpl level="debug" />-->
-    <root level="INFO">
-        <appender-ref ref="stdout"/>
+    <logger name="org.apache.iotdb" level="WARN"/>
+    <root level="WARN">
+        <appender-ref ref="stdout1"/>
     </root>
 </configuration>


### PR DESCRIPTION
If you want to read more logs. you need to modify `src/test/resources/logback.xml` by  comment:
`<logger name="org.apache.iotdb" level="WARN"/>`