### PR TITLE
[IOTDB-18] Improve startup script compatible for jdk11

### DIFF
--- a/iotdb/iotdb/conf/iotdb-env.bat
+++ b/iotdb/iotdb/conf/iotdb-env.bat
@@ -56,11 +56,11 @@ for /f "tokens=1-3" %%j in ('java -version 2^>^&1') do (
 IF "%BIT_VERSION%" == "64-Bit" (
 	rem 64-bit Java
 	echo Detect 64-bit Java, maximum memory allocation pool = 2GB, initial memory allocation pool = 2GB
-	set IOTDB_HEAP_OPTS=-Xmx2G -Xms2G -Xloggc:"%IOTDB_HOME%\gc.log"
+	set IOTDB_HEAP_OPTS=-Xmx2G -Xms2G
 ) ELSE (
 	rem 32-bit Java
 	echo Detect 32-bit Java, maximum memory allocation pool = 512MB, initial memory allocation pool = 512MB
-	set IOTDB_HEAP_OPTS=-Xmx512M -Xms512M -Xloggc:"%IOTDB_HOME%\gc.log"
+	set IOTDB_HEAP_OPTS=-Xmx512M -Xms512M
 )
 
 :end_config_setting

--- a/iotdb/iotdb/conf/iotdb-env.sh
+++ b/iotdb/iotdb/conf/iotdb-env.sh
@@ -107,6 +107,22 @@ if [ "$JVM_VERSION" \< "1.8" ] && [ "$JVM_PATCH_VERSION" -lt 40 ] ; then
     exit 1;
 fi
 
+version_arr=(${JVM_VERSION//./ })
+
+if [ "${version_arr[0]}" = "1" ] ; then
+  MAJOR_VERSION=${version_arr[1]}
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xloggc:${IOTDB_HOME}/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCDetails"
+else
+  MAJOR_VERSION=${version_arr[0]}
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xloggc:${IOTDB_HOME}/gc.log"
+fi
+
+if [ "$MAJOR_VERSION" -ne "8" ] && [ "$MAJOR_VERSION" -ne "11" ] ; then
+  echo "IoTDB only supports jdk8 or jdk11, please check your java version."
+  exit 1;
+fi
+
+
 calculate_heap_sizes
 
 # Maximum heap size
@@ -126,9 +142,6 @@ else
 	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
 fi
 
-IOTDB_DERBY_OPTS="-Dderby.stream.error.field=org.apache.iotdb.db.auth.dao.DerbyUtil.DEV_NULL"
-
-IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xloggc:${IOTDB_HOME}/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCDetails"
 
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xms${HEAP_NEWSIZE}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xmx${MAX_HEAP_SIZE}"


### PR DESCRIPTION
I have tested on Mac for jdk8, jdk11 and openjdk11, on windows for jdk8, jdk11 and openjdk11

Especially,openjdk11 is downloaded from http://jdk.java.net/11/

java -version
openjdk version "11.0.2" 2019-01-15
OpenJDK Runtime Environment 18.9 (build 11.0.2+9)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.2+9, mixed mode)