### PR TITLE
[IOTDB-142] Change String literal "UTF-8" into StandardCharsets.UTF_8

### DIFF
--- a/iotdb/src/main/java/org/apache/iotdb/db/exception/builder/ExceptionBuilder.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/exception/builder/ExceptionBuilder.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
@@ -60,7 +61,7 @@ public class ExceptionBuilder {
    */
   public void loadInfo(String filePath) {
     try(InputStream in = new BufferedInputStream(new FileInputStream(filePath))){
-      properties.load(new InputStreamReader(in, "utf-8"));
+      properties.load(new InputStreamReader(in, StandardCharsets.UTF_8));
     } catch (IOException e) {
       logger.error(
           "Read file error. File does not exist or file is broken. "

--- a/iotdb/src/test/java/org/apache/iotdb/db/exception/ExceptionBuilderTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/exception/ExceptionBuilderTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import org.apache.iotdb.db.exception.builder.ExceptionBuilder;
 import org.junit.After;
@@ -49,7 +50,7 @@ public class ExceptionBuilderTest {
       prop.setProperty("20130", "Statement not prepared");
       prop.setProperty("20220", "Fail to connect");
 
-      prop.store(new OutputStreamWriter(out1, "utf-8"), "english version");
+      prop.store(new OutputStreamWriter(out1, StandardCharsets.UTF_8), "english version");
 
       out2 = new FileOutputStream("err_info_cn.properties", true);
       prop.setProperty("20000", "未知错误");
@@ -62,7 +63,7 @@ public class ExceptionBuilderTest {
       prop.setProperty("20130", "语句未就绪");
       prop.setProperty("20220", "连接失败");
 
-      prop.store(new OutputStreamWriter(out2, "utf-8"), "chinese version");
+      prop.store(new OutputStreamWriter(out2, StandardCharsets.UTF_8), "chinese version");
     } catch (Exception e) {
       e.printStackTrace();
     } finally {

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/CompressTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/CompressTest.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.tsfile.compress;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.apache.iotdb.tsfile.utils.PublicBAOS;
 import org.junit.After;
@@ -49,35 +50,35 @@ public class CompressTest {
   @Test
   public void snappyCompressorTest1() throws IOException {
     PublicBAOS out = new PublicBAOS();
-    out.write(inputString.getBytes("UTF-8"));
+    out.write(inputString.getBytes(StandardCharsets.UTF_8));
     ICompressor.SnappyCompressor compressor = new ICompressor.SnappyCompressor();
     IUnCompressor.SnappyUnCompressor unCompressor = new IUnCompressor.SnappyUnCompressor();
     byte[] compressed = compressor.compress(out.getBuf());
     byte[] uncompressed = unCompressor.uncompress(compressed);
-    String result = new String(uncompressed, "UTF-8");
+    String result = new String(uncompressed, StandardCharsets.UTF_8);
     assertEquals(inputString, result);
   }
 
   @Test
   public void snappyCompressorTest2() throws IOException {
     PublicBAOS out = new PublicBAOS();
-    out.write(inputString.getBytes("UTF-8"));
+    out.write(inputString.getBytes(StandardCharsets.UTF_8));
     ICompressor.SnappyCompressor compressor = new ICompressor.SnappyCompressor();
     IUnCompressor.SnappyUnCompressor unCompressor = new IUnCompressor.SnappyUnCompressor();
     byte[] compressed = new byte[compressor.getMaxBytesForCompression(out.size())];
     int size = compressor.compress(out.getBuf(), 0, out.size(), compressed);
     byte[] bytes = Arrays.copyOfRange(compressed, 0, size);
     byte[] uncompressed = unCompressor.uncompress(bytes);
-    String result = new String(uncompressed, "UTF-8");
+    String result = new String(uncompressed, StandardCharsets.UTF_8);
     assertEquals(inputString, result);
   }
 
   @Test
   public void snappyTest() throws IOException {
-    byte[] compressed = Snappy.compress(inputString.getBytes("UTF-8"));
+    byte[] compressed = Snappy.compress(inputString.getBytes(StandardCharsets.UTF_8));
     byte[] uncompressed = Snappy.uncompress(compressed);
 
-    String result = new String(uncompressed, "UTF-8");
+    String result = new String(uncompressed, StandardCharsets.UTF_8);
     assertEquals(inputString, result);
   }
 

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/SnappyTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/SnappyTest.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.tsfile.compress;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.junit.After;
@@ -51,7 +52,7 @@ public class SnappyTest {
   @Test
   public void testBytes() throws IOException {
     String input = randomString(50000);
-    byte[] uncom = input.getBytes("UTF-8");
+    byte[] uncom = input.getBytes(StandardCharsets.UTF_8);
     long time = System.currentTimeMillis();
     byte[] compressed = Snappy.compress(uncom);
     System.out.println("compression time cost:" + (System.currentTimeMillis() - time));


### PR DESCRIPTION
Methods and constructors where constant charset String literal is used (like "UTF-8") which could be replaced with a predefined Charset object like StandardCharsets.UTF_8. This may work a little bit faster because charset lookup becomes unnecessary. Also catching UnsupportedEncodingException may become unnecessary as well. In this case, the catch block will be removed automatically.