### PR TITLE
[IOTDB-129]Fix statistic bug when restoring incomplete tsfile

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -475,6 +475,10 @@ public class TsFileProcessor {
     return workMemTable.memSize();
   }
 
+  RestorableTsFileIOWriter getWriter() {
+    return writer;
+  }
+
   String getStorageGroupName() {
     return storageGroupName;
   }

--- a/iotdb/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -523,7 +523,7 @@ public class TsFileProcessor {
           deviceId + IoTDBConstant.PATH_SEPARATOR + measurementId);
 
       List<ChunkMetaData> chunkMetaDataList = writer
-          .getVisibleMetadatas(deviceId, measurementId, dataType);
+          .getVisibleMetadataList(deviceId, measurementId, dataType);
       QueryUtils.modifyChunkMetaData(chunkMetaDataList,
           modifications);
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/engine/memtable/MemTableFlushTaskTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/engine/memtable/MemTableFlushTaskTest.java
@@ -62,15 +62,15 @@ public class MemTableFlushTaskTest {
         MemTableTestUtils.dataType0);
     MemTableFlushTask memTableFlushTask = new MemTableFlushTask(memTable, MemTableTestUtils.getFileSchema(), writer, storageGroup);
     assertTrue(writer
-        .getVisibleMetadatas(MemTableTestUtils.deviceId0, MemTableTestUtils.measurementId0,
+        .getVisibleMetadataList(MemTableTestUtils.deviceId0, MemTableTestUtils.measurementId0,
             MemTableTestUtils.dataType0).isEmpty());
     memTableFlushTask.syncFlushMemTable();
     writer.makeMetadataVisible();
     assertEquals(1, writer
-        .getVisibleMetadatas(MemTableTestUtils.deviceId0, MemTableTestUtils.measurementId0,
+        .getVisibleMetadataList(MemTableTestUtils.deviceId0, MemTableTestUtils.measurementId0,
             MemTableTestUtils.dataType0).size());
     ChunkMetaData chunkMetaData = writer
-        .getVisibleMetadatas(MemTableTestUtils.deviceId0, MemTableTestUtils.measurementId0,
+        .getVisibleMetadataList(MemTableTestUtils.deviceId0, MemTableTestUtils.measurementId0,
             MemTableTestUtils.dataType0).get(0);
     assertEquals(MemTableTestUtils.measurementId0, chunkMetaData.getMeasurementUid());
     assertEquals(startTime, chunkMetaData.getStartTime());

--- a/iotdb/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
@@ -107,7 +107,7 @@ public class TsFileProcessorTest {
       assertEquals(num, timeValuePair.getValue().getInt());
     }
 
-    // flush asynchronously
+    // flush synchronously
     processor.syncFlush();
 
     pair = processor.query(deviceId, measurementId, dataType, props, context);
@@ -154,7 +154,7 @@ public class TsFileProcessorTest {
       assertEquals(num, timeValuePair.getValue().getInt());
     }
 
-    // flush asynchronously
+    // flush synchronously
     processor.syncFlush();
 
     pair = processor.query(deviceId, measurementId, dataType, props, context);
@@ -166,15 +166,15 @@ public class TsFileProcessorTest {
     assertEquals(dataType, right.get(0).getTsDataType());
 
     RestorableTsFileIOWriter tsFileIOWriter = processor.getWriter();
-    List<ChunkGroupMetaData> chunkGroupMetaDatas = tsFileIOWriter.getChunkGroupMetaDatas();
-    RestorableTsFileIOWriter tsFileIOWriterRestore = new RestorableTsFileIOWriter(
+    List<ChunkGroupMetaData> chunkGroupMetaDataList = tsFileIOWriter.getChunkGroupMetaDatas();
+    RestorableTsFileIOWriter restorableTsFileIOWriter = new RestorableTsFileIOWriter(
         new File(filePath));
-    List<ChunkGroupMetaData> chunkGroupMetaDatasRestore = tsFileIOWriterRestore
+    List<ChunkGroupMetaData> restoredChunkGroupMetaDataList = restorableTsFileIOWriter
         .getChunkGroupMetaDatas();
-    assertEquals(chunkGroupMetaDatas.size(), chunkGroupMetaDatasRestore.size());
-    for (int i = 0; i < chunkGroupMetaDatas.size(); i++) {
-      ChunkGroupMetaData chunkGroupMetaData = chunkGroupMetaDatas.get(i);
-      ChunkGroupMetaData chunkGroupMetaDataRestore = chunkGroupMetaDatasRestore.get(i);
+    assertEquals(chunkGroupMetaDataList.size(), restoredChunkGroupMetaDataList.size());
+    for (int i = 0; i < chunkGroupMetaDataList.size(); i++) {
+      ChunkGroupMetaData chunkGroupMetaData = chunkGroupMetaDataList.get(i);
+      ChunkGroupMetaData chunkGroupMetaDataRestore = restoredChunkGroupMetaDataList.get(i);
       for (int j = 0; j < chunkGroupMetaData.getChunkMetaDataList().size(); j++) {
         ChunkMetaData chunkMetaData = chunkGroupMetaData.getChunkMetaDataList().get(j);
         ChunkMetaData chunkMetaDataRestore = chunkGroupMetaDataRestore.getChunkMetaDataList()
@@ -269,7 +269,7 @@ public class TsFileProcessorTest {
       assertEquals(num, timeValuePair.getValue().getInt());
     }
 
-    // flush asynchronously
+    // close synchronously
     processor.syncClose();
 
     assertTrue(processor.getTsFileResource().isClosed());

--- a/iotdb/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
@@ -182,7 +182,7 @@ public class TsFileProcessorTest {
         assertEquals(chunkMetaData, chunkMetaDataRestore);
       }
     }
-
+    restorableTsFileIOWriter.close();
     processor.syncClose();
   }
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessorTest.java
@@ -39,11 +39,13 @@ import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.db.utils.FileSchemaUtils;
 import org.apache.iotdb.db.utils.TimeValuePair;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.metadata.ChunkGroupMetaData;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetaData;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.record.TSRecord;
 import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint;
+import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -75,8 +77,9 @@ public class TsFileProcessorTest {
   public void testWriteAndFlush()
       throws WriteProcessException, IOException, TsFileProcessorException {
     processor = new TsFileProcessor(storageGroup, new File(filePath),
-        FileSchemaUtils.constructFileSchema(deviceId), SysTimeVersionController.INSTANCE, x->{},
-        ()-> true, true);
+        FileSchemaUtils.constructFileSchema(deviceId), SysTimeVersionController.INSTANCE, x -> {
+    },
+        () -> true, true);
 
     Pair<ReadOnlyMemChunk, List<ChunkMetaData>> pair = processor
         .query(deviceId, measurementId, dataType, props, context);
@@ -117,13 +120,80 @@ public class TsFileProcessorTest {
     processor.syncClose();
   }
 
+  @Test
+  public void testWriteAndRestoreMetadata()
+      throws IOException {
+    processor = new TsFileProcessor(storageGroup, new File(filePath),
+        FileSchemaUtils.constructFileSchema(deviceId), SysTimeVersionController.INSTANCE, x -> {
+    },
+        () -> true, true);
+
+    Pair<ReadOnlyMemChunk, List<ChunkMetaData>> pair = processor
+        .query(deviceId, measurementId, dataType, props, context);
+    ReadOnlyMemChunk left = pair.left;
+    List<ChunkMetaData> right = pair.right;
+    assertTrue(left.isEmpty());
+    assertEquals(0, right.size());
+
+    for (int i = 1; i <= 100; i++) {
+      TSRecord record = new TSRecord(i, deviceId);
+      record.addTuple(DataPoint.getDataPoint(dataType, measurementId, String.valueOf(i)));
+      processor.insert(new InsertPlan(record));
+    }
+
+    // query data in memory
+    pair = processor.query(deviceId, measurementId, dataType, props, context);
+    left = pair.left;
+    assertFalse(left.isEmpty());
+    int num = 1;
+    Iterator<TimeValuePair> iterator = left.getIterator();
+    for (; num <= 100; num++) {
+      iterator.hasNext();
+      TimeValuePair timeValuePair = iterator.next();
+      assertEquals(num, timeValuePair.getTimestamp());
+      assertEquals(num, timeValuePair.getValue().getInt());
+    }
+
+    // flush asynchronously
+    processor.syncFlush();
+
+    pair = processor.query(deviceId, measurementId, dataType, props, context);
+    left = pair.left;
+    right = pair.right;
+    assertTrue(left.isEmpty());
+    assertEquals(1, right.size());
+    assertEquals(measurementId, right.get(0).getMeasurementUid());
+    assertEquals(dataType, right.get(0).getTsDataType());
+
+    RestorableTsFileIOWriter tsFileIOWriter = processor.getWriter();
+    List<ChunkGroupMetaData> chunkGroupMetaDatas = tsFileIOWriter.getChunkGroupMetaDatas();
+    RestorableTsFileIOWriter tsFileIOWriterRestore = new RestorableTsFileIOWriter(
+        new File(filePath));
+    List<ChunkGroupMetaData> chunkGroupMetaDatasRestore = tsFileIOWriterRestore
+        .getChunkGroupMetaDatas();
+    assertEquals(chunkGroupMetaDatas.size(), chunkGroupMetaDatasRestore.size());
+    for (int i = 0; i < chunkGroupMetaDatas.size(); i++) {
+      ChunkGroupMetaData chunkGroupMetaData = chunkGroupMetaDatas.get(i);
+      ChunkGroupMetaData chunkGroupMetaDataRestore = chunkGroupMetaDatasRestore.get(i);
+      for (int j = 0; j < chunkGroupMetaData.getChunkMetaDataList().size(); j++) {
+        ChunkMetaData chunkMetaData = chunkGroupMetaData.getChunkMetaDataList().get(j);
+        ChunkMetaData chunkMetaDataRestore = chunkGroupMetaDataRestore.getChunkMetaDataList()
+            .get(j);
+        assertEquals(chunkMetaData, chunkMetaDataRestore);
+      }
+    }
+
+    processor.syncClose();
+  }
+
 
   @Test
   public void testMultiFlush()
       throws WriteProcessException, IOException, TsFileProcessorException {
     processor = new TsFileProcessor(storageGroup, new File(filePath),
-        FileSchemaUtils.constructFileSchema(deviceId), SysTimeVersionController.INSTANCE, x->{},
-        ()->true, true);
+        FileSchemaUtils.constructFileSchema(deviceId), SysTimeVersionController.INSTANCE, x -> {
+    },
+        () -> true, true);
 
     Pair<ReadOnlyMemChunk, List<ChunkMetaData>> pair = processor
         .query(deviceId, measurementId, dataType, props, context);
@@ -171,7 +241,7 @@ public class TsFileProcessorTest {
               throw new TsFileProcessorException(e);
             }
           }
-        }, ()->true, true);
+        }, () -> true, true);
 
     Pair<ReadOnlyMemChunk, List<ChunkMetaData>> pair = processor
         .query(deviceId, measurementId, dataType, props, context);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkMetaData.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkMetaData.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
@@ -47,9 +48,8 @@ public class ChunkMetaData {
   private TSDataType tsDataType;
 
   /**
-   * version is used to define the order of operations(insertion, deletion, update).
-   * version is set according to its belonging ChunkGroup only when being queried, so it is not
-   * persisted.
+   * version is used to define the order of operations(insertion, deletion, update). version is set
+   * according to its belonging ChunkGroup only when being queried, so it is not persisted.
    */
   private long version;
 
@@ -263,5 +263,25 @@ public class ChunkMetaData {
 
   public void setDeletedAt(long deletedAt) {
     this.deletedAt = deletedAt;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ChunkMetaData that = (ChunkMetaData) o;
+    return offsetOfChunkHeader == that.offsetOfChunkHeader &&
+        numOfPoints == that.numOfPoints &&
+        startTime == that.startTime &&
+        endTime == that.endTime &&
+        version == that.version &&
+        deletedAt == that.deletedAt &&
+        Objects.equals(measurementUid, that.measurementUid) &&
+        tsDataType == that.tsDataType &&
+        Objects.equals(valuesStatistics, that.valuesStatistics);
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/TsDigest.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/TsDigest.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 /**
@@ -217,5 +218,28 @@ public class TsDigest {
       reCalculateSerializedSize();
     }
     return serializedSize;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TsDigest digest = (TsDigest) o;
+    if (serializedSize != digest.serializedSize || sizeOfList != digest.sizeOfList
+        || statistics.size() != digest.statistics.size()) {
+      return false;
+    }
+    for (Entry<String, ByteBuffer> entry : statistics.entrySet()) {
+      String key = entry.getKey();
+      ByteBuffer value = entry.getValue();
+      if (!digest.statistics.containsKey(key) || !value.equals(digest.statistics.get(key))) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/statistics/Statistics.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/statistics/Statistics.java
@@ -161,6 +161,10 @@ public abstract class Statistics<T> {
     return isEmpty;
   }
 
+  public void setEmpty(boolean empty) {
+    isEmpty = empty;
+  }
+
   public void updateStats(boolean value) {
     throw new UnsupportedOperationException();
   }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/statistics/Statistics.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/statistics/Statistics.java
@@ -78,18 +78,22 @@ public abstract class Statistics<T> {
       throws IOException {
     Statistics statistics = getStatsByType(dataType);
     statistics.fill(inputStream);
+    statistics.isEmpty = false;
     return statistics;
   }
 
   public static Statistics deserialize(ByteBuffer buffer, TSDataType dataType) throws IOException {
     Statistics statistics = getStatsByType(dataType);
     statistics.fill(buffer);
+    statistics.isEmpty = false;
     return statistics;
   }
 
-  public static Statistics deserialize(TsFileInput input, long offset, TSDataType dataType) throws IOException {
+  public static Statistics deserialize(TsFileInput input, long offset, TSDataType dataType)
+      throws IOException {
     Statistics statistics = getStatsByType(dataType);
     statistics.fill(input, offset);
+    statistics.isEmpty = false;
     return statistics;
   }
 
@@ -170,8 +174,8 @@ public abstract class Statistics<T> {
   }
 
   /**
-   * This method with two parameters is only used by {@code unsequence} which updates/inserts/deletes
-   * timestamp.
+   * This method with two parameters is only used by {@code unsequence} which
+   * updates/inserts/deletes timestamp.
    *
    * @param min min timestamp
    * @param max max timestamp

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -27,10 +27,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.constant.StatisticConstant;
 import org.apache.iotdb.tsfile.compress.IUnCompressor;
 import org.apache.iotdb.tsfile.file.MetaMarker;
 import org.apache.iotdb.tsfile.file.footer.ChunkGroupFooter;
@@ -40,9 +42,11 @@ import org.apache.iotdb.tsfile.file.metadata.ChunkGroupMetaData;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetaData;
 import org.apache.iotdb.tsfile.file.metadata.TsDeviceMetadata;
 import org.apache.iotdb.tsfile.file.metadata.TsDeviceMetadataIndex;
+import org.apache.iotdb.tsfile.file.metadata.TsDigest;
 import org.apache.iotdb.tsfile.file.metadata.TsFileMetaData;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.read.common.Chunk;
 import org.apache.iotdb.tsfile.read.reader.DefaultTsFileInput;
 import org.apache.iotdb.tsfile.read.reader.TsFileInput;
@@ -538,28 +542,41 @@ public class TsFileSequenceReader implements AutoCloseable {
                       header.getEncodingType(), header.getCompressionType()));
             }
             dataType = header.getDataType();
+            Statistics<?> chunkStatistics = Statistics.getStatsByType(dataType);
             if (header.getNumOfPages() > 0) {
               PageHeader pageHeader = this.readPageHeader(header.getDataType());
               numOfPoints += pageHeader.getNumOfValues();
               startTimeOfChunk = pageHeader.getMinTimestamp();
               endTimeOfChunk = pageHeader.getMaxTimestamp();
+              chunkStatistics.mergeStatistics(pageHeader.getStatistics());
               this.skipPageData(pageHeader);
             }
             for (int j = 1; j < header.getNumOfPages() - 1; j++) {
               //a new Page
               PageHeader pageHeader = this.readPageHeader(header.getDataType());
               numOfPoints += pageHeader.getNumOfValues();
+              chunkStatistics.mergeStatistics(pageHeader.getStatistics());
               this.skipPageData(pageHeader);
             }
             if (header.getNumOfPages() > 1) {
               PageHeader pageHeader = this.readPageHeader(header.getDataType());
               numOfPoints += pageHeader.getNumOfValues();
               endTimeOfChunk = pageHeader.getMaxTimestamp();
+              chunkStatistics.mergeStatistics(pageHeader.getStatistics());
               this.skipPageData(pageHeader);
             }
             currentChunk = new ChunkMetaData(measurementID, dataType, fileOffsetOfChunk,
                 startTimeOfChunk, endTimeOfChunk);
             currentChunk.setNumOfPoints(numOfPoints);
+            Map<String, ByteBuffer> statisticsMap = new HashMap<>();
+            statisticsMap.put(StatisticConstant.MAX_VALUE, ByteBuffer.wrap(chunkStatistics.getMaxBytes()));
+            statisticsMap.put(StatisticConstant.MIN_VALUE, ByteBuffer.wrap(chunkStatistics.getMinBytes()));
+            statisticsMap.put(StatisticConstant.FIRST, ByteBuffer.wrap(chunkStatistics.getFirstBytes()));
+            statisticsMap.put(StatisticConstant.SUM, ByteBuffer.wrap(chunkStatistics.getSumBytes()));
+            statisticsMap.put(StatisticConstant.LAST, ByteBuffer.wrap(chunkStatistics.getLastBytes()));
+            TsDigest tsDigest = new TsDigest();
+            tsDigest.setStatistics(statisticsMap);
+            currentChunk.setDigest(tsDigest);
             chunks.add(currentChunk);
             numOfPoints = 0;
             break;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/RestorableTsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/RestorableTsFileIOWriter.java
@@ -117,19 +117,19 @@ public class RestorableTsFileIOWriter extends TsFileIOWriter {
    * @param dataType the value type
    * @return chunks' metadata
    */
-  public List<ChunkMetaData> getVisibleMetadatas(String deviceId, String measurementId, TSDataType dataType) {
-    List<ChunkMetaData> chunkMetaDatas = new ArrayList<>();
+  public List<ChunkMetaData> getVisibleMetadataList(String deviceId, String measurementId, TSDataType dataType) {
+    List<ChunkMetaData> chunkMetaDataList = new ArrayList<>();
     if (metadatas.containsKey(deviceId) && metadatas.get(deviceId).containsKey(measurementId)) {
       for (ChunkMetaData chunkMetaData : metadatas.get(deviceId).get(measurementId)) {
         // filter: if a device'sensor is defined as float type, and data has been persistent.
         // Then someone deletes the timeseries and recreate it with Int type. We have to ignore
         // all the stale data.
         if (dataType.equals(chunkMetaData.getTsDataType())) {
-          chunkMetaDatas.add(chunkMetaData);
+          chunkMetaDataList.add(chunkMetaData);
         }
       }
     }
-    return chunkMetaDatas;
+    return chunkMetaDataList;
   }
 
 
@@ -139,10 +139,10 @@ public class RestorableTsFileIOWriter extends TsFileIOWriter {
    */
   public void makeMetadataVisible() {
 
-    List<ChunkGroupMetaData> newlyFlushedMetadatas = getAppendedRowGroupMetadata();
+    List<ChunkGroupMetaData> newlyFlushedMetadataList = getAppendedRowGroupMetadata();
 
-    if (!newlyFlushedMetadatas.isEmpty()) {
-      for (ChunkGroupMetaData rowGroupMetaData : newlyFlushedMetadatas) {
+    if (!newlyFlushedMetadataList.isEmpty()) {
+      for (ChunkGroupMetaData rowGroupMetaData : newlyFlushedMetadataList) {
         String deviceId = rowGroupMetaData.getDeviceID();
         for (ChunkMetaData chunkMetaData : rowGroupMetaData.getChunkMetaDataList()) {
           String measurementId = chunkMetaData.getMeasurementUid();
@@ -167,7 +167,7 @@ public class RestorableTsFileIOWriter extends TsFileIOWriter {
    * get all the chunkGroups' metadata which are appended after the last calling of this method, or
    * after the class instance is initialized if this is the first time to call the method.
    *
-   * @return a list of chunkgroup metadata
+   * @return a list of ChunkGroupMetadata
    */
   private List<ChunkGroupMetaData> getAppendedRowGroupMetadata() {
     List<ChunkGroupMetaData> append = new ArrayList<>();

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/file/metadata/utils/TestHelper.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/file/metadata/utils/TestHelper.java
@@ -142,10 +142,11 @@ public class TestHelper {
   }
 
   public static PageHeader createSimplePageHeader() {
+    Statistics<?> statistics = Statistics.getStatsByType(PageHeaderTest.DATA_TYPE);
+    statistics.setEmpty(false);
     PageHeader header = new PageHeader(PageHeaderTest.UNCOMPRESSED_SIZE,
         PageHeaderTest.COMPRESSED_SIZE, PageHeaderTest.NUM_OF_VALUES,
-        Statistics.getStatsByType(PageHeaderTest.DATA_TYPE),
-        PageHeaderTest.MAX_TIMESTAMO, PageHeaderTest.MIN_TIMESTAMO);
+        statistics, PageHeaderTest.MAX_TIMESTAMO, PageHeaderTest.MIN_TIMESTAMO);
     return header;
   }
 }


### PR DESCRIPTION
In IoTDB system, if a file is found incomplete when restoring, it will be attempted to repair and rebuild metadata information, but the rebuilt metadata information does not contain statistical information, which leads to the error of null pointer when querying such files.

corresponding Jira link:https://issues.apache.org/jira/browse/IOTDB-129

![20_28_13__07_09_2019](https://user-images.githubusercontent.com/26211279/60948066-ac841c00-a324-11e9-8afd-fe98aa7ad37c.jpg)
