### PR TITLE
try to release memory asap in ReadOnlyMemChunk

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/querycontext/ReadOnlyMemChunk.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/querycontext/ReadOnlyMemChunk.java
@@ -89,6 +89,8 @@ public class ReadOnlyMemChunk implements TimeValuePairSorter {
           break;
       }
     }
+    //release memory
+    memSeries = null;
     initialized = true;
   }
 


### PR DESCRIPTION
In `ReadOnlyMemChunk`, the memSeries is useless after calling `init()`, so I set it to null to let GC collect it asap.