### PR TITLE
enable users define the location of their thrift compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,6 +500,9 @@
                     <exists>src/main/thrift</exists>
                 </file>
             </activation>
+            <properties>
+                <thrift.exec.absolute.path>${project.build.directory}/tools/${thrift.executable}</thrift.exec.absolute.path>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -553,7 +556,7 @@
                                 </goals>
                                 <configuration>
                                     <generator>java</generator>
-                                    <thriftExecutable>${project.build.directory}/tools/${thrift.executable}</thriftExecutable>
+                                    <thriftExecutable>${thrift.exec.absolute.path}</thriftExecutable>
                                     <thriftSourceRoot>${basedir}/src/main/thrift</thriftSourceRoot>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
This is a better way to implement #62 .

Now users can define their location of the thrift compiler:
`mvn clean package -DskipTests -Dthrift.download-url="<any file you like>" -Dthrift.exec.absolute.path="<Your thrift compiler>"`

For example, on my Mac, I have installed thrift by:
`brew install thrift@0.9`


Then we can skip downloading a thrift compiler again by:
`mvn clean package -DskipTests -Dthrift.download-url="http://w.apache.org/licenses/LICENSE-2.0.txt" -Dthrift.exec.absolute.path="/usr/local/opt/thrift@0.9/bin/thrift"`
