### PR TITLE
[IOTDB-133] Fix mistaken links in documents

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -39,7 +39,7 @@
             - Pull Request
             - The Review Process
             - Closing Your Pull Request / JIRA
-            - Code Style]
+            - Code Style
 
 <!-- /TOC -->
 
@@ -48,8 +48,7 @@
 ## Mailing Lists
 
 It is recommended to use our mailing lists to ask for help, report issues or contribute to the project.
-
-* dev@iotdb.apache.org is for anyone who want to contribute codes to IoTDB or have usage questions for IoTDB.
+dev@iotdb.apache.org is for anyone who want to contribute codes to IoTDB or have usage questions for IoTDB.
 
 Some quick tips when using email:
 * For error logs or long code examples, please use GitHub gist and include only few lines of the pertinent code / log within the email.

--- a/docs/Documentation-CHN/UserGuideV0.7.0/4-Deployment and Management/2-Configuration.md
+++ b/docs/Documentation-CHN/UserGuideV0.7.0/4-Deployment and Management/2-Configuration.md
@@ -25,19 +25,19 @@
 
 为方便IoTDB Server的配置与管理，IoTDB Server为用户提供三种配置项，使得用户可以在启动服务器或服务器运行时对其进行配置。
 
-三种配置项的配置文件均位于IoTDB安装目录：$IOTDB_HOME/conf文件夹下,其中涉及server配置的共有3个文件，分别为：iotdb-env.sh, tsfile-format.properties, iotdb-engine.properties。用户可以通过更改其中的配置项对系统运行的相关配置项进行配置。
+三种配置项的配置文件均位于IoTDB安装目录：`$IOTDB_HOME/conf`文件夹下,其中涉及server配置的共有3个文件，分别为：`iotdb-env.sh`, `tsfile-format.properties`, `iotdb-engine.properties`。用户可以通过更改其中的配置项对系统运行的相关配置项进行配置。
 
 配置文件的说明如下：
 
-* iotdb-env.sh：环境配置项的默认配置文件。用户可以在文件中配置JAVA-JVM的相关系统配置项。
+* `iotdb-env.sh`：环境配置项的默认配置文件。用户可以在文件中配置JAVA-JVM的相关系统配置项。
 
-* tsfile-format.properties：IoTDB文件层系统配置项的默认配置文件。用户可以在文件中配置IoTDB存储时TsFile文件的相关信息，如每次将内存中的数据写入到磁盘时的数据大小(group_size_in_byte)，内存中每个列打一次包的大小(page_size_in_byte)等。
+* `tsfile-format.properties`：IoTDB文件层系统配置项的默认配置文件。用户可以在文件中配置IoTDB存储时TsFile文件的相关信息，如每次将内存中的数据写入到磁盘时的数据大小(`group_size_in_byte`)，内存中每个列打一次包的大小(`page_size_in_byte`)等。
 
-* iotdb-engine.properties：IoTDB引擎层系统配置项的默认配置文件。用户可以在文件中配置IoTDB引擎运行时的相关参数，如JDBC服务监听端口(rpc_port)、overflow数据文件存储目录(overflow_data_dir)等。
+* `iotdb-engine.properties`：IoTDB引擎层系统配置项的默认配置文件。用户可以在文件中配置IoTDB引擎运行时的相关参数，如JDBC服务监听端口(`rpc_port`)、overflow数据文件存储目录(`overflow_data_dir`)等。
 
 ### 环境配置项
 
-环境配置项主要用于对IoTDB Server运行的Java环境相关参数进行配置，如JVM相关配置。IoTDB Server启动时，此部分配置会被传给JVM。用户可以通过查看 iotdb-env.sh(或iotdb-env.bat)文件查看环境配置项内容。详细配置项说明如下：
+环境配置项主要用于对IoTDB Server运行的Java环境相关参数进行配置，如JVM相关配置。IoTDB Server启动时，此部分配置会被传给JVM。用户可以通过查看 `iotdb-env.sh`(或`iotdb-env.bat`)文件查看环境配置项内容。详细配置项说明如下：
 
 * JMX\_LOCAL
 
@@ -78,7 +78,7 @@
 
 ### 系统配置项
 
