### PR TITLE
refactor QueryTokenManager: move threadlocal as QuerySession

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/query/control/QueryDataSourceManager.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/query/control/QueryDataSourceManager.java
@@ -46,7 +46,7 @@ public class QueryDataSourceManager {
 
     // add used files to current thread request cached map
     OpenedFilePathsManager.getInstance()
-        .addUsedFilesForCurrentRequestThread(jobId, queryDataSource);
+        .addUsedFilesForGivenJob(jobId, queryDataSource);
 
     return queryDataSource;
   }

--- a/iotdb/src/main/java/org/apache/iotdb/db/query/control/QuerySession.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/query/control/QuerySession.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.control;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class QuerySession {
+  /**
+   * Each jdbc request has an unique jod id, job id is stored in thread local variable jobIdContainer.
+   */
+  private ThreadLocal<Long> jobId;
+
+  /**
+   * Each unique jdbc request(query, aggregation or others job) has an unique job id. This job id
+   * will always be maintained until the request is closed. In each job, the unique file will be
+   * only opened once to avoid too many opened files error.
+   */
+  private AtomicLong jobIdGenerator = new AtomicLong();
+
+  private QuerySession() {
+    this.jobId = new ThreadLocal<Long>(){
+      @Override
+      protected Long initialValue() {
+        super.initialValue();
+        long id = jobIdGenerator.incrementAndGet();
+        OpenedFilePathsManager.getInstance().addJobId(id);
+        QueryTokenManager.getInstance().addJobId(id);
+        return id;
+      }
+    };
+  }
+
+  public long getJobId() {
+    return jobId.get();
+  }
+
+  public static long getCurrentThreadJobId() {
+    return QuerySessionHelper.INSTANCE.jobId.get();
+  }
+
+  private static class QuerySessionHelper {
+
+    private static final QuerySession INSTANCE = new QuerySession();
+
+    private QuerySessionHelper() {
+    }
+  }
+
+  public static QuerySession getCurrentThreadQuerySession() {
+    return QuerySessionHelper.INSTANCE;
+  }
+
+
+
+
+}

