### PR TITLE
print apache-rat violation result on console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
                     <groupId>org.apache.rat</groupId>
                     <artifactId>apache-rat-plugin</artifactId>
                     <configuration>
+                        <consoleOutput>true</consoleOutput>
                         <excludes>
                             <!-- Git related files -->
                             <exclude>**/.git/**</exclude>


### PR DESCRIPTION
Now the apache-rat checker just print a summary on console, 

![image](https://user-images.githubusercontent.com/1021782/56454126-e32e4400-637e-11e9-8b84-7857b700d7be.png)

but as we can not get the rat.txt file from Travis-CI platform, we have to print the detailed result on console, like this:
![image](https://user-images.githubusercontent.com/1021782/56454147-17096980-637f-11e9-99fc-b213831c7fac.png)
