### PR TITLE
Add method getAllSGByFile() for MManager

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
@@ -294,6 +294,13 @@ public class MGraph implements Serializable {
   }
 
   /**
+   * Get all file names for given seriesPath
+   */
+  public List<String> getAllFileNamesByPath(String path) throws PathErrorException {
+    return mtree.getAllFileNamesByPath(path);
+  }
+
+  /**
    * Check whether the seriesPath given exists.
    */
   public boolean pathExist(String path) {

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -683,6 +683,23 @@ public class MManager {
   }
 
   /**
+   * Get all file names for given seriesPath
+   *
+   * @return List of String represented all file names
+   */
+  public List<String> getAllFileNamesByPath(String path) throws PathErrorException {
+
+    lock.readLock().lock();
+    try {
+      return mgraph.getAllFileNamesByPath(path);
+    } catch (PathErrorException e) {
+      throw new PathErrorException(e);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /**
    * return a HashMap contains all the paths separated by File Name.
    */
   public Map<String, ArrayList<String>> getAllPathGroupByFileName(String path)

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -564,6 +564,7 @@ public class MTree implements Serializable {
       }
       if (cur.isStorageLevel()) {
         sgList.add(cur.getDataFileName());
+        return sgList;
       }
       cur = cur.getChild(nodes[i]);
     }

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -39,6 +39,7 @@ public class MTree implements Serializable {
 
   private static final long serialVersionUID = -4200394435237291964L;
   private static final String QUAD_SPACE = "    ";
+  private static final String SEPARATOR = ".";
   private static final String DOUB_SEPARATOR = "\\.";
   private static final String NO_CHILD_ERROR = "Timeseries is not correct. Node[%s] "
       + "doesn't have child named:%s";
@@ -543,6 +544,44 @@ public class MTree implements Serializable {
     }
     throw new PathErrorException(
         String.format(NOT_SERIES_PATH, path));
+  }
+
+  /**
+   * Get all the storage group seriesPaths for one seriesPath.
+   *
+   * @return List storage group seriesPath list
+   */
+  public List<String> getAllFileNamesByPath(String path) throws PathErrorException {
+
+    List<String> sgList = new ArrayList<>();
+    String[] nodes = path.split(DOUB_SEPARATOR);
+    MNode cur = getRoot();
+    for (int i = 1; i < nodes.length; i++) {
+      if (cur == null) {
+        throw new PathErrorException(
+            String.format(NOT_SERIES_PATH,
+                path));
+      }
+      if (cur.isStorageLevel()) {
+        sgList.add(cur.getDataFileName());
+      }
+      cur = cur.getChild(nodes[i]);
+    }
+    if (sgList.isEmpty()) {
+      getAllStorageGroupsOfNode(cur, path, sgList);
+    }
+    return sgList;
+  }
+
+  private void getAllStorageGroupsOfNode(MNode node, String path, List<String> sgList) {
+    if (node.isStorageLevel()) {
+      sgList.add(path);
+      return;
+    }
+
+    for (MNode child : node.getChildren().values()) {
+      getAllStorageGroupsOfNode(child, path + SEPARATOR + child.getName(), sgList);
+    }
   }
 
   /**

--- a/iotdb/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -287,4 +287,29 @@ public class MManagerBasicTest {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void testGetAllFileNamesByPath() {
+
+    MManager manager = MManager.getInstance();
+    try {
+      manager.setStorageLevelToMTree("root.laptop.d1");
+      manager.setStorageLevelToMTree("root.laptop.d2");
+      manager.addPathToMTree("root.laptop.d1.s1", TSDataType.INT32, TSEncoding.PLAIN, CompressionType.GZIP, null);
+      manager.addPathToMTree("root.laptop.d1.s1", TSDataType.INT32, TSEncoding.PLAIN, CompressionType.GZIP, null);
+
+      List<String> list = new ArrayList<>();
+
+      list.add("root.laptop.d1");
+      assertEquals(list, manager.getAllFileNamesByPath("root.laptop.d1.s1"));
+      assertEquals(list, manager.getAllFileNamesByPath("root.laptop.d1"));
+
+      list.add("root.laptop.d2");
+      assertEquals(list, manager.getAllFileNamesByPath("root.laptop"));
+      assertEquals(list, manager.getAllFileNamesByPath("root"));
+    } catch (PathErrorException | IOException | MetadataArgsErrorException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 }

--- a/iotdb/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -24,8 +24,12 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import org.apache.iotdb.db.exception.PathErrorException;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -208,6 +212,31 @@ public class MTreeTest {
       assertEquals(true, root.checkStorageGroup("root.laptop.d1"));
       assertEquals(true, root.checkStorageGroup("root.laptop.d2"));
       assertEquals(false, root.checkStorageGroup("root.laptop.d3"));
+    } catch (PathErrorException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetAllFileNamesByPath() {
+    // set storage group first
+    MTree root = new MTree("root");
+    try {
+      root.setStorageGroup("root.laptop.d1");
+      root.setStorageGroup("root.laptop.d2");
+      root.addTimeseriesPath("root.laptop.d1.s1", TSDataType.INT32, TSEncoding.PLAIN, CompressionType.GZIP, null);
+      root.addTimeseriesPath("root.laptop.d1.s1", TSDataType.INT32, TSEncoding.PLAIN, CompressionType.GZIP, null);
+
+      List<String> list = new ArrayList<>();
+
+      list.add("root.laptop.d1");
+      assertEquals(list, root.getAllFileNamesByPath("root.laptop.d1.s1"));
+      assertEquals(list, root.getAllFileNamesByPath("root.laptop.d1"));
+
+      list.add("root.laptop.d2");
+      assertEquals(list, root.getAllFileNamesByPath("root.laptop"));
+      assertEquals(list, root.getAllFileNamesByPath("root"));
     } catch (PathErrorException e) {
       e.printStackTrace();
       fail(e.getMessage());


### PR DESCRIPTION
Add method getAllSGByFile() for MManager. If it only returns one SG, then one of the input path's parents is storage level; if it returns mltiple SGs, then they are all children of the input path.