--- a/iotdb/src/main/java/org/apache/iotdb/db/query/control/QuerySession.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/query/control/QuerySession.java
@@ -32,7 +32,7 @@ public class QuerySession {
    * will always be maintained until the request is closed. In each job, the unique file will be
    * only opened once to avoid too many opened files error.
    */
-  private AtomicLong jobIdGenerator = new AtomicLong();
+  private static AtomicLong jobIdGenerator = new AtomicLong();
 
   private QuerySession() {
     this.jobId = new ThreadLocal<Long>(){
@@ -40,8 +40,6 @@ public class QuerySession {
       protected Long initialValue() {
         super.initialValue();
         long id = jobIdGenerator.incrementAndGet();
-        OpenedFilePathsManager.getInstance().addJobId(id);
-        QueryTokenManager.getInstance().addJobId(id);
         return id;
       }
     };

--- a/iotdb/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -49,7 +49,7 @@ import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
 import org.apache.iotdb.db.qp.physical.sys.AuthorPlan;
-import org.apache.iotdb.db.query.control.OpenedFilePathsManager;
+import org.apache.iotdb.db.query.control.QuerySession;
 import org.apache.iotdb.db.query.control.QueryTokenManager;
 import org.apache.iotdb.service.rpc.thrift.ServerProperties;
 import org.apache.iotdb.service.rpc.thrift.TSCancelOperationReq;
@@ -185,10 +185,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     LOGGER.info("{}: receive close operation", IoTDBConstant.GLOBAL_DB_NAME);
     try {
       // end query for all the query tokens created by current thread
-      QueryTokenManager.getInstance().endQueryForCurrentRequestThread();
-
-      // remove usage of opened file paths of current thread
-      OpenedFilePathsManager.getInstance().removeUsedFilesForCurrentRequestThread();
+      QueryTokenManager.getInstance().endQueryForGivenJob(QuerySession.getCurrentThreadJobId());
 
       clearAllStatusForCurrentRequest();
     } catch (FileNodeManagerException e) {

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
@@ -197,7 +197,7 @@ public class IoTDBEngineTimeGeneratorIT {
 
     SingleSeriesExpression singleSeriesExpression = new SingleSeriesExpression(pd0s0,
         FilterFactory.and(valueGtEq, timeGt));
-    OpenedFilePathsManager.getInstance().setJobIdForCurrentRequestThread(0);
+    OpenedFilePathsManager.getInstance().addJobId(0);
     QueryContext context = new QueryContext();
     EngineTimeGenerator timeGenerator = new EngineTimeGenerator(0, singleSeriesExpression,
         context);
@@ -222,7 +222,7 @@ public class IoTDBEngineTimeGeneratorIT {
     Path pd1s0 = new Path(Constant.d1s0);
     ValueFilter.ValueGtEq valueGtEq = ValueFilter.gtEq(5);
 
-    OpenedFilePathsManager.getInstance().setJobIdForCurrentRequestThread(0);
+    OpenedFilePathsManager.getInstance().addJobId(0);
     IExpression singleSeriesExpression = new SingleSeriesExpression(pd1s0, valueGtEq);
     QueryContext context = new QueryContext();
     EngineTimeGenerator timeGenerator = new EngineTimeGenerator(0, singleSeriesExpression,
@@ -258,7 +258,7 @@ public class IoTDBEngineTimeGeneratorIT {
     IExpression andExpression = BinaryExpression
         .and(singleSeriesExpression1, singleSeriesExpression2);
 
-    OpenedFilePathsManager.getInstance().setJobIdForCurrentRequestThread(0);
+    OpenedFilePathsManager.getInstance().addJobId(0);
     QueryContext context = new QueryContext();
     EngineTimeGenerator timeGenerator = new EngineTimeGenerator(0, andExpression, context);
     int cnt = 0;

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
@@ -27,6 +27,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.apache.iotdb.db.exception.FileNodeManagerException;
+import org.apache.iotdb.db.query.control.QuerySession;
 import org.apache.iotdb.db.query.control.QueryTokenManager;
 import org.apache.iotdb.db.query.executor.EngineQueryRouter;
 import org.apache.iotdb.db.service.IoTDB;
@@ -188,7 +189,7 @@ public class IoTDBSequenceDataQueryIT {
     }
     assertEquals(1000, cnt);
 
-    QueryTokenManager.getInstance().endQueryForCurrentRequestThread();
+    QueryTokenManager.getInstance().endQueryForGivenJob(QuerySession.getCurrentThreadJobId());
   }
 
   @Test
@@ -214,7 +215,7 @@ public class IoTDBSequenceDataQueryIT {
     }
     assertEquals(350, cnt);
 
-    QueryTokenManager.getInstance().endQueryForCurrentRequestThread();
+    QueryTokenManager.getInstance().endQueryForGivenJob(QuerySession.getCurrentThreadJobId());
   }
 
   @Test
@@ -245,7 +246,7 @@ public class IoTDBSequenceDataQueryIT {
     }
     assertEquals(count, cnt);
 
-    QueryTokenManager.getInstance().endQueryForCurrentRequestThread();
+    QueryTokenManager.getInstance().endQueryForGivenJob(QuerySession.getCurrentThreadJobId());
   }
 
 }

--- a/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
@@ -29,6 +29,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.apache.iotdb.db.exception.FileNodeManagerException;
+import org.apache.iotdb.db.query.control.QuerySession;
 import org.apache.iotdb.db.query.control.QueryTokenManager;
 import org.apache.iotdb.db.query.executor.EngineQueryRouter;
 import org.apache.iotdb.db.service.IoTDB;
@@ -262,7 +263,7 @@ public class IoTDBSeriesReaderIT {
     }
     assertEquals(23400, cnt);
 
-    QueryTokenManager.getInstance().endQueryForCurrentRequestThread();
+    QueryTokenManager.getInstance().endQueryForGivenJob(QuerySession.getCurrentThreadJobId());
   }
 
   @Test
@@ -290,7 +291,7 @@ public class IoTDBSeriesReaderIT {
     }
     assertEquals(16440, cnt);
 
-    QueryTokenManager.getInstance().endQueryForCurrentRequestThread();
+    QueryTokenManager.getInstance().endQueryForGivenJob(QuerySession.getCurrentThreadJobId());
   }
 
   @Test
@@ -316,7 +317,7 @@ public class IoTDBSeriesReaderIT {
     }
     assertEquals(3012, cnt);
 
-    QueryTokenManager.getInstance().endQueryForCurrentRequestThread();
+    QueryTokenManager.getInstance().endQueryForGivenJob(QuerySession.getCurrentThreadJobId());
   }
 
   @Test
@@ -343,7 +344,7 @@ public class IoTDBSeriesReaderIT {
     }
     assertEquals(22800, cnt);
 
-    QueryTokenManager.getInstance().endQueryForCurrentRequestThread();
+    QueryTokenManager.getInstance().endQueryForGivenJob(QuerySession.getCurrentThreadJobId());
   }
 
   @Test

