### PR TITLE
Add 3 OS platforms and 2 JDK versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
       install:
         - choco install jdk11 -params 'installdir=c:\\java11'
         - export PATH=$PATH:"/c/java11"
-        - export JAVA_HOME="/c/java8"
+        - export JAVA_HOME="/c/java11"
         - choco install maven
 #    - os: linux
 #      name: linux-openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       name: win-jdk11
       install:
         - choco install jdk11 -params 'installdir=c:\\java11'
-        - export PATH=$PATH:"/c/java11"
+        - export PATH=$PATH:"/c/java11/bin"
         - export JAVA_HOME="/c/java11"
         - choco install maven
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,13 @@ matrix:
       name: win-jdk8
       install:
         - choco install jdk8
+        - export PATH=$PATH:"/c/Program Files/Java/jdk1.8.0_191/bin"
         - choco install maven
     - os: windows
       name: win-jdk11
       install:
-        - choco install jdk11
+        - choco install jdk11 -params 'installdir=c:\\java11'
+        - export PATH=$PATH:"/c/java11"
         - choco install maven
 #    - os: linux
 #      name: linux-openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,8 @@ matrix:
       install:
         #for openjdk, -params does not work.
         - choco install openjdk
-        - export PATH=$PATH:"/c/Program Files/OpenJDK/bin"
-        - export JAVA_HOME="/c/Program Files/OpenJDK"
+        - export PATH=$PATH:"/c/Program\ Files/OpenJDK/bin"
+        - export JAVA_HOME="/c/Program\ Files/OpenJDK"
         - choco install maven
     - os: linux
       name: linux-openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,15 +71,15 @@ matrix:
         - export JAVA_HOME="/c/java11"
         - choco install maven
     #choco does not support openjdk8. we have to install it manually
-    - os: windows
-      language: c
-      name: win-openjdk11
-      install:
-        #for openjdk, -params does not work.
-        - choco install openjdk
-        - export PATH=$PATH:"C:\Program Files\OpenJDK\bin"
-        - export JAVA_HOME="C:\Program Files\OpenJDK"
-        - choco install maven
+#    - os: windows
+#      language: c
+#      name: win-openjdk11
+#      install:
+#        #for openjdk, -params does not work.
+#        - choco install openjdk
+#        - export PATH=$PATH:"C:\Program Files\OpenJDK\bin"
+#        - export JAVA_HOME="C:\Program Files\OpenJDK"
+#        - choco install maven
     - os: linux
       name: linux-openjdk11
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,9 @@ matrix:
       language: c
       name: win-jdk8
       install:
-        - choco install jdk8
-        - export PATH=$PATH:"/c/Program Files/Java/jdk1.8.0_191/bin"
+        - choco install jdk8 -params 'installdir=c:\\java8'
+        - export PATH=$PATH:"/c/java8/bin"
+        - export JAVA_HOME="/c/java8"
         - choco install maven
     - os: windows
       language: c
@@ -47,6 +48,7 @@ matrix:
       install:
         - choco install jdk11 -params 'installdir=c:\\java11'
         - export PATH=$PATH:"/c/java11"
+        - export JAVA_HOME="/c/java8"
         - choco install maven
 #    - os: linux
 #      name: linux-openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
       addons:
         homebrew:
           taps:
-            - homebrew/cask-versions
+            #- homebrew/cask-versions
             - AdoptOpenJDK/openjdk
           update: true
           casks: adoptopenjdk-openjdk11
@@ -50,7 +50,7 @@ matrix:
       addons:
         homebrew:
           taps:
-           - homebrew/cask-versions
+           #- homebrew/cask-versions
            - AdoptOpenJDK/openjdk
           update: true
           casks: adoptopenjdk-openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,33 @@ matrix:
   include:
     - os: osx
       osx_image: xcode10.1 # with JDK11.0.1+13 installed
-      name: osx-jdk11
+      name: osx-oraclejdk11
     - os: osx
       osx_image: xcode9.3  # with JDK1.8.0_112-b16 installed
