### PR TITLE
[IOTDB-105] fix bug of write lock operation in merge() when IoTDB recover

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/filenode/FileNodeProcessor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/filenode/FileNodeProcessor.java
@@ -1044,6 +1044,7 @@ public class FileNodeProcessor extends Processor implements IStatistic {
    * Merge this storage group, merge the tsfile data with overflow data.
    */
   public void merge() throws FileNodeProcessorException {
+    writeLock();
     // close bufferwrite and overflow, prepare for merge
     LOGGER.info("The filenode processor {} begins to merge.", getProcessorName());
     prepareForMerge();
@@ -2045,7 +2046,6 @@ public class FileNodeProcessor extends Processor implements IStatistic {
       try {
         ZoneId zoneId = IoTDBDescriptor.getInstance().getConfig().getZoneID();
         long mergeStartTime = System.currentTimeMillis();
-        writeLock();
         merge();
         long mergeEndTime = System.currentTimeMillis();
         long intervalTime = mergeEndTime - mergeStartTime;


### PR DESCRIPTION
Currenttly, when IoTDB revover, it is possible that exception of write lock operation will be thrown as shown below.
![图片](https://user-images.githubusercontent.com/16442316/58675775-6b453780-8388-11e9-847c-a49cf6b15384.png)
After checking, during the MERGE of recovery, locking and unlocking operations are not in pairs. This is mainly because FileNodeProcessor.merge() contains 2 locking operations and 3 unlocking operations. In normal process, an extra locking operation is processed before merge(). Therefore, to fix this bug, the locking operation is moved into merge().