### PR TITLE
fix the issues that difference of key-value order between hashMap.toS…

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import org.apache.iotdb.db.exception.PathErrorException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -941,7 +942,7 @@ public class MTree implements Serializable {
       builder
           .append(String.format("%s Encoding: %s,\n", getTabs(tab + 1), node.getSchema().encoding));
       builder
-          .append(String.format("%s args: %s,\n", getTabs(tab + 1), node.getSchema().getArgsMap()));
+          .append(String.format("%s args: %s,\n", getTabs(tab + 1), new TreeMap<>(node.getSchema().getArgsMap())));
       builder.append(
           String.format("%s StorageGroup: %s \n", getTabs(tab + 1), node.getDataFileName()));
       builder.append(getTabs(tab));

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import org.apache.iotdb.db.exception.PathErrorException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -942,7 +941,7 @@ public class MTree implements Serializable {
       builder
           .append(String.format("%s Encoding: %s,\n", getTabs(tab + 1), node.getSchema().encoding));
       builder
-          .append(String.format("%s args: %s,\n", getTabs(tab + 1), new TreeMap<>(node.getSchema().getArgsMap())));
+          .append(String.format("%s args: %s,\n", getTabs(tab + 1), node.getSchema().getArgsMap()));
       builder.append(
           String.format("%s StorageGroup: %s \n", getTabs(tab + 1), node.getDataFileName()));
       builder.append(getTabs(tab));

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBCompleteIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBCompleteIT.java
@@ -58,15 +58,15 @@ public class IoTDBCompleteIT {
   }
 
   @Test
-  public void Test() throws ClassNotFoundException, SQLException {
+  public void test() throws ClassNotFoundException, SQLException {
     String[] sqls = {"SET STORAGE GROUP TO root.vehicle"};
     executeSQL(sqls);
-    SimpleTest();
-    InsertTest();
-    SelectTest();
+    simpleTest();
+    insertTest();
+    selectTest();
   }
 
-  public void SimpleTest() throws ClassNotFoundException, SQLException {
+  public void simpleTest() throws ClassNotFoundException, SQLException {
     String[] sqlS = {"CREATE TIMESERIES root.vehicle.d0.s0 WITH DATATYPE=INT32,ENCODING=RLE",
         "SHOW TIMESERIES",
         "===  Timeseries Tree  ===\n" + "\n" + "root:{\n" + "    vehicle:{\n" + "        d0:{\n"
@@ -104,11 +104,11 @@ public class IoTDBCompleteIT {
             + "                 StorageGroup: root.vehicle \n" + "            }\n" + "        },\n"
             + "        d5:{\n" + "            s9:{\n" + "                 DataType: FLOAT,\n"
             + "                 Encoding: PLAIN,\n"
-            + "                 args: {compressor=SNAPPY, MAX_POINT_NUMBER=10},\n"
+            + "                 args: {MAX_POINT_NUMBER=10, compressor=SNAPPY},\n"
             + "                 StorageGroup: root.vehicle \n" + "            }\n" + "        },\n"
             + "        d6:{\n" + "            s10:{\n" + "                 DataType: DOUBLE,\n"
             + "                 Encoding: RLE,\n"
-            + "                 args: {compressor=UNCOMPRESSOR, MAX_POINT_NUMBER=10},\n"
+            + "                 args: {MAX_POINT_NUMBER=10, compressor=UNCOMPRESSOR},\n"
             + "                 StorageGroup: root.vehicle \n" + "            }\n" + "        }\n"
             + "    }\n" + "}",
         "DELETE TIMESERIES root.vehicle.*", "SHOW TIMESERIES",
@@ -116,7 +116,7 @@ public class IoTDBCompleteIT {
     executeSQL(sqlS);
   }
 
-  public void InsertTest() throws ClassNotFoundException, SQLException {
+  public void insertTest() throws ClassNotFoundException, SQLException {
     String[] sqlS = {"CREATE TIMESERIES root.vehicle.d0.s0 WITH DATATYPE=INT32,ENCODING=RLE",
         "INSERT INTO root.vehicle.d0(timestamp,s0) values(1,101)",
         "CREATE TIMESERIES root.vehicle.d0.s1 WITH DATATYPE=INT32,ENCODING=RLE",
@@ -129,7 +129,7 @@ public class IoTDBCompleteIT {
     executeSQL(sqlS);
   }
 
-  public void DeleteTest() throws ClassNotFoundException, SQLException {
+  public void deleteTest() throws ClassNotFoundException, SQLException {
     String[] sqlS = {"CREATE TIMESERIES root.vehicle.d0.s0 WITH DATATYPE=INT32,ENCODING=RLE",
         "INSERT INTO root.vehicle.d0(timestamp,s0) values(1,1)",
         "INSERT INTO root.vehicle.d0(timestamp,s0) values(2,1)",
@@ -165,7 +165,7 @@ public class IoTDBCompleteIT {
     executeSQL(sqlS);
   }
 
-  public void SelectTest() throws ClassNotFoundException, SQLException {
+  public void selectTest() throws ClassNotFoundException, SQLException {
     String[] sqlS = {"CREATE TIMESERIES root.vehicle.d0.s0 WITH DATATYPE=INT32,ENCODING=RLE",
         "INSERT INTO root.vehicle.d0(timestamp,s0) values(1,101)",
         "INSERT INTO root.vehicle.d0(timestamp,s0) values(2,102)",
@@ -186,7 +186,7 @@ public class IoTDBCompleteIT {
     executeSQL(sqlS);
   }
 
-  public void FuncTest() throws ClassNotFoundException, SQLException {
+  public void funcTest() throws ClassNotFoundException, SQLException {
     String[] sqlS = {"CREATE TIMESERIES root.vehicle.d0.s0 WITH DATATYPE=INT32,ENCODING=RLE",
         "INSERT INTO root.vehicle.d0(timestamp,s0) values(1,110)",
         "INSERT INTO root.vehicle.d0(timestamp,s0) values(2,109)",
@@ -219,7 +219,7 @@ public class IoTDBCompleteIT {
     executeSQL(sqlS);
   }
 
-  public void GroupByTest() throws ClassNotFoundException, SQLException {
+  public void groupByTest() throws ClassNotFoundException, SQLException {
     String[] sqlS = {"CREATE TIMESERIES root.vehicle.d0.s0 WITH DATATYPE=INT32,ENCODING=RLE",
         "INSERT INTO root.vehicle.d0(timestamp,s0) values(1,110)",
         "INSERT INTO root.vehicle.d0(timestamp,s0) values(2,109)",

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
@@ -94,7 +94,7 @@ public class IoTDBMetadataFetchIT {
   }
 
   @Test
-  public void ShowTimeseriesTest1() throws ClassNotFoundException, SQLException {
+  public void showTimeseriesTest1() throws ClassNotFoundException, SQLException {
     Class.forName(Config.JDBC_DRIVER_NAME);
     Connection connection = null;
     try {
@@ -151,7 +151,7 @@ public class IoTDBMetadataFetchIT {
   }
 
   @Test
-  public void ShowTimeseriesTest2() throws ClassNotFoundException, SQLException {
+  public void showTimeseriesTest2() throws ClassNotFoundException, SQLException {
     Class.forName(Config.JDBC_DRIVER_NAME);
     Connection connection = null;
     Statement statement = null;
@@ -171,7 +171,7 @@ public class IoTDBMetadataFetchIT {
   }
 
   @Test
-  public void ShowStorageGroupTest() throws ClassNotFoundException, SQLException {
+  public void showStorageGroupTest() throws ClassNotFoundException, SQLException {
     Class.forName(Config.JDBC_DRIVER_NAME);
     Connection connection = null;
     try {
@@ -211,7 +211,7 @@ public class IoTDBMetadataFetchIT {
   }
 
   @Test
-  public void DatabaseMetaDataTest() throws ClassNotFoundException, SQLException {
+  public void databaseMetaDataTest() throws ClassNotFoundException, SQLException {
     Class.forName(Config.JDBC_DRIVER_NAME);
     Connection connection = null;
     try {
@@ -219,12 +219,12 @@ public class IoTDBMetadataFetchIT {
           .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
       databaseMetaData = connection.getMetaData();
 
-      AllColumns();
-      Device();
-      ShowTimeseriesPath1();
-      ShowTimeseriesPath2();
-      ShowStorageGroup();
-      ShowTimeseriesInJson();
+      allColumns();
+      device();
+      showTimeseriesPath1();
+      showTimeseriesPath2();
+      showStorageGroup();
+      showTimeseriesInJson();
 
     } catch (Exception e) {
       e.printStackTrace();
@@ -239,7 +239,7 @@ public class IoTDBMetadataFetchIT {
   /**
    * get all columns' name under a given seriesPath
    */
-  private void AllColumns() throws SQLException {
+  private void allColumns() throws SQLException {
     String standard =
         "Column,\n" + "root.ln.wf01.wt01.status,\n" + "root.ln.wf01.wt01.temperature,\n";
 
@@ -263,7 +263,7 @@ public class IoTDBMetadataFetchIT {
   /**
    * get all delta objects under a given column
    */
-  private void Device() throws SQLException {
+  private void device() throws SQLException {
     String standard = "Column,\n" + "root.ln.wf01.wt01,\n";
 
     ResultSet resultSet = databaseMetaData.getColumns(Constant.CatalogDevice, "ln", null, null);
@@ -286,7 +286,7 @@ public class IoTDBMetadataFetchIT {
   /**
    * show timeseries <seriesPath> usage 1
    */
-  private void ShowTimeseriesPath1() throws SQLException {
+  private void showTimeseriesPath1() throws SQLException {
     String standard = "Timeseries,Storage Group,DataType,Encoding,\n"
         + "root.ln.wf01.wt01.status,root.ln.wf01.wt01,BOOLEAN,PLAIN,\n"
         + "root.ln.wf01.wt01.temperature,root.ln.wf01.wt01,FLOAT,RLE,\n";
@@ -312,7 +312,7 @@ public class IoTDBMetadataFetchIT {
   /**
    * show timeseries <seriesPath> usage 2
    */
-  private void ShowTimeseriesPath2() throws SQLException {
+  private void showTimeseriesPath2() throws SQLException {
     String standard = "DataType,\n" + "BOOLEAN,\n";
 
     ResultSet resultSet = databaseMetaData
@@ -332,7 +332,7 @@ public class IoTDBMetadataFetchIT {
   /**
    * show storage group
    */
-  private void ShowStorageGroup() throws SQLException {
+  private void showStorageGroup() throws SQLException {
     String standard = "Storage Group,\n" + "root.ln.wf01.wt01,\n";
 
     ResultSet resultSet = databaseMetaData
@@ -356,7 +356,7 @@ public class IoTDBMetadataFetchIT {
   /**
    * show metadata in json
    */
-  private void ShowTimeseriesInJson() {
+  private void showTimeseriesInJson() {
     String metadataInJson = databaseMetaData.toString();
     String standard =
         "===  Timeseries Tree  ===\n" + "\n" + "root:{\n" + "    ln:{\n" + "        wf01:{\n"
@@ -366,7 +366,7 @@ public class IoTDBMetadataFetchIT {
             + "                     StorageGroup: root.ln.wf01.wt01 \n" + "                },\n"
             + "                temperature:{\n" + "                     DataType: FLOAT,\n"
             + "                     Encoding: RLE,\n"
-            + "                     args: {compressor=SNAPPY, MAX_POINT_NUMBER=3},\n"
+            + "                     args: {MAX_POINT_NUMBER=3, compressor=SNAPPY},\n"
             + "                     StorageGroup: root.ln.wf01.wt01 \n" + "                }\n"
             + "            }\n"
             + "        }\n" + "    }\n" + "}";


### PR DESCRIPTION
fix the issues that difference of key-value order between hashMap.toString() and expected string.

1. In MTree, when using Metadata.hashMap.toString(), convert it to a TreeMap first.
2. set the key-value pairs as a string in expected results  with lexicographical order