-      name: osx-jdk8
+      name: osx-oraclejdk8
+    - os: osx
+      osx_image: xcode10.1 # with JDK11.0.1+13 installed
+      name: osx-openjdk11
+      addons:
+        homebrew:
+          taps:
+            - homebrew/cask-versions
+            - AdoptOpenJDK/openjdk
+          update: true
+          casks: adoptopenjdk-openjdk11
+    - os: osx
+      osx_image: xcode9.3  # with JDK1.8.0_112-b16 installed
+      name: osx-openjdk8
+      addons:
+        homebrew:
+          taps:
+           - homebrew/cask-versions
+           - AdoptOpenJDK/openjdk
+          update: true
+          casks: adoptopenjdk-openjdk8
     - os: windows
       language: c
-      name: win-jdk8
+      name: win-oraclejdk8
       install:
         - choco install jdk8 -params 'installdir=c:\\java8'
         - export PATH=$PATH:"/c/java8/bin"
@@ -44,9 +64,18 @@ matrix:
         - choco install maven
     - os: windows
       language: c
-      name: win-jdk11
+      name: win-oraclejdk11
       install:
         - choco install jdk11 -params 'installdir=c:\\java11'
+        - export PATH=$PATH:"/c/java11/bin"
+        - export JAVA_HOME="/c/java11"
+        - choco install maven
+    #choco does not support openjdk8. we have to install it manually
+    - os: windows
+      language: c
+      name: win-openjdk11
+      install:
+        - choco install openjdk -params 'installdir=c:\\java11'
         - export PATH=$PATH:"/c/java11/bin"
         - export JAVA_HOME="/c/java11"
         - choco install maven
@@ -83,6 +112,7 @@ script:
   # For each test, travis-ci limits its output log. So we cannot test some sub-modules like tsfile, iotdb.
   # We only test jdbc to ensure maven commands work correctly on travis-ci.
   #- mvn clean test -pl jdbc -am -Dtsfile.test.skip=true
+  - java -version
   - mvn clean integration-test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,52 +28,46 @@ language: java
 
 matrix:
   include:
-    - os: osx
-      osx_image: xcode10.1 # with JDK11.0.1+13 installed
-      name: osx-jdk11
-    - os: osx
-      osx_image: xcode9.3  # with JDK1.8.0_112-b16 installed
-      name: osx-jdk8
+#    - os: osx
+#      osx_image: xcode10.1 # with JDK11.0.1+13 installed
+#      name: osx-jdk11
+#    - os: osx
+#      osx_image: xcode9.3  # with JDK1.8.0_112-b16 installed
+#      name: osx-jdk8
     - os: windows
+      language: c
       name: win-jdk8
       install:
         - choco install jdk8
         - export PATH=$PATH:"/c/Program Files/Java/jdk1.8.0_191/bin"
         - choco install maven
     - os: windows
+      language: c
       name: win-jdk11
       install:
         - choco install jdk11 -params 'installdir=c:\\java11'
         - export PATH=$PATH:"/c/java11"
         - choco install maven
 #    - os: linux
-#      name: linux-openjdk6
+#      name: linux-openjdk11
 #      dist: trusty
-#      addons:
-#        apt:
-#          packages:
-#            - openjdk-6-jdk
+#      sudo: required
+#      before_install:
+#        - sudo add-apt-repository ppa:openjdk-r/ppa -y
+#        - sudo apt-get update -q
+#        - sudo apt-get install openjdk-11-jdk -y
+#    - os: linux
+#      name: linux-openjdk8
+#      dist: trusty
 #      jdk: openjdk8
