### PR TITLE
[IOTDB-67] call valueDecoder reset() when reading data from a new Page

### DIFF
--- a/tsfile/example/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead.java
+++ b/tsfile/example/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead.java
@@ -70,6 +70,7 @@ public class TsFileSequenceRead {
           Decoder valueDecoder = Decoder
               .getDecoderByType(header.getEncodingType(), header.getDataType());
           for (int j = 0; j < header.getNumOfPages(); j++) {
+            valueDecoder.reset();
             System.out.println("\t\t[Page]\n \t\tPage head position: " + reader.position());
             PageHeader pageHeader = reader.readPageHeader(header.getDataType());
             System.out.println("\t\tPage data position: " + reader.position());


### PR DESCRIPTION
tsfile/example/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead has a bug:

if the data type is Float and the TsFile uses RLE encoding, when we read data by using this class, an exception will occur if there are more than 2 pages in a chunk. 

It is because that for each page, we need to either call `valueDecoder.reset()` or generate a new decoder. However, the example java file does not.