### PR TITLE
[IOTDB-39]add autoRepair option for NativeRestorableIOWriter

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -326,6 +326,7 @@ public class TsFileIOWriter {
    * close the inputstream or file channel in force. This is just used for Testing.
    */
   void forceClose() throws IOException {
+    canWrite = false;
     out.close();
   }
 


### PR DESCRIPTION
By default the autoRepair is true.

Notice that, if the file does not contain a correct magic string header, we will never repair it.
