### PR TITLE
Add check existence of storage group of path for MManager, MGraph and MTree

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
@@ -148,9 +148,20 @@ public class MGraph implements Serializable {
    * Check whether the input path is storage level for current Metadata Tree or not.
    *
    * @param path Format: root.node.(node)*
+   * @apiNote :for cluster
    */
   public boolean checkStorageLevel(String path) {
     return mtree.checkStorageGroup(path);
+  }
+
+  /**
+   * Check whether the storage group of the input path exists or not
+   *
+   * @param path Format: root.node.(node)*
+   * @apiNote :for cluster
+   */
+  public boolean checkStorageExistOfPath(String path) {
+    return mtree.checkStorageExistOfPath(path);
   }
 
   /**

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -343,11 +343,25 @@ public class MManager {
 
   /**
    * function for checking if the given path is storage level of mTree or not.
+   * @apiNote :for cluster
    */
   public boolean checkStorageLevelOfMTree(String path) {
     lock.readLock().lock();
     try {
       return mgraph.checkStorageLevel(path);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /**
+   * function for checking if the storage group of given path exists in mTree or not.
+   * @apiNote :for cluster
+   */
+  public boolean checkStorageExistOfPath(String path) {
+    lock.readLock().lock();
+    try {
+      return mgraph.checkStorageExistOfPath(path);
     } finally {
       lock.readLock().unlock();
     }

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -216,6 +216,7 @@ public class MTree implements Serializable {
    * check whether the input path is storage group or not
    * @param path input path
    * @return if it is storage group, return true. Else return false
+   * @apiNote :for cluster
    */
   public boolean checkStorageGroup(String path) {
     String[] nodeNames = path.split(DOUB_SEPARATOR);
@@ -237,6 +238,38 @@ public class MTree implements Serializable {
       return false;
     } else {
       return true;
+    }
+  }
+
+  /**
+   * Check whether the storage group of the path exists or not
+   * @param path input path
+   * @return If it's storage group exists, return true. Else return false
+   * @apiNote :for cluster
+   */
+  public boolean checkStorageExistOfPath(String path) {
+    String[] nodeNames = path.split(DOUB_SEPARATOR);
+    MNode cur = root;
+    if (nodeNames.length <= 1 || !nodeNames[0].equals(root.getName())) {
+      return false;
+    }
+    int i = 1;
+    while (i < nodeNames.length - 1) {
+      MNode temp = cur.getChild(nodeNames[i]);
+      if (temp == null) {
+        return false;
+      }
+      if(temp.isStorageLevel()){
+        return true;
+      }
+      cur = cur.getChild(nodeNames[i]);
+      i++;
+    }
+    MNode temp = cur.getChild(nodeNames[i]);
+    if(temp != null && temp.isStorageLevel()) {
+      return true;
+    } else {
+      return false;
     }
   }
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -287,4 +287,32 @@ public class MManagerBasicTest {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void testCheckStorageExistOfPath() {
+    MManager manager = MManager.getInstance();
+
+    try {
+      assertEquals(false, manager.checkStorageExistOfPath("root"));
+      assertEquals(false, manager.checkStorageExistOfPath("root.vehicle"));
+      assertEquals(false, manager.checkStorageExistOfPath("root.vehicle.device"));
+      assertEquals(false, manager.checkStorageExistOfPath("root.vehicle.device.sensor"));
+
+      manager.setStorageLevelToMTree("root.vehicle");
+      assertEquals(true, manager.checkStorageExistOfPath("root.vehicle"));
+      assertEquals(true, manager.checkStorageExistOfPath("root.vehicle.device"));
+      assertEquals(true, manager.checkStorageExistOfPath("root.vehicle.device.sensor"));
+      assertEquals(false, manager.checkStorageExistOfPath("root.vehicle1"));
+      assertEquals(false, manager.checkStorageExistOfPath("root.vehicle1.device"));
+
+      manager.setStorageLevelToMTree("root.vehicle1.device");
+      assertEquals(false, manager.checkStorageExistOfPath("root.vehicle1.device1"));
+      assertEquals(false, manager.checkStorageExistOfPath("root.vehicle1.device2"));
+      assertEquals(false, manager.checkStorageExistOfPath("root.vehicle1.device3"));
+      assertEquals(true, manager.checkStorageExistOfPath("root.vehicle1.device"));
+    } catch (PathErrorException | IOException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 }

--- a/iotdb/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -213,4 +213,33 @@ public class MTreeTest {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void testCheckStorageExistOfPath() {
+    // set storage group first
+    MTree root = new MTree("root");
+    try {
+      assertEquals(false, root.checkStorageExistOfPath("root"));
+      assertEquals(false, root.checkStorageExistOfPath("root.vehicle"));
+      assertEquals(false, root.checkStorageExistOfPath("root.vehicle.device"));
+      assertEquals(false, root.checkStorageExistOfPath("root.vehicle.device.sensor"));
+
+      root.setStorageGroup("root.vehicle");
+      assertEquals(true, root.checkStorageExistOfPath("root.vehicle"));
+      assertEquals(true, root.checkStorageExistOfPath("root.vehicle.device"));
+      assertEquals(true, root.checkStorageExistOfPath("root.vehicle.device.sensor"));
+      assertEquals(false, root.checkStorageExistOfPath("root.vehicle1"));
+      assertEquals(false, root.checkStorageExistOfPath("root.vehicle1.device"));
+
+      root.setStorageGroup("root.vehicle1.device");
+      assertEquals(false, root.checkStorageExistOfPath("root.vehicle1.device1"));
+      assertEquals(false, root.checkStorageExistOfPath("root.vehicle1.device2"));
+      assertEquals(false, root.checkStorageExistOfPath("root.vehicle1.device3"));
+      assertEquals(true, root.checkStorageExistOfPath("root.vehicle1.device"));
+    } catch (PathErrorException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
 }


### PR DESCRIPTION
Add a method to check whether the storage group of a input path exists or not. This method will be used in Cluster module. It helps data state machine to decide whether it needs to execute null-read in meta group while applying a task of adding path or not.