-    - os: linux
-      name: linux-openjdk11
-      dist: trusty
-      sudo: required
-      before_install:
-        - sudo add-apt-repository ppa:openjdk-r/ppa -y
-        - sudo apt-get update -q
-        - sudo apt-get install openjdk-11-jdk -y
-    - os: linux
-      name: linux-openjdk8
-      dist: trusty
-      jdk: openjdk8
-    - os: linux
-      name: linux-jdk8
-      dist: trusty
-      jdk: oraclejdk8
-    - os: linux
-      name: linux-jdk11
-      dist: trusty
-      jdk: oraclejdk11
+#    - os: linux
+#      name: linux-jdk8
+#      dist: trusty
+#      jdk: oraclejdk8
+#    - os: linux
+#      name: linux-jdk11
+#      dist: trusty
+#      jdk: oraclejdk11
 
 
 # skip `before_install` stage

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,58 @@
 # Since we don't have osx test environment, we use travis-ci to test on osx.
 # Free-plan of travis-ci offers limited resources, we only test whether iotdb can be packaged on jdk8 and jdk11.
 
-dist: trusty
-#sudo: required
-
 language: java
+
+#dist: trusty
+#sudo: required
 
 matrix:
   include:
     - os: osx
       osx_image: xcode10.1 # with JDK11.0.1+13 installed
+      name: osx-jdk11
     - os: osx
       osx_image: xcode9.3  # with JDK1.8.0_112-b16 installed
+      name: osx-jdk8
+    - os: windows
+      name: win-jdk8
+      install:
+        - choco install jdk8
+        - choco install maven
+    - os: windows
+      name: win-jdk11
+      install:
+        - choco install jdk11
+        - choco install maven
+#    - os: linux
+#      name: linux-openjdk6
+#      dist: trusty
+#      addons:
+#        apt:
+#          packages:
+#            - openjdk-6-jdk
+#      jdk: openjdk8
+    - os: linux
+      name: linux-openjdk11
+      dist: trusty
+      sudo: required
+      before_install:
+        - sudo add-apt-repository ppa:openjdk-r/ppa -y
+        - sudo apt-get update -q
+        - sudo apt-get install openjdk-11-jdk -y
+    - os: linux
+      name: linux-openjdk8
+      dist: trusty
+      jdk: openjdk8
+    - os: linux
+      name: linux-jdk8
+      dist: trusty
+      jdk: oraclejdk8
+    - os: linux
+      name: linux-jdk11
+      dist: trusty
+      jdk: oraclejdk11
+
 
 # skip `before_install` stage
 before_install: true
@@ -40,10 +81,11 @@ before_install: true
 install: true
 
 script:
-  - mvn clean package -Dmaven.test.skip=true
+  #- mvn clean package -Dmaven.test.skip=true
   # For each test, travis-ci limits its output log. So we cannot test some sub-modules like tsfile, iotdb.
   # We only test jdbc to ensure maven commands work correctly on travis-ci.
-  - mvn clean test -pl jdbc -am -Dtsfile.test.skip=true
+  #- mvn clean test -pl jdbc -am -Dtsfile.test.skip=true
+  - mvn clean integration-test
 
 after_success:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,8 @@ matrix:
       install:
         #for openjdk, -params does not work.
         - choco install openjdk
-        - export PATH=$PATH:"/c/Program\ Files/OpenJDK/bin"
-        - export JAVA_HOME="/c/Program\ Files/OpenJDK"
+        - export PATH=$PATH:"C:\Program Files\OpenJDK\bin"
+        - export JAVA_HOME="C:\Program Files\OpenJDK"
         - choco install maven
     - os: linux
       name: linux-openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,20 +28,20 @@ language: java
 
 matrix:
   include:
