### PR TITLE
[IOTDB-109]Fix native restore tsfile writer if file is complete and append=true

### DIFF
--- a/tsfile/example/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead.java
+++ b/tsfile/example/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.encoding.decoder.Decoder;
@@ -104,13 +106,21 @@ public class TsFileSequenceRead {
     List<TsDeviceMetadataIndex> deviceMetadataIndexList = metaData.getDeviceMap().values().stream()
         .sorted((x, y) -> (int) (x.getOffset() - y.getOffset())).collect(Collectors.toList());
     for (TsDeviceMetadataIndex index : deviceMetadataIndexList) {
+      System.out.println(String
+          .format("\t[DeviceMetadata List]File Offset: %d, Len %d",
+              index.getOffset(), index.getLen()));
+
       TsDeviceMetadata deviceMetadata = reader.readTsDeviceMetaData(index);
       List<ChunkGroupMetaData> chunkGroupMetaDataList = deviceMetadata.getChunkGroupMetaDataList();
+      int i = 0;
       for (ChunkGroupMetaData chunkGroupMetaData : chunkGroupMetaDataList) {
         System.out.println(String
-            .format("\t[Device]File Offset: %d, Device %s, Number of Chunk Groups %d",
-                index.getOffset(), chunkGroupMetaData.getDeviceID(),
-                chunkGroupMetaDataList.size()));
+            .format("\t[DeviceMetadata]Data Start Offset: %d,  Data End Offset: %d, "
+                    + "Device %s, Number %d/%d of Chunk Groups",
+                chunkGroupMetaData.getStartOffsetOfChunkGroup(),
+                chunkGroupMetaData.getEndOffsetOfChunkGroup(),
+                chunkGroupMetaData.getDeviceID(),
+                ++i, chunkGroupMetaDataList.size()));
 
         for (ChunkMetaData chunkMetadata : chunkGroupMetaData.getChunkMetaDataList()) {
           System.out.println("\t\tMeasurement:" + chunkMetadata.getMeasurementUid());

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkGroupMetaData.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkGroupMetaData.java
@@ -45,6 +45,7 @@ public class ChunkGroupMetaData {
 
   /**
    * Byte offset of the corresponding data in the file.
+   * ( Notice: include the marker of its first Chunk header.)
    * For Hadoop and Spark.
    */
   private long startOffsetOfChunkGroup;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkGroupMetaData.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkGroupMetaData.java
@@ -44,7 +44,7 @@ public class ChunkGroupMetaData {
   private int serializedSize;
 
   /**
-   * Byte offset of the corresponding data in the file Notice: include the chunk group header and marker.
+   * Byte offset of the corresponding data in the file.
    * For Hadoop and Spark.
    */
   private long startOffsetOfChunkGroup;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -524,7 +524,6 @@ public class TsFileSequenceReader implements AutoCloseable{
     long startOffsetOfChunkGroup = 0;
     long endOffsetOfChunkGroup;
     long versionOfChunkGroup = 0;
-    boolean newGroup = true;
 
     if (fileSize < TSFileConfig.MAGIC_STRING.length()) {
       return TsFileCheckStatus.INCOMPATIBLE_FILE;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -620,7 +620,7 @@ public class TsFileSequenceReader implements AutoCloseable{
       truncatedPosition = this.position() - 1;
     } catch (IOException e2) {
       LOGGER.info("TsFile self-check cannot proceed at position {} after {} chunk groups "
-              + "recovered, because", this.position(), newMetaData.size(), e2);
+              + "recovered, because {}", this.position(), newMetaData.size(), e2.getMessage());
     }
     // Despite the completeness of the data section, we will discard current FileMetadata
     // so that we can continue to write data into this tsfile.

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
@@ -335,7 +335,11 @@ public class ReadWriteIOUtils {
    */
   public static short readShort(InputStream inputStream) throws IOException {
     byte[] bytes = new byte[SHORT_LEN];
-    inputStream.read(bytes);
+    int readLen = inputStream.read(bytes);
+    if (readLen != SHORT_LEN) {
+      throw new IOException(String.format("Intend to read %d bytes but %d are actually returned",
+          SHORT_LEN, readLen));
+    }
     return BytesUtils.bytesToShort(bytes);
   }
 
@@ -351,7 +355,11 @@ public class ReadWriteIOUtils {
    */
   public static float readFloat(InputStream inputStream) throws IOException {
     byte[] bytes = new byte[FLOAT_LEN];
-    inputStream.read(bytes);
+    int readLen = inputStream.read(bytes);
+    if (readLen != FLOAT_LEN) {
+      throw new IOException(String.format("Intend to read %d bytes but %d are actually returned",
+          FLOAT_LEN, readLen));
+    }
     return BytesUtils.bytesToFloat(bytes);
   }
 
@@ -369,7 +377,11 @@ public class ReadWriteIOUtils {
    */
   public static double readDouble(InputStream inputStream) throws IOException {
     byte[] bytes = new byte[DOUBLE_LEN];
-    inputStream.read(bytes);
+    int readLen = inputStream.read(bytes);
+    if (readLen != DOUBLE_LEN) {
+      throw new IOException(String.format("Intend to read %d bytes but %d are actually returned",
+          DOUBLE_LEN, readLen));
+    }
     return BytesUtils.bytesToDouble(bytes);
   }
 
@@ -387,7 +399,11 @@ public class ReadWriteIOUtils {
    */
   public static int readInt(InputStream inputStream) throws IOException {
     byte[] bytes = new byte[INT_LEN];
-    inputStream.read(bytes);
+    int readLen = inputStream.read(bytes);
+    if (readLen != INT_LEN) {
+      throw new IOException(String.format("Intend to read %d bytes but %d are actually returned",
+       INT_LEN, readLen));
+    }
     return BytesUtils.bytesToInt(bytes);
   }
 
@@ -415,7 +431,11 @@ public class ReadWriteIOUtils {
    */
   public static long readLong(InputStream inputStream) throws IOException {
     byte[] bytes = new byte[LONG_LEN];
-    inputStream.read(bytes);
+    int readLen = inputStream.read(bytes);
+    if (readLen != LONG_LEN) {
+      throw new IOException(String.format("Intend to read %d bytes but %d are actually returned",
+          LONG_LEN, readLen));
+    }
     return BytesUtils.bytesToLong(bytes);
   }
 
@@ -432,7 +452,11 @@ public class ReadWriteIOUtils {
   public static String readString(InputStream inputStream) throws IOException {
     int strLength = readInt(inputStream);
     byte[] bytes = new byte[strLength];
-    inputStream.read(bytes, 0, strLength);
+    int readLen = inputStream.read(bytes, 0, strLength);
+    if (readLen != strLength) {
+      throw new IOException(String.format("Intend to read %d bytes but %d are actually returned",
+          strLength, readLen));
+    }
     return new String(bytes, 0, strLength);
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/NativeRestorableIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/NativeRestorableIOWriter.java
@@ -83,7 +83,7 @@ public class NativeRestorableIOWriter extends TsFileIOWriter {
           out.truncate(TSFileConfig.MAGIC_STRING.length());
         } else {
           //remove broken data
-          out.truncate(truncatedPosition);
+          out.truncate(truncatedPosition + 1);
         }
       }
     }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/NativeRestorableIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/NativeRestorableIOWriter.java
@@ -83,7 +83,7 @@ public class NativeRestorableIOWriter extends TsFileIOWriter {
           out.truncate(TSFileConfig.MAGIC_STRING.length());
         } else {
           //remove broken data
-          out.truncate(truncatedPosition + 1);
+          out.truncate(truncatedPosition);
         }
       }
     }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/NativeRestorableIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/NativeRestorableIOWriter.java
@@ -100,7 +100,8 @@ public class NativeRestorableIOWriter extends TsFileIOWriter {
       TsFileMetaData metaData = reader.readFileMetadata();
       knownSchemas = metaData.getMeasurementSchema();
       chunkGroupMetaDataList = reader.readAllChunkGroupMetaData(metaData);
-      out.truncate(reader.getFirstTsDeviceMetadataPosition(metaData) - 1);
+      truncatedPosition = reader.getFirstTsDeviceMetadataPosition(metaData) - 1;
+      out.truncate(truncatedPosition);
     }
   }
 

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/NativeRestorableIOWriterTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/NativeRestorableIOWriterTest.java
@@ -188,8 +188,8 @@ public class NativeRestorableIOWriterTest {
     assertEquals(2, record.getTimestamp());
     assertEquals(5.0f, record.getFields().get(0).getFloatV(), 0.001f);
     assertEquals(4.0f, record.getFields().get(1).getFloatV(), 0.001f);
+    assertFalse(dataSet.hasNext());
 
-    assertEquals(271, rWriter.getTruncatedPosition());
     assertTrue(file.delete());
   }
 
@@ -383,7 +383,6 @@ public class NativeRestorableIOWriterTest {
     assertEquals(4.0f, record.getFields().get(1).getFloatV(), 0.001f);
     assertFalse(dataSet.hasNext());
 
-    assertEquals(271, rWriter.getTruncatedPosition());
     assertTrue(file.delete());
   }
 }

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/NativeRestorableIOWriterTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/NativeRestorableIOWriterTest.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.file.MetaMarker;
 import org.apache.iotdb.tsfile.file.metadata.TsDeviceMetadataIndex;
@@ -34,8 +36,13 @@ import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.file.metadata.statistics.FloatStatistics;
+import org.apache.iotdb.tsfile.read.ReadOnlyTsFile;
 import org.apache.iotdb.tsfile.read.TsFileCheckStatus;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
+import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.read.common.RowRecord;
+import org.apache.iotdb.tsfile.read.expression.QueryExpression;
+import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.iotdb.tsfile.write.TsFileWriter;
 import org.apache.iotdb.tsfile.write.record.TSRecord;
 import org.apache.iotdb.tsfile.write.record.datapoint.FloatDataPoint;
@@ -164,7 +171,23 @@ public class NativeRestorableIOWriterTest {
     NativeRestorableIOWriter rWriter = new NativeRestorableIOWriter(file);
     writer = new TsFileWriter(rWriter);
     writer.close();
-    assertEquals(TsFileIOWriter.magicStringBytes.length, rWriter.getTruncatedPosition());
+
+    ReadOnlyTsFile readOnlyTsFile = new ReadOnlyTsFile(new TsFileSequenceReader(file.getPath()));
+    List<Path> pathList = new ArrayList<>();
+    pathList.add(new Path("d1", "s1"));
+    pathList.add(new Path("d1", "s2"));
+    QueryExpression queryExpression = QueryExpression.create(pathList, null);
+    QueryDataSet dataSet = readOnlyTsFile.query(queryExpression);
+    RowRecord record = dataSet.next();
+    assertEquals(1, record.getTimestamp());
+    assertEquals(5.0f, record.getFields().get(0).getFloatV(), 0.001f);
+    assertEquals(4.0f, record.getFields().get(1).getFloatV(), 0.001f);
+    record = dataSet.next();
+    assertEquals(2, record.getTimestamp());
+    assertEquals(5.0f, record.getFields().get(0).getFloatV(), 0.001f);
+    assertEquals(4.0f, record.getFields().get(1).getFloatV(), 0.001f);
+
+    assertEquals(271, rWriter.getTruncatedPosition());
     assertTrue(file.delete());
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-109

when using nativeRestoreIOWriter to open a sealed TsFile with append=true mode, the parameter does not work now..

The correct behavior is:

if append == true, then the sealed TsFile's file metadata should be truncated and the existing metadata should be loaded into the memory.