### PR TITLE
add check SG for MManager, MGraph and MTree

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
@@ -145,6 +145,15 @@ public class MGraph implements Serializable {
   }
 
   /**
+   * Check whether the input path is storage level for current Metadata Tree or not.
+   *
+   * @param path Format: root.node.(node)*
+   */
+  public boolean checkStorageLevel(String path) {
+    return mtree.checkStorageGroup(path);
+  }
+
+  /**
    * Get all paths for given seriesPath regular expression if given seriesPath belongs to MTree, or
    * get all linked seriesPath for given seriesPath if given seriesPath belongs to PTree Notice:
    * Regular expression in this method is formed by the amalgamation of seriesPath and the character

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -342,6 +342,13 @@ public class MManager {
   }
 
   /**
+   * function for checking if the given path is storage level of mTree or not.
+   */
+  public boolean checkStorageLevelOfMTree(String path) {
+    return mgraph.checkStorageLevel(path);
+  }
+
+  /**
    * function for adding a pTree.
    */
   public void addAPTree(String ptreeRootName) throws IOException, MetadataArgsErrorException {

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -345,7 +345,12 @@ public class MManager {
    * function for checking if the given path is storage level of mTree or not.
    */
   public boolean checkStorageLevelOfMTree(String path) {
-    return mgraph.checkStorageLevel(path);
+    lock.readLock().lock();
+    try {
+      return mgraph.checkStorageLevel(path);
+    } finally {
+      lock.readLock().unlock();
+    }
   }
 
   /**

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -213,6 +213,34 @@ public class MTree implements Serializable {
   }
 
   /**
+   * check whether the input path is storage group or not
+   * @param path input path
+   * @return if it is storage group, return true. Else return false
+   */
+  public boolean checkStorageGroup(String path) {
+    String[] nodeNames = path.split(DOUB_SEPARATOR);
+    MNode cur = root;
+    if (nodeNames.length <= 1 || !nodeNames[0].equals(root.getName())) {
+      return false;
+    }
+    int i = 1;
+    while (i < nodeNames.length - 1) {
+      MNode temp = cur.getChild(nodeNames[i]);
+      if (temp == null && temp.isStorageLevel()) {
+        return false;
+      }
+      cur = cur.getChild(nodeNames[i]);
+      i++;
+    }
+    MNode temp = cur.getChild(nodeNames[i]);
+    if (temp == null || !temp.isStorageLevel()) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  /**
    * Check whether set file seriesPath for this node or not. If not, throw an exception
    */
   private void checkStorageGroup(MNode node) throws PathErrorException {

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -226,7 +226,7 @@ public class MTree implements Serializable {
     int i = 1;
     while (i < nodeNames.length - 1) {
       MNode temp = cur.getChild(nodeNames[i]);
-      if (temp == null && temp.isStorageLevel()) {
+      if (temp == null || temp.isStorageLevel()) {
         return false;
       }
       cur = cur.getChild(nodeNames[i]);

--- a/iotdb/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -261,4 +261,25 @@ public class MManagerBasicTest {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void testSetStorageLevelAndExist() {
+
+    MManager manager = MManager.getInstance();
+
+    try {
+      manager.setStorageLevelToMTree("root.laptop.d1");
+      assertEquals(true, manager.checkStorageLevelOfMTree("root.laptop.d1"));
+      assertEquals(false, manager.checkStorageLevelOfMTree("root.laptop.d2"));
+
+      manager.setStorageLevelToMTree("root.laptop.d2");
+      assertEquals(true, manager.checkStorageLevelOfMTree("root.laptop.d1"));
+      assertEquals(true, manager.checkStorageLevelOfMTree("root.laptop.d2"));
+      assertEquals(false, manager.checkStorageLevelOfMTree("root.laptop.d3"));
+      assertEquals(false, manager.checkStorageLevelOfMTree("root.laptop"));
+    } catch (PathErrorException | IOException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 }

--- a/iotdb/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -268,9 +268,14 @@ public class MManagerBasicTest {
     MManager manager = MManager.getInstance();
 
     try {
+      assertEquals(false, manager.checkStorageLevelOfMTree("root"));
+      assertEquals(false, manager.checkStorageLevelOfMTree("root1.laptop.d2"));
+
       manager.setStorageLevelToMTree("root.laptop.d1");
       assertEquals(true, manager.checkStorageLevelOfMTree("root.laptop.d1"));
       assertEquals(false, manager.checkStorageLevelOfMTree("root.laptop.d2"));
+      assertEquals(false, manager.checkStorageLevelOfMTree("root.laptop"));
+      assertEquals(false, manager.checkStorageLevelOfMTree("root.laptop.d1.s1"));
 
       manager.setStorageLevelToMTree("root.laptop.d2");
       assertEquals(true, manager.checkStorageLevelOfMTree("root.laptop.d1"));

--- a/iotdb/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -189,4 +189,23 @@ public class MTreeTest {
     assertEquals(root.isPathExist("root.laptop.d2"), true);
     assertEquals(root.isPathExist("root.laptop.d2.s0"), true);
   }
+
+  @Test
+  public void testCheckStorageGroup() {
+    // set storage group first
+    MTree root = new MTree("root");
+    try {
+      root.setStorageGroup("root.laptop.d1");
+      assertEquals(true, root.checkStorageGroup("root.laptop.d1"));
+      assertEquals(false, root.checkStorageGroup("root.laptop.d2"));
+
+      root.setStorageGroup("root.laptop.d2");
+      assertEquals(true, root.checkStorageGroup("root.laptop.d1"));
+      assertEquals(true, root.checkStorageGroup("root.laptop.d2"));
+      assertEquals(false, root.checkStorageGroup("root.laptop.d3"));
+    } catch (PathErrorException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 }

--- a/iotdb/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -195,9 +195,14 @@ public class MTreeTest {
     // set storage group first
     MTree root = new MTree("root");
     try {
+      assertEquals(false, root.checkStorageGroup("root"));
+      assertEquals(false, root.checkStorageGroup("root1.laptop.d2"));
+
       root.setStorageGroup("root.laptop.d1");
       assertEquals(true, root.checkStorageGroup("root.laptop.d1"));
       assertEquals(false, root.checkStorageGroup("root.laptop.d2"));
+      assertEquals(false, root.checkStorageGroup("root.laptop"));
+      assertEquals(false, root.checkStorageGroup("root.laptop.d1.s1"));
 
       root.setStorageGroup("root.laptop.d2");
       assertEquals(true, root.checkStorageGroup("root.laptop.d1"));


### PR DESCRIPTION
Add a method to check whether a input path has already been set to storage level or not. This method will be used in Cluster module. It helps a node to decide whether it is able to execute a cammand or not.