### PR TITLE
[IOTDB-94]IoTDB failed to start client since the required jars are no…

### DIFF
--- a/iotdb-cli/cli/bin/start-client.bat
+++ b/iotdb-cli/cli/bin/start-client.bat
@@ -37,7 +37,7 @@ set JAVA_OPTS=-ea^
  -DIOTDB_HOME=%IOTDB_HOME%
 
 REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
+for %%i in ("%IOTDB_CLI_HOME%\lib\*.jar") do call :append "%%i"
 goto okClasspath
 
 :append


### PR DESCRIPTION
Corresponding JIRA issue link: https://issues.apache.org/jira/browse/IOTDB-94