-系统配置项是IoTDB Server运行的核心配置，它主要用于设置IoTDB Server文件层和引擎层的参数，便于用户根据自身需求调整Server的相关配置，以达到较好的性能表现。系统配置项可分为两大模块：文件层配置项和引擎层配置项。用户可以通过查看tsfile-format.properties, iotdb-engine.properties,文件查看和修改两种配置项的内容。在0.7.0版本中字符串类型的配置项大小写敏感。
+系统配置项是IoTDB Server运行的核心配置，它主要用于设置IoTDB Server文件层和引擎层的参数，便于用户根据自身需求调整Server的相关配置，以达到较好的性能表现。系统配置项可分为两大模块：文件层配置项和引擎层配置项。用户可以通过查看`tsfile-format.properties`, `iotdb-engine.properties`,文件查看和修改两种配置项的内容。在0.7.0版本中字符串类型的配置项大小写敏感。
 
 #### 文件层配置
 

--- a/docs/Documentation/UserGuideV0.7.0/4-Deployment and Management/2-Configuration.md
+++ b/docs/Documentation/UserGuideV0.7.0/4-Deployment and Management/2-Configuration.md
@@ -28,17 +28,17 @@ Before starting to use IoTDB, you need to config the configuration files first. 
 
 In total, we provide users three kinds of configurations module: 
 
-* environment configuration file (iotdb-env.bat, iotdb-env.sh). The default configuration file for the environment configuration item. Users can configure the relevant system configuration items of JAVA-JVM in the file.
-* system configuration file (tsfile-format.properties, iotdb-engine.properties). 
-	* tsfile-format.properties: The default configuration file for the IoTDB file layer configuration item. Users can configure the information about the TsFile, such as the data size written to the disk per time(group\_size\_in_byte). 
-	* iotdb-engine.properties: The default configuration file for the IoTDB engine layer configuration item. Users can configure the IoTDB engine related parameters in the file, such as JDBC service listening port (rpc\_port), unsequence data storage directory (unsequence\_data\_dir), etc.
-* log configuration file (logback.xml)
+* environment configuration file (`iotdb-env.bat`, `iotdb-env.sh`). The default configuration file for the environment configuration item. Users can configure the relevant system configuration items of JAVA-JVM in the file.
+* system configuration file (`tsfile-format.properties`, `iotdb-engine.properties`). 
+	* `tsfile-format.properties`: The default configuration file for the IoTDB file layer configuration item. Users can configure the information about the TsFile, such as the data size written to the disk per time(`group_size_in_byte`). 
+	* `iotdb-engine.properties`: The default configuration file for the IoTDB engine layer configuration item. Users can configure the IoTDB engine related parameters in the file, such as JDBC service listening port (`rpc_port`), unsequence data storage directory (`unsequence_data_dir`), etc.
+* log configuration file (`logback.xml`)
 
-The configuration files of the three configuration items are located in the IoTDB installation directory: $IOTDB_HOME/conf folder.
+The configuration files of the three configuration items are located in the IoTDB installation directory: `$IOTDB_HOME/conf` folder.
 
 ### IoTDB Environment Configuration File
 
-The environment configuration file is mainly used to configure the Java environment related parameters when IoTDB Server is running, such as JVM related configuration. This part of the configuration is passed to the JVM when the IoTDB Server starts. Users can view the contents of the environment configuration file by viewing the iotdb-env.sh (or iotdb-env.bat) file.
+The environment configuration file is mainly used to configure the Java environment related parameters when IoTDB Server is running, such as JVM related configuration. This part of the configuration is passed to the JVM when the IoTDB Server starts. Users can view the contents of the environment configuration file by viewing the `iotdb-env.sh` (or `iotdb-env.bat`) file.
 
 The detail of each variables are as follows:
 


### PR DESCRIPTION
Fix mistaken links in documents proposed in issue [IOTDB-133](https://issues.apache.org/jira/browse/IOTDB-133):

-  `iotdb-env.sh` and other configuration files shouldn't be shown as links in [Chapter 4 - Configuration page](https://iotdb.apache.org/#/Documents/latest/chap4/sec2).
- Clicking`dev@iotdb.apache.orgIn` should be jumped to email client correctly in [development page](https://iotdb.apache.org/#/Development).

