### PR TITLE
degrade log level in ParseDriver and TSServiceImpl

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -482,7 +482,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         return executeUpdateStatement(physicalPlan);
       }
     } catch (Exception e) {
-      LOGGER.error("meet error while executing statement.", e);
+      LOGGER.info("meet error while executing statement: {}", e.getMessage());
       return getTSExecuteStatementResp(TS_StatusCode.ERROR_STATUS, e.getMessage());
     }
   }

--- a/iotdb/src/main/java/org/apache/iotdb/db/sql/parse/ParseDriver.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/sql/parse/ParseDriver.java
@@ -97,7 +97,7 @@ public class ParseDriver {
 
       r = parser.statement();
     } catch (RecognitionException e) {
-      LOG.error("meet error while parsing statement.", e);
+      LOG.trace("meet error while parsing statement, {} : {}", command, e.getMessage());
     }
 
     if (lexer.getErrors().isEmpty() && parser.errors.isEmpty()) {


### PR DESCRIPTION
set parsing incorrect cmd as tracing level log in ParseDriver;

set TsserviceImple failed executing as info leve log;

the are for fixing the following notifications:
![image](https://user-images.githubusercontent.com/1021782/56359481-4485d400-6214-11e9-8340-c0a77106177f.png)
