### PR TITLE
[Fix issue 124] Add pathExist() check after obtaining lock when trying to add path to me…

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -289,7 +289,7 @@ public class MManager {
     boolean isNewMeasurement = true;
     // Thread safety: just one thread can access/modify the schemaMap
     synchronized (schemaMap) {
-      // Need to check the path again to avoid duplicated inserting by multi concurrent thread
+      // Need to check the path again to avoid duplicated inserting by multi concurrent threads
       if (pathExist(path.getFullPath())) {
         throw new MetadataErrorException(
             String.format("Timeseries %s already exist", path.getFullPath()));

--- a/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -289,6 +289,11 @@ public class MManager {
     boolean isNewMeasurement = true;
     // Thread safety: just one thread can access/modify the schemaMap
     synchronized (schemaMap) {
+      // Need to check the path again to avoid duplicated inserting by multi concurrent thread
+      if (pathExist(path.getFullPath())) {
+        throw new MetadataErrorException(
+            String.format("Timeseries %s already exist", path.getFullPath()));
+      }
       if (schemaMap.containsKey(lastNode)) {
         isNewMeasurement = false;
         MeasurementSchema columnSchema = schemaMap.get(lastNode);


### PR DESCRIPTION
Add `pathExist()` check after obtaining lock when trying to add a new path to metadata tree.

If this validation doesn't exist, multi concurrent thread could write same `timeseries` to our system, which is a bug.