### PR TITLE
 Fix a clerical error in console display when run 'start-server.sh'

### DIFF
--- a/iotdb/iotdb/conf/iotdb-env.sh
+++ b/iotdb/iotdb/conf/iotdb-env.sh
@@ -146,5 +146,5 @@ fi
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xms${HEAP_NEWSIZE}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xmx${MAX_HEAP_SIZE}"
 
-echo "Maximum memory allocation pool = ${MAX_HEAP_SIZE}MB, initial memory allocation pool = ${HEAP_NEWSIZE}MB"
+echo "Maximum memory allocation pool = ${MAX_HEAP_SIZE}MB, initial memory allocation pool = ${HEAP_NEWSIZE}B"
 echo "If you want to change this configuration, please check conf/iotdb-env.sh(Unix or OS X, if you use Windows, check conf/iotdb-env.bat)."

--- a/iotdb/iotdb/conf/iotdb-env.sh
+++ b/iotdb/iotdb/conf/iotdb-env.sh
@@ -146,5 +146,5 @@ fi
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xms${HEAP_NEWSIZE}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xmx${MAX_HEAP_SIZE}"
 
-echo "Maximum memory allocation pool = ${MAX_HEAP_SIZE}MB, initial memory allocation pool = ${HEAP_NEWSIZE}B"
+echo "Maximum memory allocation pool = ${MAX_HEAP_SIZE}B, initial memory allocation pool = ${HEAP_NEWSIZE}B"
 echo "If you want to change this configuration, please check conf/iotdb-env.sh(Unix or OS X, if you use Windows, check conf/iotdb-env.bat)."


### PR DESCRIPTION
When I run `incubator-iotdb/iotdb/iotdb/bin/start-server.sh` on Unix/OS X, the output in console is

```bash
---------------------
Starting IoTDB
---------------------
Maximum memory allocation pool = 4096MMB, initial memory allocation pool = 800MMB
...
```

You can see that there are redundant "M"s in " `4096MMB`"  and "`800MMB`". I have just removed them.

The problem comes from the duplicate declaration of "M" in line 78 & 149 of file `incubator-iotdb/iotdb/iotdb/conf/iotdb-env.sh`:

- Line 78

```bash
MAX_HEAP_SIZE="${max_heap_size_in_mb}M"
```

- Line 149

```bash
echo "Maximum memory allocation pool = ${MAX_HEAP_SIZE}MB, initial memory allocation pool = ${HEAP_NEWSIZE}MB"
```

After changing the Line 149:

```bash
echo "Maximum memory allocation pool = ${MAX_HEAP_SIZE}B, initial memory allocation pool = ${HEAP_NEWSIZE}B"
```

And the correct output in console is

```bash
---------------------
Starting IoTDB
---------------------
Maximum memory allocation pool = 4096MB, initial memory allocation pool = 800MB
...
```