### PR TITLE
[IOTDB-34] implement close function for IoTDBMetadataResultSet

### DIFF
--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBMetadataResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBMetadataResultSet.java
@@ -75,11 +75,6 @@ public class IoTDBMetadataResultSet extends IoTDBQueryResultSet {
   }
 
   @Override
-  public void close() throws SQLException {
-    throw new SQLException(METHOD_NOT_SUPPORTED);
-  }
-
-  @Override
   public int findColumn(String columnName) throws SQLException {
     throw new SQLException(METHOD_NOT_SUPPORTED);
   }


### PR DESCRIPTION
Since IoTDBMetadataResultSet  extends ResultSetMetaData, it can use close() function in super class.