-#    - os: osx
-#      osx_image: xcode10.1 # with JDK11.0.1+13 installed
-#      name: osx-jdk11
-#    - os: osx
-#      osx_image: xcode9.3  # with JDK1.8.0_112-b16 installed
-#      name: osx-jdk8
-#    - os: windows
-#      language: c
-#      name: win-jdk8
-#      install:
-#        - choco install jdk8 -params 'installdir=c:\\java8'
-#        - export PATH=$PATH:"/c/java8/bin"
-#        - export JAVA_HOME="/c/java8"
-#        - choco install maven
+    - os: osx
+      osx_image: xcode10.1 # with JDK11.0.1+13 installed
+      name: osx-jdk11
+    - os: osx
+      osx_image: xcode9.3  # with JDK1.8.0_112-b16 installed
+      name: osx-jdk8
+    - os: windows
+      language: c
+      name: win-jdk8
+      install:
+        - choco install jdk8 -params 'installdir=c:\\java8'
+        - export PATH=$PATH:"/c/java8/bin"
+        - export JAVA_HOME="/c/java8"
+        - choco install maven
     - os: windows
       language: c
       name: win-jdk11
@@ -50,26 +50,26 @@ matrix:
         - export PATH=$PATH:"/c/java11"
         - export JAVA_HOME="/c/java11"
         - choco install maven
-#    - os: linux
-#      name: linux-openjdk11
-#      dist: trusty
-#      sudo: required
-#      before_install:
-#        - sudo add-apt-repository ppa:openjdk-r/ppa -y
-#        - sudo apt-get update -q
-#        - sudo apt-get install openjdk-11-jdk -y
-#    - os: linux
-#      name: linux-openjdk8
-#      dist: trusty
-#      jdk: openjdk8
-#    - os: linux
-#      name: linux-jdk8
-#      dist: trusty
-#      jdk: oraclejdk8
-#    - os: linux
-#      name: linux-jdk11
-#      dist: trusty
-#      jdk: oraclejdk11
+    - os: linux
+      name: linux-openjdk11
+      dist: trusty
+      sudo: required
+      before_install:
+        - sudo add-apt-repository ppa:openjdk-r/ppa -y
+        - sudo apt-get update -q
+        - sudo apt-get install openjdk-11-jdk -y
+    - os: linux
+      name: linux-openjdk8
+      dist: trusty
+      jdk: openjdk8
+    - os: linux
+      name: linux-jdk8
+      dist: trusty
+      jdk: oraclejdk8
+    - os: linux
+      name: linux-jdk11
+      dist: trusty
+      jdk: oraclejdk11
 
 
 # skip `before_install` stage

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,10 @@ matrix:
       language: c
       name: win-openjdk11
       install:
-        - choco install openjdk -params 'installdir=c:\\java11'
-        - export PATH=$PATH:"/c/java11/bin"
-        - export JAVA_HOME="/c/java11"
+        #for openjdk, -params does not work.
+        - choco install openjdk
+        - export PATH=$PATH:"/c/Program Files/OpenJDK/bin"
+        - export JAVA_HOME="/c/Program Files/OpenJDK"
         - choco install maven
     - os: linux
       name: linux-openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,14 @@ matrix:
 #    - os: osx
 #      osx_image: xcode9.3  # with JDK1.8.0_112-b16 installed
 #      name: osx-jdk8
-    - os: windows
-      language: c
-      name: win-jdk8
-      install:
-        - choco install jdk8 -params 'installdir=c:\\java8'
-        - export PATH=$PATH:"/c/java8/bin"
-        - export JAVA_HOME="/c/java8"
-        - choco install maven
+#    - os: windows
+#      language: c
+#      name: win-jdk8
+#      install:
+#        - choco install jdk8 -params 'installdir=c:\\java8'
+#        - export PATH=$PATH:"/c/java8/bin"
+#        - export JAVA_HOME="/c/java8"
+#        - choco install maven
     - os: windows
       language: c
       name: win-jdk11


### PR DESCRIPTION
By applying this PR,  Travis-CI will have the following jobs:
* osx-oraclejdk8 
* osx-oraclejdk11 
* osx-openjdk8
* osx-openjdk11
* linux-oraclejdk8 (ubuntu)
* linux-oraclejdk11 (ubuntu)
* linux-openjdk8 (ubuntu)
* linux-openjdk11 (ubuntu)
* Windows-jdk8 (oracle JDK)
* WIndows-jdk11 (oracle JDK)