--- a/iotdb/src/test/java/org/apache/iotdb/db/query/control/FileReaderManagerTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/query/control/FileReaderManagerTest.java
@@ -62,7 +62,7 @@ public class FileReaderManagerTest {
 
     Thread t1 = new Thread(() -> {
       try {
-        OpenedFilePathsManager.getInstance().setJobIdForCurrentRequestThread(1L);
+        OpenedFilePathsManager.getInstance().addJobId(1L);
 
         for (int i = 1; i <= 6; i++) {
           OpenedFilePathsManager.getInstance().addFilePathToMap(1L, filePath + i,
@@ -80,7 +80,7 @@ public class FileReaderManagerTest {
 
     Thread t2 = new Thread(() -> {
       try {
-        OpenedFilePathsManager.getInstance().setJobIdForCurrentRequestThread(2L);
+        OpenedFilePathsManager.getInstance().addJobId(2L);
 
         for (int i = 4; i <= MAX_FILE_SIZE; i++) {
           OpenedFilePathsManager.getInstance().addFilePathToMap(2L, filePath + i,
@@ -120,7 +120,7 @@ public class FileReaderManagerTest {
     // }
     // }
 
-    OpenedFilePathsManager.getInstance().removeUsedFilesForCurrentRequestThread();
+    OpenedFilePathsManager.getInstance().removeUsedFilesForGivenJob(QuerySession.getCurrentThreadJobId());
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
     for (int i = 1; i < MAX_FILE_SIZE; i++) {
       File file = new File(filePath + i);

--- a/iotdb/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.db.exception.StartupException;
 import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.monitor.StatMonitor;
 import org.apache.iotdb.db.query.control.FileReaderManager;
+import org.apache.iotdb.db.query.control.QuerySession;
 import org.apache.iotdb.db.query.control.QueryTokenManager;
 import org.apache.iotdb.db.writelog.manager.MultiFileLogNodeManager;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
@@ -60,7 +61,7 @@ public class EnvironmentUtils {
 
   public static void cleanEnv() throws IOException, FileNodeManagerException {
 
-    QueryTokenManager.getInstance().endQueryForCurrentRequestThread();
+    QueryTokenManager.getInstance().endQueryForGivenJob(QuerySession.getCurrentThreadJobId());
 
     // clear opened file streams
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();


### PR DESCRIPTION
I move the threadLocal jobId out of OpenedFilePathsManager and QueryTokenManager, and put it into a class QuerySession.

Notice, this PR is for modifying branch `aggregate`, because the branch has too many modifications already..