### PR TITLE
fix the future instance is replaced when the flush frequency is high

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/bufferwrite/BufferWriteProcessor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/bufferwrite/BufferWriteProcessor.java
@@ -332,16 +332,16 @@ public class BufferWriteProcessor extends Processor {
     }
     lastFlushTime = System.nanoTime();
     // check value count
+    // waiting for the end of last flush operation.
+    try {
+      flushFuture.get();
+    } catch (InterruptedException | ExecutionException e) {
+      LOGGER.error("Encounter an interrupt error when waitting for the flushing, "
+              + "the bufferwrite processor is {}.",
+          getProcessorName(), e);
+      Thread.currentThread().interrupt();
+    }
     if (valueCount > 0) {
-      // waiting for the end of last flush operation.
-      try {
-        flushFuture.get();
-      } catch (InterruptedException | ExecutionException e) {
-        LOGGER.error("Encounter an interrupt error when waitting for the flushing, "
-                + "the bufferwrite processor is {}.",
-            getProcessorName(), e);
-        Thread.currentThread().interrupt();
-      }
       // update the lastUpdatetime, prepare for flush
       try {
         bufferwriteFlushAction.act();

--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/bufferwrite/BufferWriteProcessor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/bufferwrite/BufferWriteProcessor.java
@@ -339,7 +339,7 @@ public class BufferWriteProcessor extends Processor {
       LOGGER.error("Encounter an interrupt error when waitting for the flushing, "
               + "the bufferwrite processor is {}.",
           getProcessorName(), e);
-      Thread.currentThread().interrupt();
+      throw new IOException(e);
     }
     if (valueCount > 0) {
       // update the lastUpdatetime, prepare for flush

--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/bufferwrite/BufferWriteProcessor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/bufferwrite/BufferWriteProcessor.java
@@ -336,9 +336,6 @@ public class BufferWriteProcessor extends Processor {
     try {
       flushFuture.get();
     } catch (InterruptedException | ExecutionException e) {
-      LOGGER.error("Encounter an interrupt error when waitting for the flushing, "
-              + "the bufferwrite processor is {}.",
-          getProcessorName(), e);
       throw new IOException(e);
     }
     if (valueCount > 0) {

--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/overflow/io/OverflowProcessor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/overflow/io/OverflowProcessor.java
@@ -475,7 +475,7 @@ public class OverflowProcessor extends Processor {
   @Override
   public synchronized Future<Boolean> flush() throws IOException {
     // statistic information for flush
-    if (lastFlushTime > 0) {
+    if (lastFlushTime > 0 && LOGGER.isInfoEnabled()) {
       long thisFLushTime = System.currentTimeMillis();
       ZonedDateTime lastDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(lastFlushTime),
           IoTDBDescriptor.getInstance().getConfig().getZoneID());
@@ -492,9 +492,8 @@ public class OverflowProcessor extends Processor {
       flushFuture.get();
     } catch (InterruptedException | ExecutionException e) {
       LOGGER.error("Encounter an interrupt error when waitting for the flushing, "
-              + "the bufferwrite processor is {}.",
-          getProcessorName(), e);
-      Thread.currentThread().interrupt();
+              + "the bufferwrite processor is {}.", getProcessorName(), e);
+      throw new IOException(e);
     }
     if (valueCount > 0) {
       try {

--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/overflow/io/OverflowProcessor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/overflow/io/OverflowProcessor.java
@@ -491,8 +491,6 @@ public class OverflowProcessor extends Processor {
     try {
       flushFuture.get();
     } catch (InterruptedException | ExecutionException e) {
-      LOGGER.error("Encounter an interrupt error when waitting for the flushing, "
-              + "the bufferwrite processor is {}.", getProcessorName(), e);
       throw new IOException(e);
     }
     if (valueCount > 0) {

--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/overflow/io/OverflowProcessor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/overflow/io/OverflowProcessor.java
@@ -488,16 +488,15 @@ public class OverflowProcessor extends Processor {
           (thisFLushTime - lastFlushTime) / 1000);
     }
     lastFlushTime = System.currentTimeMillis();
-    // value count
+    try {
+      flushFuture.get();
+    } catch (InterruptedException | ExecutionException e) {
+      LOGGER.error("Encounter an interrupt error when waitting for the flushing, "
+              + "the bufferwrite processor is {}.",
+          getProcessorName(), e);
+      Thread.currentThread().interrupt();
+    }
     if (valueCount > 0) {
-      try {
-        flushFuture.get();
-      } catch (InterruptedException | ExecutionException e) {
-        LOGGER.error("Encounter an interrupt error when waitting for the flushing, "
-                + "the bufferwrite processor is {}.",
-            getProcessorName(), e);
-        Thread.currentThread().interrupt();
-      }
       try {
         // backup newIntervalFile list and emptyIntervalFileNode
         overflowFlushAction.act();


### PR DESCRIPTION
If we call flush() twice (and in the 2nt calling, `value count` = 0), then the first future instance will be replaced. If there is exception in the first flush process, we will have no idea to catch it.

In this PR, we will wait to finish the last flush process before submitting a new one.
