### PR TITLE
fix travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,22 +64,22 @@ matrix:
            - AdoptOpenJDK/openjdk
           update: true
           casks: adoptopenjdk-openjdk8
-    - os: windows
-      language: c
-      name: win-oraclejdk11
-      install:
-        - choco install jdk11 -params 'installdir=c:\\java11'
-        - export PATH=$PATH:"/c/java11/bin"
-        - export JAVA_HOME="/c/java11"
-        - wget -q https://www-eu.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.zip
-        - /C/Progra~1/7-Zip/7z.exe x apache-maven-3.6.1-bin.zip -o/c/mvn361
-        - export "MAVEN_HOME=/c/mvn361/apache-maven-3.6.1"
-        - export "M2_HOME=/c/mvn361/apache-maven-3.6.1"
-        - export "PATH=$MAVEN_HOME/bin:$PATH"
-      script:
-        - java -version
-        - mvn -version
-        - mvn -B clean package -pl iotdb,grafana,iotdb-cli,example,:kafka-example,:rocketmq-example -am integration-test
+#    - os: windows
+#      language: c
+#      name: win-oraclejdk11
+#      install:
+#        - choco install jdk11 -params 'installdir=c:\\java11'
+#        - export PATH=$PATH:"/c/java11/bin"
+#        - export JAVA_HOME="/c/java11"
+#        - wget -q https://www-eu.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.zip
+#        - /C/Progra~1/7-Zip/7z.exe x apache-maven-3.6.1-bin.zip -o/c/mvn361
+#        - export "MAVEN_HOME=/c/mvn361/apache-maven-3.6.1"
+#        - export "M2_HOME=/c/mvn361/apache-maven-3.6.1"
+#        - export "PATH=$MAVEN_HOME/bin:$PATH"
+#      script:
+#        - java -version
+#        - mvn -version
+#        - mvn -B clean package -pl iotdb,grafana,iotdb-cli,example,:kafka-example,:rocketmq-example -am integration-test
           
     - os: windows
       language: c
@@ -121,15 +121,15 @@ matrix:
       name: linux-oraclejdk8
       dist: trusty
       jdk: oraclejdk8
-    - os: linux
-      name: linux-oraclejdk11
-      dist: trusty
-      jdk: oraclejdk11
-      script:
-        - java -version
-        - mvn -version
-        - mvn -B apache-rat:check
-        - mvn -B clean package -pl iotdb,grafana,iotdb-cli,example,:kafka-example,:rocketmq-example -am integration-test
+#    - os: linux
+#      name: linux-oraclejdk11
+#      dist: trusty
+#      jdk: oraclejdk11
+#      script:
+#        - java -version
+#        - mvn -version
+#        - mvn -B apache-rat:check
+#        - mvn -B clean package -pl iotdb,grafana,iotdb-cli,example,:kafka-example,:rocketmq-example -am integration-test
 
 cache:
   directories:


### PR DESCRIPTION
Oracle JDK 11 has been updated on June 25 while travis hasn't implemented relevant updates yet. So we should remove win-oraclejdk11 and linux-oraclejdk11 from **.travis.yml** temporarily.