### PR TITLE
[IOTDB-56] faster memtable.getSortedTimeValuePairList

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/memtable/TimeValuePairInMemTable.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/memtable/TimeValuePairInMemTable.java
@@ -23,16 +23,10 @@ import java.util.Objects;
 import org.apache.iotdb.db.utils.TimeValuePair;
 import org.apache.iotdb.db.utils.TsPrimitiveType;
 
-public class TimeValuePairInMemTable extends TimeValuePair implements
-        Comparable<TimeValuePairInMemTable> {
+public class TimeValuePairInMemTable extends TimeValuePair {
 
   public TimeValuePairInMemTable(long timestamp, TsPrimitiveType value) {
     super(timestamp, value);
-  }
-
-  @Override
-  public int compareTo(TimeValuePairInMemTable o) {
-    return Long.compare(this.getTimestamp(), o.getTimestamp());
   }
 
   @Override

--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunk.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunk.java
@@ -102,12 +102,12 @@ public class WritableMemChunk implements IWritableMemChunk {
   public List<TimeValuePair> getSortedTimeValuePairList() {
     int length = list.size();
 
-    Map<Long, TsPrimitiveType> treeMap = new HashMap<>(length, 1.0f);
+    Map<Long, TsPrimitiveType> map = new HashMap<>(length, 1.0f);
     for (int i = 0; i < length; i++) {
-      treeMap.put(list.getTimestamp(i), TsPrimitiveType.getByType(dataType, list.getValue(i)));
+      map.put(list.getTimestamp(i), TsPrimitiveType.getByType(dataType, list.getValue(i)));
     }
-    List<TimeValuePair> ret = new ArrayList<>(treeMap.size());
-    treeMap.forEach((k, v) -> ret.add(new TimeValuePairInMemTable(k, v)));
+    List<TimeValuePair> ret = new ArrayList<>(map.size());
+    map.forEach((k, v) -> ret.add(new TimeValuePairInMemTable(k, v)));
     ret.sort(TimeValuePair::compareTo);
     return ret;
 

--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunk.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunk.java
@@ -101,12 +101,12 @@ public class WritableMemChunk implements IWritableMemChunk {
   // TODO: Consider using arrays to sort and remove duplicates
   public List<TimeValuePair> getSortedTimeValuePairList() {
     int length = list.size();
-    List<TimeValuePair> ret = new ArrayList<>(length);
+
     Map<Long, TsPrimitiveType> treeMap = new HashMap<>(length, 1.0f);
-    //Map<Long, TsPrimitiveType> treeMap = new TreeMap<>();
     for (int i = 0; i < length; i++) {
       treeMap.put(list.getTimestamp(i), TsPrimitiveType.getByType(dataType, list.getValue(i)));
     }
+    List<TimeValuePair> ret = new ArrayList<>(treeMap.size());
     treeMap.forEach((k, v) -> ret.add(new TimeValuePairInMemTable(k, v)));
     ret.sort(TimeValuePair::compareTo);
     return ret;

--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunk.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/memtable/WritableMemChunk.java
@@ -19,9 +19,10 @@
 package org.apache.iotdb.db.engine.memtable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
-
 import org.apache.iotdb.db.utils.PrimitiveArrayList;
 import org.apache.iotdb.db.utils.PrimitiveArrayListFactory;
 import org.apache.iotdb.db.utils.TimeValuePair;
@@ -100,13 +101,16 @@ public class WritableMemChunk implements IWritableMemChunk {
   // TODO: Consider using arrays to sort and remove duplicates
   public List<TimeValuePair> getSortedTimeValuePairList() {
     int length = list.size();
-    TreeMap<Long, TsPrimitiveType> treeMap = new TreeMap<>();
+    List<TimeValuePair> ret = new ArrayList<>(length);
+    Map<Long, TsPrimitiveType> treeMap = new HashMap<>(length, 1.0f);
+    //Map<Long, TsPrimitiveType> treeMap = new TreeMap<>();
     for (int i = 0; i < length; i++) {
       treeMap.put(list.getTimestamp(i), TsPrimitiveType.getByType(dataType, list.getValue(i)));
     }
-    List<TimeValuePair> ret = new ArrayList<>();
     treeMap.forEach((k, v) -> ret.add(new TimeValuePairInMemTable(k, v)));
+    ret.sort(TimeValuePair::compareTo);
     return ret;
+
   }
 
   @Override

--- a/iotdb/src/main/java/org/apache/iotdb/db/utils/PrimitiveArrayList.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/utils/PrimitiveArrayList.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 
-public class  PrimitiveArrayList {
+public class PrimitiveArrayList {
 
   private static final int MAX_SIZE_OF_ONE_ARRAY = 512;
   private static final int INITIAL_SIZE = 1;

--- a/iotdb/src/main/java/org/apache/iotdb/db/utils/PrimitiveArrayList.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/utils/PrimitiveArrayList.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PrimitiveArrayList {
+public class  PrimitiveArrayList {
 
   private static final int MAX_SIZE_OF_ONE_ARRAY = 512;
   private static final int INITIAL_SIZE = 1;
@@ -131,4 +131,5 @@ public class PrimitiveArrayList {
     System.arraycopy(array, 0, cloneArray, 0, Array.getLength(array));
     return cloneArray;
   }
+
 }

--- a/iotdb/src/main/java/org/apache/iotdb/db/utils/TimeValuePair.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/utils/TimeValuePair.java
@@ -20,7 +20,7 @@ package org.apache.iotdb.db.utils;
 
 import java.io.Serializable;
 
-public class TimeValuePair implements Serializable, Comparable<TimeValuePair>{
+public class TimeValuePair implements Serializable, Comparable<TimeValuePair> {
 
   private long timestamp;
   private TsPrimitiveType value;

--- a/iotdb/src/main/java/org/apache/iotdb/db/utils/TimeValuePair.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/utils/TimeValuePair.java
@@ -20,7 +20,7 @@ package org.apache.iotdb.db.utils;
 
 import java.io.Serializable;
 
-public class TimeValuePair implements Serializable {
+public class TimeValuePair implements Serializable, Comparable<TimeValuePair>{
 
   private long timestamp;
   private TsPrimitiveType value;
@@ -70,5 +70,10 @@ public class TimeValuePair implements Serializable {
 
   public int getSize() {
     return 8 + 8 + value.getSize();
+  }
+
+  @Override
+  public int compareTo(TimeValuePair o) {
+    return Long.compare(this.getTimestamp(), o.getTimestamp());
   }
 }


### PR DESCRIPTION
Now, when we write data into memory, the data is not sorted.

Before we flush data on disk, we need to call getSortedTimeValuePairList() to get the sorted data.

However, current method is implemented by:

 

```
Map<> tmp = new TreeMap();
tmp.putAll();
List<> result = new ArrayList();
tmp.forEach( x -> result.add(x));
```
TreeMap.put() is O(N), the total time complexity is O(N^2), which is not good for this scenario.

 

We can change it to 

```
Map<> tmp = new HashMap(length);
tmp.putAll();
List<> result = new ArrayList(length);
tmp.forEach( x -> result.add(x));
result.sort();
```
Then, the time complexity is O(N) + O(Nlog(N)).

In my experiments, it can save 1/3 time.

