### PR TITLE
[WAIT FOR JENKINS PIPELINE]add sync function for jdbc server to  close and remove sleep fuction in ITs

### DIFF
--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBAuthorizationIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBAuthorizationIT.java
@@ -62,7 +62,6 @@ public class IoTDBAuthorizationIT {
   @After
   public void tearDown() throws Exception {
     deamon.stop();
-    Thread.sleep(2000);
     EnvironmentUtils.cleanEnv();
   }
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBCompleteIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBCompleteIT.java
@@ -53,7 +53,6 @@ public class IoTDBCompleteIT {
   @After
   public void tearDown() throws Exception {
     deamon.stop();
-    Thread.sleep(5000);
     EnvironmentUtils.cleanEnv();
   }
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBDaemonIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBDaemonIT.java
@@ -128,8 +128,6 @@ public class IoTDBDaemonIT {
   public static void tearDown() throws Exception {
     connection.close();
     deamon.stop();
-    Thread.sleep(5000);
-
     EnvironmentUtils.cleanEnv();
   }
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
@@ -93,8 +93,6 @@ public class IoTDBEngineTimeGeneratorIT {
     connection.close();
 
     daemon.stop();
-    Thread.sleep(5000);
-
     // recovery value
     tsFileConfig.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
     tsFileConfig.pageSizeInByte = pageSizeInByte;

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBLargeDataIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBLargeDataIT.java
@@ -87,7 +87,6 @@ public class IoTDBLargeDataIT {
     connection.close();
 
     deamon.stop();
-    Thread.sleep(5000);
 
     // recovery value
     tsFileConfig.maxNumberOfPointsInPage = maxNumberOfPointsInPage;

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBLimitSlimitIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBLimitSlimitIT.java
@@ -99,7 +99,6 @@ public class IoTDBLimitSlimitIT {
   @AfterClass
   public static void tearDown() throws Exception {
     deamon.stop();
-    Thread.sleep(5000);
     EnvironmentUtils.cleanEnv();
   }
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
@@ -89,7 +89,6 @@ public class IoTDBMetadataFetchIT {
   @After
   public void tearDown() throws Exception {
     deamon.stop();
-    Thread.sleep(5000);
     EnvironmentUtils.cleanEnv();
   }
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBMultiSeriesIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBMultiSeriesIT.java
@@ -87,8 +87,6 @@ public class IoTDBMultiSeriesIT {
     connection.close();
 
     deamon.stop();
-    Thread.sleep(5000);
-
     // recovery value
     tsFileConfig.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
     tsFileConfig.pageSizeInByte = pageSizeInByte;

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
@@ -93,8 +93,6 @@ public class IoTDBSequenceDataQueryIT {
     connection.close();
 
     daemon.stop();
-    Thread.sleep(5000);
-
     // recovery value
     tsFileConfig.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
     tsFileConfig.pageSizeInByte = pageSizeInByte;

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
@@ -91,8 +91,6 @@ public class IoTDBSeriesReaderIT {
   public static void tearDown() throws Exception {
     connection.close();
     deamon.stop();
-    Thread.sleep(5000);
-
     // recovery value
     tsFileConfig.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
     tsFileConfig.pageSizeInByte = pageSizeInByte;

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBTimeZoneIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBTimeZoneIT.java
@@ -66,7 +66,6 @@ public class IoTDBTimeZoneIT {
   public void tearDown() throws Exception {
     // if (testFlag) {
     deamon.stop();
-    Thread.sleep(5000);
     EnvironmentUtils.cleanEnv();
     // }
   }


### PR DESCRIPTION
Before this commit, if you run `mvn clean verify` to trigger IT, you will see some logs like

```
ERROR [2019-02-13 11:42:31,571] [JDBC-ServerServiceImpl] org.apache.iotdb.db.service.JDBCService$JDBCServiceThread:181 - IoTDB: failed to start JDBC ServerService, because  
org.apache.thrift.transport.TTransportException: Could not create ServerSocket on address 0.0.0.0/0.0.0.0:6667.
	at org.apache.thrift.transport.TServerSocket.<init>(TServerSocket.java:109)
	at org.apache.thrift.transport.TServerSocket.<init>(TServerSocket.java:91)
	at org.apache.thrift.transport.TServerSocket.<init>(TServerSocket.java:83)
	at org.apache.thrift.transport.TServerSocket.<init>(TServerSocket.java:76)
	at org.apache.iotdb.db.service.JDBCService$JDBCServiceThread.run(JDBCService.java:171)
Caused by: java.net.BindException: Address already in use (Bind failed)
	at java.net.PlainSocketImpl.socketBind(Native Method)
	at java.net.AbstractPlainSocketImpl.bind(AbstractPlainSocketImpl.java:387)
	at java.net.ServerSocket.bind(ServerSocket.java:375)
	at org.apache.thrift.transport.TServerSocket.<init>(TServerSocket.java:106)
	... 4 common frames omitted
```

This pull request solves problems about failing to create JDBC server.

Also, I remove `Thread.sleep(5000)` in our ITs, now JDBCService.close() is a synchronized method.

I have tested on my own mac and windows platforms. Apache Jenkins will help me test Unix platform.
