### PR TITLE
[IOTDB-128] Fix links of nav content in documents

### DIFF
--- a/docs/Community-Powered By.md
+++ b/docs/Community-Powered By.md
@@ -21,9 +21,11 @@
 
 <!-- TOC -->
 
-- [Powered By](#powered-by)
-    - [Project and Product names using "IoTDB"](#project-and-product-names-using-iotdb)
-    - [Companies and Organizations](#companies-and-organizations)
+## Outline
+
+- Powered By
+    - Project and Product names using "IoTDB"
+    - Companies and Organizations
 
 <!-- /TOC -->
 ## Powered By

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -21,23 +21,25 @@
 
 <!-- TOC -->
 
-- [Have Questions](#have-questions)
-    - [Mailing Lists](#mailing-lists)
-    - [JIRA issues](#jira-issues)
-- [How to contribute](#how-to-contribute)
-    - [Becoming a committer](#becoming-a-committer)
-        - [Contributing by Helping Other Users](#contributing-by-helping-other-users)
-        - [Contributing by Testing Releases](#contributing-by-testing-releases)
-        - [Contributing by Reviewing Changes](#contributing-by-reviewing-changes)
-        - [Contributing by Documentation Changes](#contributing-by-documentation-changes)
-        - [Contributing Bug Reports](#contributing-bug-reports)
-        - [Contributing Code Changes](#contributing-code-changes)
-            - [Cloning source code](#cloning-source-code)
-            - [JIRA](#jira)
-            - [Pull Request](#pull-request)
-            - [The Review Process](#the-review-process)
-            - [Closing Your Pull Request / JIRA](#closing-your-pull-request--jira)
-            - [Code Style](#code-style)
+## Outline
+
+- Have Questions
+    - Mailing Lists
+    - JIRA issues
+- How to contribute
+    - Becoming a committer
+        - Contributing by Helping Other Users
+        - Contributing by Testing Releases
+        - Contributing by Reviewing Changes
+        - Contributing by Documentation Changes
+        - Contributing Bug Reports
+        - Contributing Code Changes
+            - Cloning source code
+            - JIRA
+            - Pull Request
+            - The Review Process
+            - Closing Your Pull Request / JIRA
+            - Code Style]
 
 <!-- /TOC -->
 

--- a/docs/Documentation-CHN/QuickStart.md
+++ b/docs/Documentation-CHN/QuickStart.md
@@ -19,6 +19,23 @@
 
 -->
 
+<!-- TOC -->
+
+## 概览 
+
+- 快速入门
+ - 安装环境
+    - IoTDB安装
+    - IoTDB试用
+        - 启动IoTDB
+        - 操作IoTDB
+            - 使用Cli/Shell工具
+            - IoTDB的基本操作
+        - 停止IoTDB
+            - 使用stop-server脚本强制停止
+
+<!-- /TOC -->
+
 # 快速入门
 ## 安装环境
 

--- a/docs/Documentation-CHN/UserGuideV0.7.0/7-Tools-Cli.md
+++ b/docs/Documentation-CHN/UserGuideV0.7.0/7-Tools-Cli.md
@@ -19,6 +19,14 @@
 
 -->
 
+<!-- TOC -->
+## 概览
+- Cli / Shell工具
+    - Cli  / Shell运行方式
+    - Cli / Shell运行参数
+
+<!-- /TOC -->
+
 # Cli / Shell工具
 IOTDB为用户提供CLI/Shell工具用于启动客户端和服务端程序。下面介绍每个CLI/Shell工具的运行方式和相关参数。
 > \$IOTDB\_HOME表示IoTDB的安装目录所在路径。

--- a/docs/Documentation-CHN/UserGuideV0.7.0/7-Tools-Grafana.md
+++ b/docs/Documentation-CHN/UserGuideV0.7.0/7-Tools-Grafana.md
@@ -19,6 +19,23 @@
 
 -->
 
+<!-- TOC -->
+## 概览
+
+- IoTDB-Grafana
+    - Grafana的安装与部署
+        - 安装
+        - simple-json-datasource数据源插件安装
+        - 启动Grafana
+    - IoTDB安装
+    - IoTDB-Grafana连接器安装
+        - 启动IoTDB-Grafana
+    - 使用Grafana
+        - 添加IoTDB数据源
+        - 操作Grafana
+
+<!-- /TOC -->
+
 # IoTDB-Grafana
 
 Grafana是开源的指标量监测和可视化工具，可用于展示时序数据和应用程序运行分析。Grafana支持Graphite，InfluxDB等国际主流时序时序数据库作为数据源。在IoTDB项目中，我们开发了Grafana展现IoTDB中时序数据的连接器IoTDB-Grafana，为您提供使用Grafana展示IoTDB数据库中的时序数据的可视化方法。

--- a/docs/Documentation/Frequently asked questions.md
+++ b/docs/Documentation/Frequently asked questions.md
@@ -21,15 +21,17 @@
 
 <!-- TOC -->
 
-- [Frequently Asked Questions](#frequently-asked-questions)
-    - [How can I identify my version of IoTDB?](#how-can-i-identify-my-version-of-iotdb)
-    - [Where can I find IoTDB logs?](#where-can-i-find-iotdb-logs)
-    - [Where can I find IoTDB data files?](#where-can-i-find-iotdb-data-files)
-    - [How do I know how many time series are stored in IoTDB?](#how-do-i-know-how-many-time-series-are-stored-in-iotdb)
-    - [Can I use Hadoop and Spark to read TsFile in IoTDB?](#can-i-use-hadoop-and-spark-to-read-tsfile-in-iotdb)
-    - [How does IoTDB handle duplicate points?](#how-does-iotdb-handle-duplicate-points)
-    - [How can I tell what type of the specific timeseries?](#how-can-i-tell-what-type-of-the-specific-timeseries)
-    - [How can I change IoTDB's CLI time display format?](#how-can-i-change-iotdbs-cli-time-display-format)
+## Outline
+
+- Frequently Asked Questions
+    - How can I identify my version of IoTDB?
+    - Where can I find IoTDB logs?
+    - Where can I find IoTDB data files?
+    - How do I know how many time series are stored in IoTDB?
+    - Can I use Hadoop and Spark to read TsFile in IoTDB?
+    - How does IoTDB handle duplicate points?
+    - How can I tell what type of the specific timeseries?
+    - How can I change IoTDB's CLI time display format?
 
 <!-- /TOC -->
 # Frequently Asked Questions

--- a/docs/Documentation/OtherMaterial-ReleaseNotesV0.7.0.md
+++ b/docs/Documentation/OtherMaterial-ReleaseNotesV0.7.0.md
@@ -21,13 +21,15 @@
 
 <!-- TOC -->
 
-- [v0.7.0 Release Notes](#v070-release-notes)
-    - [Features](#features)
-        - [IoTDB](#iotdb)
-        - [IoTDB-Transfer-Tool](#iotdb-transfer-tool)
-    - [Bugfixes](#bugfixes)
-        - [IoTDB](#iotdb-1)
-    - [System Organization](#system-organization)
+## Outline
+
+- v0.7.0 Release Notes
+    - Features
+        - IoTDB
+        - IoTDB-Transfer-Tool
+    - Bugfixes
+        - IoTDB
+    - System Organization
 
 <!-- /TOC -->
 ### v0.7.0 Release Notes

--- a/docs/Documentation/OtherMaterial-Sample Data.md
+++ b/docs/Documentation/OtherMaterial-Sample Data.md
@@ -21,9 +21,11 @@
 
 <!-- TOC -->
 
-- [Material: Sample Data](#material-sample-data)
-        - [Scenario Description](#scenario-description)
-        - [Sample Data](#sample-data)
+## Outline
+
+- Material: Sample Data
+    - Scenario Description
+    - Sample Data
 
 <!-- /TOC -->
 # Material: Sample Data

--- a/docs/Documentation/QuickStart.md
+++ b/docs/Documentation/QuickStart.md
@@ -21,16 +21,18 @@
 
 <!-- TOC -->
 
-- [Quick Start](#quick-start)
-    - [Prerequisites](#prerequisites)
-    - [Installation](#installation)
-        - [Installation from source code](#installation-from-source-code)
-    - [Configure](#configure)
-    - [Start](#start)
-        - [Start Server](#start-server)
-        - [Start Client](#start-client)
-        - [Have a try](#have-a-try)
-        - [Stop Server](#stop-server)
+## Outline
+
+- Quick Start
+ - Prerequisites
+    - Installation
+        - Installation from source code
+    - Configure
+    - Start
+        - Start Server
+        - Start Client
+        - Have a try
+        - Stop Server
 
 <!-- /TOC -->
 # Quick Start

--- a/docs/Documentation/UserGuideV0.7.0/7-Tools-Cli.md
+++ b/docs/Documentation/UserGuideV0.7.0/7-Tools-Cli.md
@@ -20,10 +20,10 @@
 -->
 
 <!-- TOC -->
-
-- [Cli/shell tool](#clishell-tool)
-    - [Running Cli/Shell](#running-clishell)
-    - [Cli/Shell Parameters](#clishell-parameters)
+## Outline
+- Cli/shell tool
+    - Running Cli/Shell
+    - Cli/Shell Parameters
 
 <!-- /TOC -->
 # Cli/shell tool

--- a/docs/Documentation/UserGuideV0.7.0/7-Tools-Grafana.md
+++ b/docs/Documentation/UserGuideV0.7.0/7-Tools-Grafana.md
@@ -20,18 +20,19 @@
 -->
 
 <!-- TOC -->
+## Outline
 
-- [IoTDB-Grafana](#iotdb-grafana)
-    - [Grafana installation](#grafana-installation)
-        - [Install Grafana](#install-grafana)
-        - [Install data source plugin](#install-data-source-plugin)
-        - [Start Grafana](#start-grafana)
-    - [IoTDB installation](#iotdb-installation)
-    - [IoTDB-Grafana installation](#iotdb-grafana-installation)
-        - [Start IoTDB-Grafana](#start-iotdb-grafana)
-    - [Explore in Grafana](#explore-in-grafana)
-        - [Add data source](#add-data-source)
-        - [Design in dashboard](#design-in-dashboard)
+- IoTDB-Grafana
+    - Grafana installation
+        - Install Grafana
+        - Install data source plugin
+        - Start Grafana
+    - IoTDB installation
+    - IoTDB-Grafana installation
+        - Start IoTDB-Grafana
+    - Explore in Grafana
+        - Add data source
+        - Design in dashboard
 
 <!-- /TOC -->
 # IoTDB-Grafana

--- a/docs/Documentation/UserGuideV0.7.0/7-Tools-Hadoop.md
+++ b/docs/Documentation/UserGuideV0.7.0/7-Tools-Hadoop.md
@@ -20,8 +20,9 @@
 -->
 
 <!-- TOC -->
+## Outline
 
-- [TsFile-Hadoop-Connector User Guide](#tsfile-hadoop-connector-user-guide)
+- TsFile-Hadoop-Connector User Guide
 
 <!-- /TOC -->
 # TsFile-Hadoop-Connector User Guide

--- a/docs/Documentation/UserGuideV0.7.0/7-Tools-Sync.md
+++ b/docs/Documentation/UserGuideV0.7.0/7-Tools-Sync.md
@@ -21,15 +21,17 @@
 
 <!-- TOC -->
 
-- [Introduction](#introduction)
-- [Configuration](#configuration)
-    - [Sync Receiver](#sync-receiver)
-    - [Sync Sender](#sync-sender)
-- [Usage](#usage)
-    - [Start Sync Receiver](#start-sync-receiver)
-    - [Stop Sync Receiver](#stop-sync-receiver)
-    - [Start Sync Sender](#start-sync-sender)
-    - [Stop Sync Sender](#stop-sync-sender)
+## Outline
+
+- Introduction
+- Configuration
+    - Sync Receiver
+    - Sync Sender
+- Usage
+    - Start Sync Receiver
+    - Stop Sync Receiver
+    - Start Sync Sender
+    - Stop Sync Sender
 
 <!-- /TOC -->
 # Introduction

--- a/docs/Documentation/UserGuideV0.7.0/7-Tools-spark.md
+++ b/docs/Documentation/UserGuideV0.7.0/7-Tools-spark.md
@@ -21,32 +21,31 @@
 
 
 <!-- TOC -->
+## Outline
 
-- [TsFile-Spark-Connector User Guide](#tsfile-spark-connector-user-guide)
-	- [1. About TsFile-Spark-Connector](#1-about-tsfile-spark-connector)
-	- [2. System Requirements](#2-system-requirements)
-	- [3. Quick Start](#3-quick-start)
-		- [Local Mode](#local-mode)
-		- [Distributed Mode](#distributed-mode)
-	- [4. Data Type Correspondence](#4-data-type-correspondence)
-	- [5. Schema Inference](#5-schema-inference)
-	- [6. Scala API](#6-scala-api)
-		- [Example 1: read from the local file system](#example-1-read-from-the-local-file-system)
-		- [Example 2: read from the hadoop file system](#example-2-read-from-the-hadoop-file-system)
-		- [Example 3: read from a specific directory](#example-3-read-from-a-specific-directory)
-		- [Example 4: query](#example-4-query)
-		- [Example 5: write](#example-5-write)
-	- [Appendix A: Old Design of Schema Inference](#appendix-a-old-design-of-schema-inference)
-        - [the default way](#the-default-way)
-        - [unfolding delta_object column](#unfolding-delta_object-column)
-	- [Appendix B: Old Note](#appendix-b-old-note)
+- TsFile-Spark-Connector User Guide
+	- 1. About TsFile-Spark-Connector
+	- 2. System Requirements
+	- 3. Quick Start
+		- Local Mode
+		- Distributed Mode
+	- 4. Data Type Correspondence
+	- 5. Schema Inference
+	- 6. Scala API
+		- Example 1: read from the local file system
+		- Example 2: read from the hadoop file system
+		- Example 3: read from a specific directory
+		- Example 4: query
+		- Example 5: write
+	- Appendix A: Old Design of Schema Inference
+        - the default way
+        - unfolding delta_object column
+	- Appendix B: Old Note
 
 <!-- /TOC -->
 
-<a id="tsfile-spark-connector-user-guide"></a>
 # TsFile-Spark-Connector User Guide
 
-<a id="1-about-tsfile-spark-connector"></a>
 ## 1. About TsFile-Spark-Connector
 
 TsFile-Spark-Connector implements the support of Spark for external data sources of Tsfile type. This enables users to read, write and query Tsfile by Spark.
@@ -56,7 +55,6 @@ With this connector, you can
 * load all files in a specific directory, from either the local file system or hdfs, into Spark
 * write data from Spark into TsFile
 
-<a id="2-system-requirements"></a>
 ## 2. System Requirements
 
 |Spark Version | Scala Version | Java Version | TsFile |
@@ -65,9 +63,7 @@ With this connector, you can
 
 > Note: For more information about how to download and use TsFile, please see the following link: https://github.com/apache/incubator-iotdb/tree/master/tsfile.
 
-<a id="3-quick-start"></a>
 ## 3. Quick Start
-<a id="local-mode"></a>
 ### Local Mode
 
 Start Spark with TsFile-Spark-Connector in local mode: 
@@ -83,7 +79,6 @@ Note:
 * See https://github.com/apache/incubator-iotdb/tree/master/tsfile for how to get TsFile.
 
 
-<a id="distributed-mode"></a>
 ### Distributed Mode
 
 Start Spark with TsFile-Spark-Connector in distributed mode (That is, the spark cluster is connected by spark-shell): 
@@ -98,7 +93,6 @@ Note:
 * Multiple jar packages are separated by commas without any spaces.
 * See https://github.com/apache/incubator-iotdb/tree/master/tsfile for how to get TsFile.
 
-<a id="4-data-type-correspondence"></a>
 ## 4. Data Type Correspondence
 
 | TsFile data type | SparkSQL data type|
@@ -110,7 +104,6 @@ Note:
 | DOUBLE      		   | DoubleType     |
 | TEXT      				| StringType     |
 
-<a id="5-schema-inference"></a>
 ## 5. Schema Inference
 
 The way to display TsFile is dependent on the schema. Take the following TsFile structure as an example: There are three Measurements in the TsFile schema: status, temperature, and hardware. The basic information of these three measurements is as follows:
@@ -151,12 +144,10 @@ The corresponding SparkSQL table is as follows:
 |    6 | null                          | null                     | ccc                        | null                          | null                     | null                       |
 
 
-<a id="6-scala-api"></a>
 ## 6. Scala API
 
 NOTE: Remember to assign necessary read and write permissions in advance.
 
-<a id="example-1-read-from-the-local-file-system"></a>
 ### Example 1: read from the local file system
 
 ```scala
@@ -165,7 +156,6 @@ val df = spark.read.tsfile("test.tsfile")
 df.show
 ```
 
-<a id="example-2-read-from-the-hadoop-file-system"></a>
 ### Example 2: read from the hadoop file system
 
 ```scala
@@ -174,7 +164,6 @@ val df = spark.read.tsfile("hdfs://localhost:9000/test.tsfile")
 df.show
 ```
 
-<a id="example-3-read-from-a-specific-directory"></a>
 ### Example 3: read from a specific directory
 
 ```scala
@@ -187,7 +176,6 @@ Note 1: Global time ordering of all TsFiles in a directory is not supported now.
 
 Note 2: Measurements of the same name should have the same schema.
 
-<a id="example-4-query"></a>
 ### Example 4: query
 
 ```scala
@@ -206,7 +194,6 @@ val newDf = spark.sql("select count(*) from tsfile_table")
 newDf.show
 ```
 
-<a id="example-5-write"></a>
 ### Example 5: write
 
 ```scala
@@ -221,7 +208,6 @@ newDf.show
 ```
 
 
-<a id="appendix-a-old-design-of-schema-inference"></a>
 ## Appendix A: Old Design of Schema Inference
 
 The way to display TsFile is related to TsFile Schema. Take the following TsFile structure as an example: There are three Measurements in the Schema of TsFile: status, temperature, and hardware. The basic info of these three Measurements is as follows:
@@ -253,7 +239,6 @@ The existing data in the file is as follows:
 
 There are two ways to show it out:
 
-<a id="the-default-way"></a>
 #### the default way
 
 Two columns will be created to store the full path of the device: time(LongType) and delta_object(StringType).
@@ -289,7 +274,6 @@ Next, a column is created for each Measurement to store the specific data. The S
 </center>
 
 
-<a id="unfolding-delta_object-column"></a>
 #### unfolding delta_object column
 
 Expand the device column by "." into multiple columns, ignoring the root directory "root". Convenient for richer aggregation operations. If the user wants to use this display way, the parameter "delta\_object\_name" needs to be set in the table creation statement (refer to Example 5 in Section 5.1 of this manual), as in this example, parameter "delta\_object\_name" is set to "root.device.turbine". The number of path layers needs to be one-to-one. At this point, one column is created for each layer of the device path except the "root" layer. The column name is the name in the parameter and the value is the name of the corresponding layer of the device. Next, one column will be created for each Measurement to store the specific data.
@@ -326,6 +310,5 @@ TsFile-Spark-Connector can display one or more TsFiles as a table in SparkSQL By
 
 The writing process is to write a DataFrame as one or more TsFiles. By default, two columns need to be included: time and delta_object. The rest of the columns are used as Measurement. If user wants to write the second table structure back to TsFile, user can set the "delta\_object\_name" parameter(refer to Section 5.1 of Section 5.1 of this manual).
 
-<a id="appendix-b-old-note"></a>
 ## Appendix B: Old Note
 NOTE: Check the jar packages in the root directory  of your Spark and replace libthrift-0.9.2.jar and libfb303-0.9.2.jar with libthrift-0.9.1.jar and libfb303-0.9.1.jar respectively.


### PR DESCRIPTION
Fix links of nav content in documents by turning nav content into "Overview" part to fix the bug proposed in [issue IOTDB-128](https://issues.apache.org/jira/browse/IOTDB-128).