### PR TITLE
Fix a clerical error in console display when  run 'start-server.sh'

### DIFF
--- a/iotdb/iotdb/conf/iotdb-env.sh
+++ b/iotdb/iotdb/conf/iotdb-env.sh
@@ -146,5 +146,5 @@ fi
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xms${HEAP_NEWSIZE}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xmx${MAX_HEAP_SIZE}"
 
-echo "Maximum memory allocation pool = ${MAX_HEAP_SIZE}MB, initial memory allocation pool = ${HEAP_NEWSIZE}MB"
+echo "Maximum memory allocation pool = ${MAX_HEAP_SIZE}MB, initial memory allocation pool = ${HEAP_NEWSIZE}B"
 echo "If you want to change this configuration, please check conf/iotdb-env.sh(Unix or OS X, if you use Windows, check conf/iotdb-env.bat)."


### PR DESCRIPTION
To remove the redundant "M"s displayed in console when trying to run the bash `start-server.sh`.