### PR TITLE
add a new parameter for maven: -Duse.local.thrift.compiler (false by default)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,10 +449,6 @@
                 <os>
                     <family>windows</family>
                 </os>
-                <property>
-                    <name>use.local.thrift.compiler</name>
-                    <value>false</value>
-                </property>
             </activation>
             <properties>
                 <thrift.download-url>http://artfiles.org/apache.org/thrift/${thrift.version}/thrift-${thrift.version}.exe</thrift.download-url>
@@ -469,10 +465,6 @@
                 <os>
                     <family>unix</family>
                 </os>
-                <property>
-                    <name>use.local.thrift.compiler</name>
-                    <value>false</value>
-                </property>
             </activation>
             <properties>
                 <thrift.download-url>https://github.com/ccascone/mvn-thrift-compiler/raw/1.0_${thrift.version}/exe/thrift-linux-x86_64.exe</thrift.download-url>
@@ -488,10 +480,6 @@
                 <os>
                     <family>mac</family>
                 </os>
-                <property>
-                    <name>use.local.thrift.compiler</name>
-                    <value>false</value>
-                </property>
             </activation>
             <properties>
                 <thrift.download-url>https://github.com/ccascone/mvn-thrift-compiler/raw/1.0_${thrift.version}/exe/thrift-osx-x86_64.exe</thrift.download-url>
@@ -516,10 +504,6 @@
                 <file>
                     <exists>src/main/thrift</exists>
                 </file>
-                <property>
-                    <name>use.local.thrift.compiler</name>
-                    <value>false</value>
-                </property>
             </activation>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
         <sonar.host.url>https://builds.apache.org/analysis</sonar.host.url>
         <!-- Exclude all generated code -->
         <sonar.exclusions>**/generated-sources</sonar.exclusions>
+        <!-- whether using a thrift compiler locally
+        (if false, maven will download a binary thrift compiler).
+        if true, you must set the thrift compiler into your PATH, and make sure
+        the version is ${thrift.version}-->
+        <use.local.thrift.compiler>false</use.local.thrift.compiler>
     </properties>
     <!--
         if we claim dependencies in dependencyManagement, then we do not claim
@@ -444,6 +449,10 @@
                 <os>
                     <family>windows</family>
                 </os>
+                <property>
+                    <name>use.local.thrift.compiler</name>
+                    <value>false</value>
+                </property>
             </activation>
             <properties>
                 <thrift.download-url>http://artfiles.org/apache.org/thrift/${thrift.version}/thrift-${thrift.version}.exe</thrift.download-url>
@@ -460,6 +469,10 @@
                 <os>
                     <family>unix</family>
                 </os>
+                <property>
+                    <name>use.local.thrift.compiler</name>
+                    <value>false</value>
+                </property>
             </activation>
             <properties>
                 <thrift.download-url>https://github.com/ccascone/mvn-thrift-compiler/raw/1.0_${thrift.version}/exe/thrift-linux-x86_64.exe</thrift.download-url>
@@ -475,6 +488,10 @@
                 <os>
                     <family>mac</family>
                 </os>
+                <property>
+                    <name>use.local.thrift.compiler</name>
+                    <value>false</value>
+                </property>
             </activation>
             <properties>
                 <thrift.download-url>https://github.com/ccascone/mvn-thrift-compiler/raw/1.0_${thrift.version}/exe/thrift-osx-x86_64.exe</thrift.download-url>
@@ -494,11 +511,15 @@
           {maven local repo}/.cache/download-maven-plugin
         -->
         <profile>
-            <id>thrift-generation</id>
+            <id>thrift-download-and-generation</id>
             <activation>
                 <file>
                     <exists>src/main/thrift</exists>
                 </file>
+                <property>
+                    <name>use.local.thrift.compiler</name>
+                    <value>false</value>
+                </property>
             </activation>
             <build>
                 <plugins>
@@ -554,6 +575,40 @@
                                 <configuration>
                                     <generator>java</generator>
                                     <thriftExecutable>${project.build.directory}/tools/${thrift.executable}</thriftExecutable>
+                                    <thriftSourceRoot>${basedir}/src/main/thrift</thriftSourceRoot>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>thrift-generation-using-local-compiler</id>
+            <activation>
+                <file>
+                    <exists>src/main/thrift</exists>
+                </file>
+                <property>
+                    <name>use.local.thrift.compiler</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.thrift.tools</groupId>
+                        <artifactId>maven-thrift-plugin</artifactId>
+                        <version>0.1.11</version>
+                        <executions>
+                            <execution>
+                                <id>generate-thrift-sources</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <generator>java</generator>
                                     <thriftSourceRoot>${basedir}/src/main/thrift</thriftSourceRoot>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Now downloading a thrift compiler using maven-exec-plugin is too slow for Unix (40MB size). 

If someone has installed thrift-compiler by `apt install thrift-compiler=0.9.1-2.1` (which is far faster...), there is no need to download the thrift compiler again.

So, I add a new parameter, ${use.local.thrift.compiler} to skip the downloading process.

By default, it is false, which means maven will download the correct compiler and use it. So everything runs well as normal.
