### PR TITLE
remove useless fetchSize in some places

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/qp/executor/AbstractQueryProcessExecutor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/qp/executor/AbstractQueryProcessExecutor.java
@@ -43,7 +43,6 @@ import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 
 public abstract class AbstractQueryProcessExecutor implements IQueryProcessExecutor {
 
-  protected ThreadLocal<Integer> fetchSize = new ThreadLocal<>();
   protected IEngineQueryRouter queryRouter = new EngineQueryRouter();
 
   @Override
@@ -87,18 +86,6 @@ public abstract class AbstractQueryProcessExecutor implements IQueryProcessExecu
     return queryRouter.query(queryExpression, context);
   }
 
-  @Override
-  public int getFetchSize() {
-    if (fetchSize.get() == null) {
-      return 100;
-    }
-    return fetchSize.get();
-  }
-
-  @Override
-  public void setFetchSize(int fetchSize) {
-    this.fetchSize.set(fetchSize);
-  }
 
   @Override
   public boolean delete(DeletePlan deletePlan) throws ProcessorException {

--- a/iotdb/src/main/java/org/apache/iotdb/db/qp/executor/IQueryProcessExecutor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/qp/executor/IQueryProcessExecutor.java
@@ -126,8 +126,4 @@ public interface IQueryProcessExecutor {
    */
   List<String> getAllPaths(String originPath) throws MetadataErrorException;
 
-  int getFetchSize();
-
-  void setFetchSize(int fetchSize);
-
 }

--- a/iotdb/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -653,25 +653,28 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       if (!checkLogin()) {
         return getTSFetchResultsResp(TS_StatusCode.ERROR_STATUS, "Not login.");
       }
-      String statement = req.getStatement();
 
+      String statement = req.getStatement();
       if (!queryStatus.get().containsKey(statement)) {
         return getTSFetchResultsResp(TS_StatusCode.ERROR_STATUS, "Has not executed statement");
       }
 
-      int fetchSize = req.getFetch_size();
       QueryDataSet queryDataSet;
       if (!queryRet.get().containsKey(statement)) {
-        queryDataSet = createNewDataSet(statement, fetchSize, req);
+        queryDataSet = createNewDataSet(statement, req);
       } else {
         queryDataSet = queryRet.get().get(statement);
       }
+
+      int fetchSize = req.getFetch_size();
       TSQueryDataSet result = QueryDataSetUtils
           .convertQueryDataSetByFetchSize(queryDataSet, fetchSize);
+
       boolean hasResultSet = !result.getRecords().isEmpty();
       if (!hasResultSet && queryRet.get() != null) {
         queryRet.get().remove(statement);
       }
+
       TSFetchResultsResp resp = getTSFetchResultsResp(TS_StatusCode.SUCCESS_STATUS,
           "FetchResult successfully. Has more result: " + hasResultSet);
       resp.setHasResultSet(hasResultSet);
@@ -683,11 +686,10 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     }
   }
 
-  protected QueryDataSet createNewDataSet(String statement, int fetchSize, TSFetchResultsReq req)
+  protected QueryDataSet createNewDataSet(String statement, TSFetchResultsReq req)
       throws PathErrorException, QueryFilterOptimizationException, StorageEngineException,
       ProcessorException, IOException {
     PhysicalPlan physicalPlan = queryStatus.get().get(statement);
-    processor.getExecutor().setFetchSize(fetchSize);
 
     QueryDataSet queryDataSet;
     QueryContext context = new QueryContext(QueryResourceManager.getInstance().assignJobId());

--- a/iotdb/src/test/java/org/apache/iotdb/db/qp/utils/MemIntQpExecutor.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/qp/utils/MemIntQpExecutor.java
@@ -62,10 +62,6 @@ public class MemIntQpExecutor extends AbstractQueryProcessExecutor {
   private TreeSet<Long> timeStampUnion = new TreeSet<>();
   private Map<String, List<String>> fakeAllPaths;
 
-  public MemIntQpExecutor() {
-    this.fetchSize.set(5);
-  }
-
   public void setFakeAllPaths(Map<String, List<String>> fakeAllPaths) {
     this.fakeAllPaths = fakeAllPaths;
   }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -45,8 +45,6 @@ import org.apache.iotdb.service.rpc.thrift.TSOperationHandle;
 import org.apache.iotdb.service.rpc.thrift.TS_SessionHandle;
 import org.apache.iotdb.service.rpc.thrift.TS_StatusCode;
 import org.apache.thrift.TException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class IoTDBStatement implements Statement {
@@ -54,15 +52,13 @@ public class IoTDBStatement implements Statement {
   private static final String SHOW_TIMESERIES_COMMAND_LOWERCASE = "show timeseries";
   private static final String SHOW_STORAGE_GROUP_COMMAND_LOWERCASE = "show storage group";
   private static final String METHOD_NOT_SUPPORTED_STRING = "Method not supported";
-  private static final Logger logger = LoggerFactory
-          .getLogger(IoTDBStatement.class);
   ZoneId zoneId;
   private ResultSet resultSet = null;
   private IoTDBConnection connection;
-  private int fetchSize = Config.fetchSize;
+  private int fetchSize;
   private int queryTimeout = 10;
-  protected TSIService.Iface client = null;
-  private TS_SessionHandle sessionHandle = null;
+  protected TSIService.Iface client;
+  private TS_SessionHandle sessionHandle;
   private TSOperationHandle operationHandle = null;
   private List<String> batchSQLList;
   private AtomicLong queryId = new AtomicLong(0);
@@ -376,7 +372,8 @@ public class IoTDBStatement implements Statement {
           return executeUpdateSQL(sql);
         } catch (TException e2) {
           throw new SQLException(
-              "Fail to execute update " + sql + "after reconnecting. please check server status", e2);
+              "Fail to execute update " + sql + "after reconnecting. please check server status",
+              e2);
         }
       } else {
         throw new SQLException(


### PR DESCRIPTION
`fetchSize` is a parameter used to control the size of the query dataset that the client fetches from the server at a time. The default value of `fetchSize` is 10000 as set in `Config`.

From the client JDBC side, `fetchSize` is an attribute of `IoTDBStatement` and it is passed to the server as shown by the following two lines when JDBC implements `nextWithoutConstraints` to get the query result:

> TSFetchResultsReq req = new TSFetchResultsReq(sql, fetchSize, queryId);
> TSFetchResultsResp resp = client.fetchResults(req); 

From the server side, `fetchSize` is used in `TSServiceImpl.fetchResults` by the following two lines:
1. > queryDataSet = createNewDataSet(statement, fetchSize, req);

2. > QueryDataSetUtils.convertQueryDataSetByFetchSize(queryDataSet, fetchSize)

However, `fetchSize` is actually useless in the first line. Thus, this pr is aimed at removing this kind of  useless `fetchSize`.