### PR TITLE
Timestamp precision

### DIFF
--- a/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/AbstractClient.java
+++ b/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/AbstractClient.java
@@ -1,15 +1,19 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements.  See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with the License.  You may obtain
- * a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied.  See the License for the specific language governing permissions and limitations
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.apache.iotdb.cli.client;

--- a/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/AbstractClient.java
+++ b/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/AbstractClient.java
@@ -92,8 +92,6 @@ public abstract class AbstractClient {
   protected static int maxTimeLength = ISO_DATETIME_LEN;
   protected static int maxValueLength = 15;
   protected static boolean isQuit = false;
-
-  //wmx
   protected static String TIMESTAMP_PRECISION = "ms";
 
   /**
@@ -223,7 +221,6 @@ public abstract class AbstractClient {
     printCount(isShow, res, cnt);
   }
 
-  //wmx
   protected static String getTimestampPrecision() {
     return TIMESTAMP_PRECISION;
   }
@@ -350,7 +347,6 @@ public abstract class AbstractClient {
     return options;
   }
 
-  //wmx
   public static String getInstantWithPrecision(DateTimeFormatter formatter,
                                                long timestamp, String timestampPrecision, ZoneId zoneid){
 

--- a/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/Client.java
+++ b/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/Client.java
@@ -130,6 +130,10 @@ public class Client extends AbstractClient {
       String s;
       properties = connection.getServerProperties();
       AGGREGRATE_TIME_LIST.addAll(properties.getSupportedTimeAggregationOperations());
+
+      //wmx
+      TIMESTAMP_PRECISION  = properties.getTimestampPrecision();
+
       displayLogo(properties.getVersion());
       println(IOTDB_CLI_PREFIX + "> login successfully");
       while (true) {

--- a/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/Client.java
+++ b/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/Client.java
@@ -130,8 +130,6 @@ public class Client extends AbstractClient {
       String s;
       properties = connection.getServerProperties();
       AGGREGRATE_TIME_LIST.addAll(properties.getSupportedTimeAggregationOperations());
-
-      //wmx
       TIMESTAMP_PRECISION  = properties.getTimestampPrecision();
 
       displayLogo(properties.getVersion());

--- a/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/WinClient.java
+++ b/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/WinClient.java
@@ -135,8 +135,6 @@ public class WinClient extends AbstractClient {
         .getConnection(Config.IOTDB_URL_PREFIX + host + ":" + port + "/", username, password)) {
       properties = connection.getServerProperties();
       AGGREGRATE_TIME_LIST.addAll(properties.getSupportedTimeAggregationOperations());
-
-      //wmx
       TIMESTAMP_PRECISION = properties.getTimestampPrecision();
 
       displayLogo(properties.getVersion());

--- a/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/WinClient.java
+++ b/iotdb-cli/src/main/java/org/apache/iotdb/cli/client/WinClient.java
@@ -135,6 +135,10 @@ public class WinClient extends AbstractClient {
         .getConnection(Config.IOTDB_URL_PREFIX + host + ":" + port + "/", username, password)) {
       properties = connection.getServerProperties();
       AGGREGRATE_TIME_LIST.addAll(properties.getSupportedTimeAggregationOperations());
+
+      //wmx
+      TIMESTAMP_PRECISION = properties.getTimestampPrecision();
+
       displayLogo(properties.getVersion());
       println(IOTDB_CLI_PREFIX + "> login successfully");
       while (true) {

--- a/iotdb/iotdb/conf/iotdb-engine.properties
+++ b/iotdb/iotdb/conf/iotdb-engine.properties
@@ -57,8 +57,8 @@ force_wal_period_in_ms=10
 ####################
 ### Timestamp Precision Configuration
 ####################
-
-# Use this value to set timestamp precision as millisecond, microsecond or nanosecond.
+# Use this value to set timestamp precision as "ms", "us" or "ns".
+# Once the precision is been set, it can not be changed.
 timestamp_precision=ms
 
 

--- a/iotdb/iotdb/conf/iotdb-engine.properties
+++ b/iotdb/iotdb/conf/iotdb-engine.properties
@@ -53,6 +53,16 @@ flush_wal_threshold=10000
 # Set this parameter to 0 may slow down the ingestion on slow disk.
 force_wal_period_in_ms=10
 
+
+# wmx
+####################
+### Timestamp Precision Configuration
+####################
+
+# Use this value to set timestamp precision as millisecond, microsecond or nanosecond.
+timestamp_precision=ms
+
+
 ####################
 ### Directory Configuration
 ####################

--- a/iotdb/iotdb/conf/iotdb-engine.properties
+++ b/iotdb/iotdb/conf/iotdb-engine.properties
@@ -58,7 +58,7 @@ force_wal_period_in_ms=10
 ### Timestamp Precision Configuration
 ####################
 # Use this value to set timestamp precision as "ms", "us" or "ns".
-# Once the precision is been set, it can not be changed.
+# Once the precision has been set, it can not be changed.
 timestamp_precision=ms
 
 

--- a/iotdb/iotdb/conf/iotdb-engine.properties
+++ b/iotdb/iotdb/conf/iotdb-engine.properties
@@ -54,7 +54,6 @@ flush_wal_threshold=10000
 force_wal_period_in_ms=10
 
 
-# wmx
 ####################
 ### Timestamp Precision Configuration
 ####################

--- a/iotdb/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -71,6 +71,12 @@ public class IoTDBConfig {
    */
   private int flushWalThreshold = 10000;
 
+  //wmx
+  /**
+   * this variable set timestamp precision as millisecond, microsecond or nanosecond
+   */
+  private String timestampPrecision = "ms";
+
   /**
    * The cycle when write ahead log is periodically forced to be written to disk(in milliseconds) If
    * set this parameter to 0 it means call outputStream.force(true) after every each insert
@@ -302,6 +308,10 @@ public class IoTDBConfig {
   void setRpcPort(int rpcPort) {
     this.rpcPort = rpcPort;
   }
+
+  //wmx
+  public void setTimestampPrecision(String timestampPrecision) { this.timestampPrecision = timestampPrecision; }
+  public String getTimestampPrecision(){return timestampPrecision;}
 
   public boolean isEnableWal() {
     return enableWal;

--- a/iotdb/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1,15 +1,19 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements.  See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with the License.  You may obtain
- * a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied.  See the License for the specific language governing permissions and limitations
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.apache.iotdb.db.conf;

--- a/iotdb/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1,19 +1,15 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements.  See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the License.  You may obtain
+ * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
  * under the License.
  */
 package org.apache.iotdb.db.conf;
@@ -71,7 +67,6 @@ public class IoTDBConfig {
    */
   private int flushWalThreshold = 10000;
 
-  //wmx
   /**
    * this variable set timestamp precision as millisecond, microsecond or nanosecond
    */
@@ -309,9 +304,13 @@ public class IoTDBConfig {
     this.rpcPort = rpcPort;
   }
 
-  //wmx
-  public void setTimestampPrecision(String timestampPrecision) { this.timestampPrecision = timestampPrecision; }
-  public String getTimestampPrecision(){return timestampPrecision;}
+  public void setTimestampPrecision(String timestampPrecision) {
+    this.timestampPrecision = timestampPrecision;
+  }
+
+  public String getTimestampPrecision() {
+    return timestampPrecision;
+  }
 
   public boolean isEnableWal() {
     return enableWal;

--- a/iotdb/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -123,6 +123,9 @@ public class IoTDBDescriptor {
       conf.setRpcPort(Integer.parseInt(properties.getProperty("rpc_port",
           Integer.toString(conf.getRpcPort()))));
 
+      //wmx
+      conf.setTimestampPrecision(properties.getProperty("timestamp_precision", conf.getTimestampPrecision()));
+
       conf.setEnableParameterAdapter(
           Boolean.parseBoolean(properties.getProperty("enable_parameter_adapter",
               Boolean.toString(conf.isEnableParameterAdapter()))));

--- a/iotdb/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -123,8 +123,8 @@ public class IoTDBDescriptor {
       conf.setRpcPort(Integer.parseInt(properties.getProperty("rpc_port",
           Integer.toString(conf.getRpcPort()))));
 
-      //wmx
-      conf.setTimestampPrecision(properties.getProperty("timestamp_precision", conf.getTimestampPrecision()));
+      conf.setTimestampPrecision(properties.getProperty("timestamp_precision",
+          conf.getTimestampPrecision()));
 
       conf.setEnableParameterAdapter(
           Boolean.parseBoolean(properties.getProperty("enable_parameter_adapter",

--- a/iotdb/src/main/java/org/apache/iotdb/db/qp/constant/DatetimeUtils.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/qp/constant/DatetimeUtils.java
@@ -81,7 +81,6 @@ public class DatetimeUtils {
             .appendValue(ChronoField.MILLI_OF_SECOND, 3).optionalEnd().toFormatter();
   }
 
-  //wmx
   /**
    *  such as '10:15:30' or '10:15:30.123456'.
    */
@@ -94,7 +93,6 @@ public class DatetimeUtils {
             .appendValue(ChronoField.MICRO_OF_SECOND, 6).optionalEnd().toFormatter();
   }
 
-  //wmx
   /**
    *  such as '10:15:30' or '10:15:30.123456789'.
    */
@@ -119,7 +117,6 @@ public class DatetimeUtils {
             .toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456+01:00'.
    */
@@ -132,7 +129,6 @@ public class DatetimeUtils {
             .toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456789+01:00'.
    */
@@ -157,7 +153,6 @@ public class DatetimeUtils {
             .toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456+01:00'.
    */
@@ -170,7 +165,6 @@ public class DatetimeUtils {
             .toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456789+01:00'.
    */
@@ -195,7 +189,6 @@ public class DatetimeUtils {
             .toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456+01:00'.
    */
@@ -208,7 +201,6 @@ public class DatetimeUtils {
             .toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456789+01:00'.
    */
@@ -232,7 +224,6 @@ public class DatetimeUtils {
             .appendOffsetId().toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456+01:00'.
    */
@@ -244,7 +235,6 @@ public class DatetimeUtils {
             .appendOffsetId().toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456789+01:00'.
    */
@@ -269,7 +259,6 @@ public class DatetimeUtils {
             .toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456+01:00'.
    */
@@ -283,7 +272,6 @@ public class DatetimeUtils {
             .toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456789+01:00'.
    */
@@ -309,7 +297,6 @@ public class DatetimeUtils {
             .toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456+01:00'.
    */
@@ -322,7 +309,6 @@ public class DatetimeUtils {
             .toFormatter();
   }
 
-  //wmx
   /**
    * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456789+01:00'.
    */
@@ -342,13 +328,11 @@ public class DatetimeUtils {
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_MS)
 
-          //wmx
           /**
            * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456+01:00'.
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_US)
 
-          //wmx
           /**
            * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456789+01:00'.
            */
@@ -359,13 +343,11 @@ public class DatetimeUtils {
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH)
 
-          //wmx
           /**
            * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456+01:00'.
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_US)
 
-          //wmx
           /**
            * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456789+01:00'.
            */
@@ -376,13 +358,11 @@ public class DatetimeUtils {
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT)
 
-          //wmx
           /**
            * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456+01:00'.
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_US)
 
-          //wmx
           /**
            * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456789+01:00'.
            */
@@ -393,13 +373,11 @@ public class DatetimeUtils {
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE)
 
-          //wmx
           /**
            * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456+01:00'.
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE_US)
 
-          //wmx
           /**
            * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456789+01:00'.
            */
@@ -410,13 +388,11 @@ public class DatetimeUtils {
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE)
 
-          //wmx
           /**
            * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456+01:00'.
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_US)
 
-          //wmx
           /**
            * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456789+01:00'.
            */
@@ -427,13 +403,11 @@ public class DatetimeUtils {
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE)
 
-          //wmx
           /**
            * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456+01:00'.
            */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_US)
 
-          //wmx
           /**
            * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456789+01:00'.
            */
@@ -444,7 +418,6 @@ public class DatetimeUtils {
     return convertDatetimeStrToMillisecond(str, toZoneOffset(zoneId), 0);
   }
 
-  //wmx
   public static long getInstantWithPrecision(String str, String timestampPrecision){
     /* str have dot */
     if (str.substring(20) != "") {
@@ -483,13 +456,11 @@ public class DatetimeUtils {
   }
 
   /**
-   * //wmx
    * convert date time string to millisecond, microsecond or nanosecond.
    */
   public static long convertDatetimeStrToMillisecond(String str, ZoneOffset offset, int depth)
           throws LogicalOperatorException {
 
-    //wmx
     String timestampPrecision = IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision();
 
     if (depth >= 2){
@@ -506,7 +477,6 @@ public class DatetimeUtils {
               String.format("%s with [time-region] at end is not supported now, "
                       + "please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00", str));
     }
-    //wmx
     return getInstantWithPrecision(str, timestampPrecision);
   }
 

--- a/iotdb/src/main/java/org/apache/iotdb/db/qp/constant/DatetimeUtils.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/qp/constant/DatetimeUtils.java
@@ -40,9 +40,9 @@ public class DatetimeUtils {
 
   static {
     ISO_LOCAL_DATE_WIDTH_1_2 = new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('-')
-        .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('-')
-        .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
+            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
   }
 
   /**
@@ -52,9 +52,9 @@ public class DatetimeUtils {
 
   static {
     ISO_LOCAL_DATE_WITH_SLASH = new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('/')
-        .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('/')
-        .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
+            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('/')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('/')
+            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
   }
 
   /**
@@ -64,9 +64,9 @@ public class DatetimeUtils {
 
   static {
     ISO_LOCAL_DATE_WITH_DOT = new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('.')
-        .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('.')
-        .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
+            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('.')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('.')
+            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
   }
 
   /**
@@ -76,9 +76,35 @@ public class DatetimeUtils {
 
   static {
     ISO_LOCAL_TIME_WITH_MS = new DateTimeFormatterBuilder().appendValue(ChronoField.HOUR_OF_DAY, 2)
-        .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
-        .appendValue(ChronoField.SECOND_OF_MINUTE, 2).optionalStart().appendLiteral('.')
-        .appendValue(ChronoField.MILLI_OF_SECOND, 3).optionalEnd().toFormatter();
+            .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2).optionalStart().appendLiteral('.')
+            .appendValue(ChronoField.MILLI_OF_SECOND, 3).optionalEnd().toFormatter();
+  }
+
+  //wmx
+  /**
+   *  such as '10:15:30' or '10:15:30.123456'.
+   */
+  public static final DateTimeFormatter ISO_LOCAL_TIME_WITH_US;
+
+  static {
+    ISO_LOCAL_TIME_WITH_US  = new DateTimeFormatterBuilder().appendValue(ChronoField.HOUR_OF_DAY, 2)
+            .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2).optionalStart().appendLiteral('.')
+            .appendValue(ChronoField.MICRO_OF_SECOND, 6).optionalEnd().toFormatter();
+  }
+
+  //wmx
+  /**
+   *  such as '10:15:30' or '10:15:30.123456789'.
+   */
+  public static final DateTimeFormatter ISO_LOCAL_TIME_WITH_NS;
+
+  static {
+    ISO_LOCAL_TIME_WITH_NS  = new DateTimeFormatterBuilder().appendValue(ChronoField.HOUR_OF_DAY, 2)
+            .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2).optionalStart().appendLiteral('.')
+            .appendValue(ChronoField.NANO_OF_SECOND, 9).optionalEnd().toFormatter();
   }
 
   /**
@@ -88,9 +114,35 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_MS = new DateTimeFormatterBuilder().parseCaseInsensitive()
-        .append(ISO_LOCAL_DATE_WIDTH_1_2).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
-        .appendOffsetId()
-        .toFormatter();
+            .append(ISO_LOCAL_DATE_WIDTH_1_2).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
+            .appendOffsetId()
+            .toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_US;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_US = new DateTimeFormatterBuilder().parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WIDTH_1_2).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_US)
+            .appendOffsetId()
+            .toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456789+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_NS;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_NS = new DateTimeFormatterBuilder().parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WIDTH_1_2).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_NS)
+            .appendOffsetId()
+            .toFormatter();
   }
 
   /**
@@ -100,9 +152,35 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SLASH = new DateTimeFormatterBuilder().parseCaseInsensitive()
-        .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
-        .appendOffsetId()
-        .toFormatter();
+            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
+            .appendOffsetId()
+            .toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_SLASH_US;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_SLASH_US = new DateTimeFormatterBuilder().parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_US)
+            .appendOffsetId()
+            .toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456789+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_SLASH_NS;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_SLASH_NS = new DateTimeFormatterBuilder().parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_NS)
+            .appendOffsetId()
+            .toFormatter();
   }
 
   /**
@@ -112,9 +190,35 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_DOT = new DateTimeFormatterBuilder().parseCaseInsensitive()
-        .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
-        .appendOffsetId()
-        .toFormatter();
+            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
+            .appendOffsetId()
+            .toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_DOT_US;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_DOT_US = new DateTimeFormatterBuilder().parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_US)
+            .appendOffsetId()
+            .toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456789+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_DOT_NS;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_DOT_NS = new DateTimeFormatterBuilder().parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_NS)
+            .appendOffsetId()
+            .toFormatter();
   }
 
   /**
@@ -124,8 +228,32 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SPACE = new DateTimeFormatterBuilder().parseCaseInsensitive()
-        .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
-        .appendOffsetId().toFormatter();
+            .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
+            .appendOffsetId().toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_SPACE_US;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_SPACE_US = new DateTimeFormatterBuilder().parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_US)
+            .appendOffsetId().toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456789+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_SPACE_NS;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_SPACE_NS = new DateTimeFormatterBuilder().parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_NS)
+            .appendOffsetId().toFormatter();
   }
 
   /**
@@ -135,10 +263,38 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE = new DateTimeFormatterBuilder()
-        .parseCaseInsensitive()
-        .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
-        .appendOffsetId()
-        .toFormatter();
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
+            .appendOffsetId()
+            .toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_US;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_US = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_US)
+            .appendOffsetId()
+            .toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456789+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_NS;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_NS = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_NS)
+            .appendOffsetId()
+            .toFormatter();
   }
 
   /**
@@ -148,48 +304,194 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE = new DateTimeFormatterBuilder().parseCaseInsensitive()
-        .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
-        .appendOffsetId()
-        .toFormatter();
+            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
+            .appendOffsetId()
+            .toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_US;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_US = new DateTimeFormatterBuilder().parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_US)
+            .appendOffsetId()
+            .toFormatter();
+  }
+
+  //wmx
+  /**
+   * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456789+01:00'.
+   */
+  public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_NS;
+
+  static {
+    ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_NS = new DateTimeFormatterBuilder().parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_NS)
+            .appendOffsetId()
+            .toFormatter();
   }
 
   public static final DateTimeFormatter formatter = new DateTimeFormatterBuilder()
-      /**
-       * The ISO date-time formatter that formats or parses a date-time with an offset, such as
-       * '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123+01:00'.
-       */
-      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_MS)
-      /**
-       * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123+01:00'.
-       */
-      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH)
-      /**
-       * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123+01:00'.
-       */
-      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT)
-      /**
-       * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123+01:00'.
-       */
-      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE)
-      /**
-       * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123+01:00'.
-       */
-      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE)
-      /**
-       * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123+01:00'.
-       */
-      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE).toFormatter();
+          /**
+           * The ISO date-time formatter that formats or parses a date-time with an offset, such as
+           * '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_MS)
+
+          //wmx
+          /**
+           * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_US)
+
+          //wmx
+          /**
+           * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456789+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_NS)
+
+          /**
+           * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH)
+
+          //wmx
+          /**
+           * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_US)
+
+          //wmx
+          /**
+           * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456789+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_NS)
+
+          /**
+           * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT)
+
+          //wmx
+          /**
+           * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_US)
+
+          //wmx
+          /**
+           * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456789+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_NS)
+
+          /**
+           * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE)
+
+          //wmx
+          /**
+           * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE_US)
+
+          //wmx
+          /**
+           * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456789+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE_NS)
+
+          /**
+           * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE)
+
+          //wmx
+          /**
+           * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_US)
+
+          //wmx
+          /**
+           * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456789+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_NS)
+
+          /**
+           * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE)
+
+          //wmx
+          /**
+           * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_US)
+
+          //wmx
+          /**
+           * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456789+01:00'.
+           */
+          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_NS).toFormatter();
 
   public static long convertDatetimeStrToMillisecond(String str, ZoneId zoneId)
-      throws LogicalOperatorException {
+          throws LogicalOperatorException {
     return convertDatetimeStrToMillisecond(str, toZoneOffset(zoneId), 0);
   }
 
+  //wmx
+  public static long getInstantWithPrecision(String str, String timestampPrecision){
+    /* str have dot */
+    if (str.substring(20) != "") {
+      char[] st = str.substring(20).toCharArray();
+      for (char s : st) {
+        if(s == '.') {
+          if ((str.substring(20).length() != 3 && timestampPrecision == "ms")
+                  || (str.substring(20).length() != 6 && timestampPrecision == "us")
+                  || (str.substring(20).length() != 9 && timestampPrecision == "ns")) {
+            System.out.println(str.substring(20));
+            System.exit(-1);
+          }
+        }
+      }
+    }
+
+    ZonedDateTime zonedDateTime = ZonedDateTime.parse(str, formatter);
+    Instant instant = zonedDateTime.toInstant();
+
+    if(timestampPrecision == "us"){
+      if (instant.getEpochSecond() < 0 && instant.getNano() > 0) {
+        /* adjustment can reduce loss of division */
+        long micros = Math.multiplyExact(instant.getEpochSecond() + 1, 1000_000);
+        long adjustment = instant.getNano() / 1000 - 1;
+        return Math.addExact(micros, adjustment);
+      } else {
+        long micros = Math.multiplyExact(instant.getEpochSecond(), 1000_000);
+        return Math.addExact(micros, instant.getNano() / 1000);
+      }
+    }
+    else if(timestampPrecision == "ns"){
+      long nanos = Math.multiplyExact(instant.getEpochSecond(), 1000_000_000);
+      return Math.addExact(nanos, instant.getNano());
+    }
+    return instant.toEpochMilli();
+  }
+
   /**
-   * convert date time string to millisecond.
+   * //wmx
+   * convert date time string to millisecond, microsecond or nanosecond.
    */
   public static long convertDatetimeStrToMillisecond(String str, ZoneOffset offset, int depth)
-      throws LogicalOperatorException {
+          throws LogicalOperatorException {
+
+    //wmx
+    String timestampPrecision = IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision();
+
     if (depth >= 2){
       throw new DateTimeException(
               String.format("Failed to convert %s to millisecond, zone offset is %s, "
@@ -201,11 +503,11 @@ public class DatetimeUtils {
       return convertDatetimeStrToMillisecond(str + offset, offset, depth + 1);
     } else if (str.contains("[")  || str.contains("]")) {
       throw new DateTimeException(
-          String.format("%s with [time-region] at end is not supported now, "
-              + "please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00", str));
+              String.format("%s with [time-region] at end is not supported now, "
+                      + "please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00", str));
     }
-    ZonedDateTime zonedDateTime = ZonedDateTime.parse(str, formatter);
-    return zonedDateTime.toInstant().toEpochMilli();
+    //wmx
+    return getInstantWithPrecision(str, timestampPrecision);
   }
 
   public static ZoneOffset toZoneOffset(ZoneId zoneId) {
@@ -214,6 +516,6 @@ public class DatetimeUtils {
 
   public static ZonedDateTime convertMillsecondToZonedDateTime(long millisecond) {
     return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millisecond),
-        IoTDBDescriptor.getInstance().getConfig().getZoneID());
+            IoTDBDescriptor.getInstance().getConfig().getZoneID());
   }
 }

--- a/iotdb/src/main/java/org/apache/iotdb/db/qp/constant/DatetimeUtils.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/qp/constant/DatetimeUtils.java
@@ -417,9 +417,9 @@ public class DatetimeUtils {
        */
       .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_NS).toFormatter();
 
-  public static long convertDatetimeStrToMillisecond(String str, ZoneId zoneId)
+  public static long convertDatetimeStrToLong(String str, ZoneId zoneId)
       throws LogicalOperatorException {
-    return convertDatetimeStrToMillisecond(str, toZoneOffset(zoneId), 0);
+    return convertDatetimeStrToLong(str, toZoneOffset(zoneId), 0);
   }
 
   public static long getInstantWithPrecision(String str, TSFileConfig.PrecisionType precisionType)
@@ -446,7 +446,7 @@ public class DatetimeUtils {
   /**
    * convert date time string to millisecond, microsecond or nanosecond.
    */
-  public static long convertDatetimeStrToMillisecond(String str, ZoneOffset offset, int depth)
+  public static long convertDatetimeStrToLong(String str, ZoneOffset offset, int depth)
       throws LogicalOperatorException {
 
     String timestampPrecision = IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision();
@@ -457,11 +457,11 @@ public class DatetimeUtils {
               + "please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00", str, offset));
     }
     if (str.contains("Z")) {
-      return convertDatetimeStrToMillisecond(str.substring(0, str.indexOf('Z')) + "+00:00", offset,
+      return convertDatetimeStrToLong(str.substring(0, str.indexOf('Z')) + "+00:00", offset,
           depth);
     } else if (str.length() - str.lastIndexOf('+') != 6
         && str.length() - str.lastIndexOf('-') != 6) {
-      return convertDatetimeStrToMillisecond(str + offset, offset, depth + 1);
+      return convertDatetimeStrToLong(str + offset, offset, depth + 1);
     } else if (str.contains("[") || str.contains("]")) {
       throw new DateTimeException(
           String.format("%s with [time-region] at end is not supported now, "

--- a/iotdb/src/main/java/org/apache/iotdb/db/qp/constant/DatetimeUtils.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/qp/constant/DatetimeUtils.java
@@ -29,6 +29,7 @@ import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.qp.LogicalOperatorException;
+import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 
 public class DatetimeUtils {
 
@@ -40,9 +41,9 @@ public class DatetimeUtils {
 
   static {
     ISO_LOCAL_DATE_WIDTH_1_2 = new DateTimeFormatterBuilder()
-            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('-')
-            .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('-')
+        .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('-')
+        .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
   }
 
   /**
@@ -52,9 +53,9 @@ public class DatetimeUtils {
 
   static {
     ISO_LOCAL_DATE_WITH_SLASH = new DateTimeFormatterBuilder()
-            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('/')
-            .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('/')
-            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('/')
+        .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('/')
+        .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
   }
 
   /**
@@ -64,9 +65,9 @@ public class DatetimeUtils {
 
   static {
     ISO_LOCAL_DATE_WITH_DOT = new DateTimeFormatterBuilder()
-            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('.')
-            .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('.')
-            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('.')
+        .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('.')
+        .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER).toFormatter();
   }
 
   /**
@@ -76,33 +77,33 @@ public class DatetimeUtils {
 
   static {
     ISO_LOCAL_TIME_WITH_MS = new DateTimeFormatterBuilder().appendValue(ChronoField.HOUR_OF_DAY, 2)
-            .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
-            .appendValue(ChronoField.SECOND_OF_MINUTE, 2).optionalStart().appendLiteral('.')
-            .appendValue(ChronoField.MILLI_OF_SECOND, 3).optionalEnd().toFormatter();
+        .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
+        .appendValue(ChronoField.SECOND_OF_MINUTE, 2).optionalStart().appendLiteral('.')
+        .appendValue(ChronoField.MILLI_OF_SECOND, 3).optionalEnd().toFormatter();
   }
 
   /**
-   *  such as '10:15:30' or '10:15:30.123456'.
+   * such as '10:15:30' or '10:15:30.123456'.
    */
   public static final DateTimeFormatter ISO_LOCAL_TIME_WITH_US;
 
   static {
-    ISO_LOCAL_TIME_WITH_US  = new DateTimeFormatterBuilder().appendValue(ChronoField.HOUR_OF_DAY, 2)
-            .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
-            .appendValue(ChronoField.SECOND_OF_MINUTE, 2).optionalStart().appendLiteral('.')
-            .appendValue(ChronoField.MICRO_OF_SECOND, 6).optionalEnd().toFormatter();
+    ISO_LOCAL_TIME_WITH_US = new DateTimeFormatterBuilder().appendValue(ChronoField.HOUR_OF_DAY, 2)
+        .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
+        .appendValue(ChronoField.SECOND_OF_MINUTE, 2).optionalStart().appendLiteral('.')
+        .appendValue(ChronoField.MICRO_OF_SECOND, 6).optionalEnd().toFormatter();
   }
 
   /**
-   *  such as '10:15:30' or '10:15:30.123456789'.
+   * such as '10:15:30' or '10:15:30.123456789'.
    */
   public static final DateTimeFormatter ISO_LOCAL_TIME_WITH_NS;
 
   static {
-    ISO_LOCAL_TIME_WITH_NS  = new DateTimeFormatterBuilder().appendValue(ChronoField.HOUR_OF_DAY, 2)
-            .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
-            .appendValue(ChronoField.SECOND_OF_MINUTE, 2).optionalStart().appendLiteral('.')
-            .appendValue(ChronoField.NANO_OF_SECOND, 9).optionalEnd().toFormatter();
+    ISO_LOCAL_TIME_WITH_NS = new DateTimeFormatterBuilder().appendValue(ChronoField.HOUR_OF_DAY, 2)
+        .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
+        .appendValue(ChronoField.SECOND_OF_MINUTE, 2).optionalStart().appendLiteral('.')
+        .appendValue(ChronoField.NANO_OF_SECOND, 9).optionalEnd().toFormatter();
   }
 
   /**
@@ -112,9 +113,9 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_MS = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WIDTH_1_2).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
-            .appendOffsetId()
-            .toFormatter();
+        .append(ISO_LOCAL_DATE_WIDTH_1_2).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -124,9 +125,9 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_US = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WIDTH_1_2).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_US)
-            .appendOffsetId()
-            .toFormatter();
+        .append(ISO_LOCAL_DATE_WIDTH_1_2).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_US)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -136,9 +137,9 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_NS = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WIDTH_1_2).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_NS)
-            .appendOffsetId()
-            .toFormatter();
+        .append(ISO_LOCAL_DATE_WIDTH_1_2).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_NS)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -148,9 +149,9 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SLASH = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
-            .appendOffsetId()
-            .toFormatter();
+        .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -160,9 +161,9 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SLASH_US = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_US)
-            .appendOffsetId()
-            .toFormatter();
+        .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_US)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -172,9 +173,9 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SLASH_NS = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_NS)
-            .appendOffsetId()
-            .toFormatter();
+        .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_NS)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -184,9 +185,9 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_DOT = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
-            .appendOffsetId()
-            .toFormatter();
+        .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_MS)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -196,9 +197,9 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_DOT_US = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_US)
-            .appendOffsetId()
-            .toFormatter();
+        .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_US)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -208,9 +209,9 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_DOT_NS = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_NS)
-            .appendOffsetId()
-            .toFormatter();
+        .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral('T').append(ISO_LOCAL_TIME_WITH_NS)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -220,8 +221,8 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SPACE = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
-            .appendOffsetId().toFormatter();
+        .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
+        .appendOffsetId().toFormatter();
   }
 
   /**
@@ -231,8 +232,8 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SPACE_US = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_US)
-            .appendOffsetId().toFormatter();
+        .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_US)
+        .appendOffsetId().toFormatter();
   }
 
   /**
@@ -242,8 +243,8 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SPACE_NS = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_NS)
-            .appendOffsetId().toFormatter();
+        .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_NS)
+        .appendOffsetId().toFormatter();
   }
 
   /**
@@ -253,10 +254,10 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE = new DateTimeFormatterBuilder()
-            .parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
-            .appendOffsetId()
-            .toFormatter();
+        .parseCaseInsensitive()
+        .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -266,10 +267,10 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_US = new DateTimeFormatterBuilder()
-            .parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_US)
-            .appendOffsetId()
-            .toFormatter();
+        .parseCaseInsensitive()
+        .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_US)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -279,10 +280,10 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_NS = new DateTimeFormatterBuilder()
-            .parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_NS)
-            .appendOffsetId()
-            .toFormatter();
+        .parseCaseInsensitive()
+        .append(ISO_LOCAL_DATE_WITH_SLASH).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_NS)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -292,9 +293,9 @@ public class DatetimeUtils {
 
   static {
     ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
-            .appendOffsetId()
-            .toFormatter();
+        .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_MS)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -303,10 +304,11 @@ public class DatetimeUtils {
   public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_US;
 
   static {
-    ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_US = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_US)
-            .appendOffsetId()
-            .toFormatter();
+    ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_US = new DateTimeFormatterBuilder()
+        .parseCaseInsensitive()
+        .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_US)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   /**
@@ -315,118 +317,119 @@ public class DatetimeUtils {
   public static final DateTimeFormatter ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_NS;
 
   static {
-    ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_NS = new DateTimeFormatterBuilder().parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_NS)
-            .appendOffsetId()
-            .toFormatter();
+    ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_NS = new DateTimeFormatterBuilder()
+        .parseCaseInsensitive()
+        .append(ISO_LOCAL_DATE_WITH_DOT).appendLiteral(' ').append(ISO_LOCAL_TIME_WITH_NS)
+        .appendOffsetId()
+        .toFormatter();
   }
 
   public static final DateTimeFormatter formatter = new DateTimeFormatterBuilder()
-          /**
-           * The ISO date-time formatter that formats or parses a date-time with an offset, such as
-           * '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_MS)
+      /**
+       * The ISO date-time formatter that formats or parses a date-time with an offset, such as
+       * '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_MS)
 
-          /**
-           * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_US)
+      /**
+       * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_US)
 
-          /**
-           * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456789+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_NS)
+      /**
+       * such as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30.123456789+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_NS)
 
-          /**
-           * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH)
+      /**
+       * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH)
 
-          /**
-           * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_US)
+      /**
+       * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_US)
 
-          /**
-           * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456789+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_NS)
+      /**
+       * such as '2011/12/03T10:15:30+01:00' or '2011/12/03T10:15:30.123456789+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_NS)
 
-          /**
-           * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT)
+      /**
+       * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT)
 
-          /**
-           * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_US)
+      /**
+       * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_US)
 
-          /**
-           * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456789+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_NS)
+      /**
+       * such as '2011.12.03T10:15:30+01:00' or '2011.12.03T10:15:30.123456789+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_NS)
 
-          /**
-           * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE)
+      /**
+       * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE)
 
-          /**
-           * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE_US)
+      /**
+       * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE_US)
 
-          /**
-           * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456789+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE_NS)
+      /**
+       * such as '2011-12-03 10:15:30+01:00' or '2011-12-03 10:15:30.123456789+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SPACE_NS)
 
-          /**
-           * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE)
+      /**
+       * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE)
 
-          /**
-           * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_US)
+      /**
+       * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_US)
 
-          /**
-           * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456789+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_NS)
+      /**
+       * such as '2011/12/03 10:15:30+01:00' or '2011/12/03 10:15:30.123456789+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_SLASH_WITH_SPACE_NS)
 
-          /**
-           * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE)
+      /**
+       * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE)
 
-          /**
-           * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_US)
+      /**
+       * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_US)
 
-          /**
-           * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456789+01:00'.
-           */
-          .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_NS).toFormatter();
+      /**
+       * such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456789+01:00'.
+       */
+      .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_NS).toFormatter();
 
   public static long convertDatetimeStrToMillisecond(String str, ZoneId zoneId)
-          throws LogicalOperatorException {
+      throws LogicalOperatorException {
     return convertDatetimeStrToMillisecond(str, toZoneOffset(zoneId), 0);
   }
 
-  public static long getInstantWithPrecision(String str, String timestampPrecision){
-    /* str have dot */
+  public static long getInstantWithPrecision(String str, String timestampPrecision,
+      TSFileConfig.PrecisionType precisionType) {
+    /* split str with dot */
     if (str.substring(20) != "") {
       char[] st = str.substring(20).toCharArray();
       for (char s : st) {
-        if(s == '.') {
-          if ((str.substring(20).length() != 3 && timestampPrecision == "ms")
-                  || (str.substring(20).length() != 6 && timestampPrecision == "us")
-                  || (str.substring(20).length() != 9 && timestampPrecision == "ns")) {
+        if (s == '.') {
+          if (str.substring(20).length() != precisionType.getDigit() && timestampPrecision
+              .equals(precisionType.getName())) {
             System.out.println(str.substring(20));
             System.exit(-1);
           }
@@ -437,47 +440,43 @@ public class DatetimeUtils {
     ZonedDateTime zonedDateTime = ZonedDateTime.parse(str, formatter);
     Instant instant = zonedDateTime.toInstant();
 
-    if(timestampPrecision == "us"){
-      if (instant.getEpochSecond() < 0 && instant.getNano() > 0) {
-        /* adjustment can reduce loss of division */
-        long micros = Math.multiplyExact(instant.getEpochSecond() + 1, 1000_000);
-        long adjustment = instant.getNano() / 1000 - 1;
-        return Math.addExact(micros, adjustment);
-      } else {
-        long micros = Math.multiplyExact(instant.getEpochSecond(), 1000_000);
-        return Math.addExact(micros, instant.getNano() / 1000);
-      }
+    if (instant.getEpochSecond() < 0 && instant.getNano() > 0) {
+      /* adjustment can reduce loss of division */
+      long digits = Math.multiplyExact(instant.getEpochSecond() + 1, precisionType.getOrder());
+      long adjustment = instant.getNano() / 1000 - 1;
+      return Math.addExact(digits, adjustment);
+    } else {
+      long digits = Math.multiplyExact(instant.getEpochSecond(), precisionType.getOrder());
+      return Math.addExact(digits, instant.getNano() / (1000_000_000L / precisionType.getOrder()));
     }
-    else if(timestampPrecision == "ns"){
-      long nanos = Math.multiplyExact(instant.getEpochSecond(), 1000_000_000);
-      return Math.addExact(nanos, instant.getNano());
-    }
-    return instant.toEpochMilli();
   }
 
   /**
    * convert date time string to millisecond, microsecond or nanosecond.
    */
   public static long convertDatetimeStrToMillisecond(String str, ZoneOffset offset, int depth)
-          throws LogicalOperatorException {
+      throws LogicalOperatorException {
 
     String timestampPrecision = IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision();
 
-    if (depth >= 2){
+    if (depth >= 2) {
       throw new DateTimeException(
-              String.format("Failed to convert %s to millisecond, zone offset is %s, "
-                      + "please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00", str, offset));
+          String.format("Failed to convert %s to millisecond, zone offset is %s, "
+              + "please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00", str, offset));
     }
-    if (str.contains("Z")){
-      return convertDatetimeStrToMillisecond(str.substring(0, str.indexOf('Z')) + "+00:00", offset, depth);
-    } else if (str.length() - str.lastIndexOf('+') != 6 && str.length() - str.lastIndexOf('-') != 6) {
+    if (str.contains("Z")) {
+      return convertDatetimeStrToMillisecond(str.substring(0, str.indexOf('Z')) + "+00:00", offset,
+          depth);
+    } else if (str.length() - str.lastIndexOf('+') != 6
+        && str.length() - str.lastIndexOf('-') != 6) {
       return convertDatetimeStrToMillisecond(str + offset, offset, depth + 1);
-    } else if (str.contains("[")  || str.contains("]")) {
+    } else if (str.contains("[") || str.contains("]")) {
       throw new DateTimeException(
-              String.format("%s with [time-region] at end is not supported now, "
-                      + "please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00", str));
+          String.format("%s with [time-region] at end is not supported now, "
+              + "please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00", str));
     }
-    return getInstantWithPrecision(str, timestampPrecision);
+    return getInstantWithPrecision(str, timestampPrecision,
+        TSFileConfig.PrecisionType.valueofKey(timestampPrecision));
   }
 
   public static ZoneOffset toZoneOffset(ZoneId zoneId) {
@@ -486,6 +485,6 @@ public class DatetimeUtils {
 
   public static ZonedDateTime convertMillsecondToZonedDateTime(long millisecond) {
     return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millisecond),
-            IoTDBDescriptor.getInstance().getConfig().getZoneID());
+        IoTDBDescriptor.getInstance().getConfig().getZoneID());
   }
 }

--- a/iotdb/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -865,7 +865,7 @@ public class LogicalGenerator {
       return System.currentTimeMillis();
     }
     try {
-      return DatetimeUtils.convertDatetimeStrToMillisecond(timestampStr, zoneId);
+      return DatetimeUtils.convertDatetimeStrToLong(timestampStr, zoneId);
     } catch (Exception e) {
       throw new LogicalOperatorException(String
           .format("Input time format %s error. "

--- a/iotdb/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -892,10 +892,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     properties.setSupportedTimeAggregationOperations(new ArrayList<>());
     properties.getSupportedTimeAggregationOperations().add(IoTDBConstant.MAX_TIME);
     properties.getSupportedTimeAggregationOperations().add(IoTDBConstant.MIN_TIME);
-
-    //wmx
     properties.setTimestampPrecision(IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision());
-
     return properties;
   }
 

--- a/iotdb/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/iotdb/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -892,6 +892,10 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     properties.setSupportedTimeAggregationOperations(new ArrayList<>());
     properties.getSupportedTimeAggregationOperations().add(IoTDBConstant.MAX_TIME);
     properties.getSupportedTimeAggregationOperations().add(IoTDBConstant.MIN_TIME);
+
+    //wmx
+    properties.setTimestampPrecision(IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision());
+
     return properties;
   }
 

--- a/iotdb/src/test/java/org/apache/iotdb/db/sql/DatetimeQueryDataSetUtilsTest.java
+++ b/iotdb/src/test/java/org/apache/iotdb/db/sql/DatetimeQueryDataSetUtilsTest.java
@@ -76,11 +76,11 @@ public class DatetimeQueryDataSetUtilsTest {
         "2019.01.02 15:13:27" + zoneOffset, "2019-01-02T15:13:27" + zoneOffset,
         "2019/01/02T15:13:27" + zoneOffset, "2019.01.02T15:13:27" + zoneOffset,};
     for (String str : timeFormatWithoutMs) {
-      Assert.assertEquals(res, DatetimeUtils.convertDatetimeStrToMillisecond(str, zoneOffset, 0));
+      Assert.assertEquals(res, DatetimeUtils.convertDatetimeStrToLong(str, zoneOffset, 0));
     }
 
     for (String str : timeFormatWithoutMs) {
-      assertEquals(res, DatetimeUtils.convertDatetimeStrToMillisecond(str, zoneId));
+      assertEquals(res, DatetimeUtils.convertDatetimeStrToLong(str, zoneId));
     }
 
   }
@@ -94,11 +94,11 @@ public class DatetimeQueryDataSetUtilsTest {
         "2019-01-02T15:13:27.689" + zoneOffset, "2019/01/02T15:13:27.689" + zoneOffset,
         "2019.01.02T15:13:27.689" + zoneOffset,};
     for (String str : timeFormatWithoutMs) {
-      assertEquals(res, DatetimeUtils.convertDatetimeStrToMillisecond(str, zoneOffset, 0));
+      assertEquals(res, DatetimeUtils.convertDatetimeStrToLong(str, zoneOffset, 0));
     }
 
     for (String str : timeFormatWithoutMs) {
-      assertEquals(res, DatetimeUtils.convertDatetimeStrToMillisecond(str, zoneId));
+      assertEquals(res, DatetimeUtils.convertDatetimeStrToLong(str, zoneId));
     }
   }
 

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBConnectionTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBConnectionTest.java
@@ -82,13 +82,15 @@ public class IoTDBConnectionTest {
         add("min_time");
       }
     };
+    final String timestampPrecision = "us";
     when(client.getProperties())
-        .thenReturn(new ServerProperties(version, supportedAggregationTime));
+        .thenReturn(new ServerProperties(version, supportedAggregationTime, timestampPrecision));
     connection.client = client;
     assertEquals(connection.getServerProperties().getVersion(), version);
     for (int i = 0; i < supportedAggregationTime.size(); i++) {
       assertEquals(connection.getServerProperties().getSupportedTimeAggregationOperations().get(i),
           supportedAggregationTime.get(i));
     }
+    assertEquals(connection.getServerProperties().getTimestampPrecision(), timestampPrecision);
   }
 }

--- a/service-rpc/src/main/thrift/rpc.thrift
+++ b/service-rpc/src/main/thrift/rpc.thrift
@@ -260,6 +260,7 @@ struct TSInsertionReq {
 struct ServerProperties {
 	1: required string version;
 	2: required list<string> supportedTimeAggregationOperations;
+	3: required string timestampPrecision;
 }
 
 service TSIService {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
@@ -24,6 +24,7 @@ package org.apache.iotdb.tsfile.common.conf;
  * @author kangrong
  */
 public class TSFileConfig {
+
   // Memory configuration
   public static final int RLE_MIN_REPEATED_NUM = 8;
   public static final int RLE_MAX_REPEATED_NUM = 0x7FFF;
@@ -49,6 +50,44 @@ public class TSFileConfig {
   public static final String STRING_ENCODING = "UTF-8";
   public static final String CONFIG_FILE_NAME = "tsfile-format.properties";
   public static final String MAGIC_STRING = "TsFilev0.8.0";
+
+  public enum PrecisionType {
+    MS("ms", 1000, 3),
+    US("us", 1000_000, 6),
+    NS("ns", 1000_000_000, 9);
+
+    private String precisionName;
+    private int orderofnum;
+    private int digit;
+
+    PrecisionType(String precisionName, int orderofnum, int digit) {
+      this.precisionName = precisionName;
+      this.orderofnum = orderofnum;
+      this.digit = digit;
+    }
+
+    public static PrecisionType valueofKey(String precisionName) {
+      for (PrecisionType precisiontype : PrecisionType.values()) {
+        if (precisiontype.precisionName.equals(precisionName)) {
+          return precisiontype;
+        }
+      }
+      throw new IllegalArgumentException("No element matches " + precisionName);
+    }
+
+    public String getName() {
+      return precisionName;
+    }
+
+    public int getOrder() {
+      return orderofnum;
+    }
+
+    public int getDigit() {
+      return digit;
+    }
+  }
+
   /**
    * Current version is 3.
    */

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
@@ -50,44 +50,6 @@ public class TSFileConfig {
   public static final String STRING_ENCODING = "UTF-8";
   public static final String CONFIG_FILE_NAME = "tsfile-format.properties";
   public static final String MAGIC_STRING = "TsFilev0.8.0";
-
-  public enum PrecisionType {
-    MS("ms", 1000, 3),
-    US("us", 1000_000, 6),
-    NS("ns", 1000_000_000, 9);
-
-    private String precisionName;
-    private int orderOfnum;
-    private int decimalNum;
-
-    PrecisionType(String precisionName, int orderOfnum, int decimalNum) {
-      this.precisionName = precisionName;
-      this.orderOfnum = orderOfnum;
-      this.decimalNum = decimalNum;
-    }
-
-    public static PrecisionType valueofKey(String precisionName) {
-      for (PrecisionType precisiontype : PrecisionType.values()) {
-        if (precisiontype.precisionName.equals(precisionName)) {
-          return precisiontype;
-        }
-      }
-      throw new IllegalArgumentException("No element matches " + precisionName);
-    }
-
-    public String getName() {
-      return precisionName;
-    }
-
-    public int getOrder() {
-      return orderOfnum;
-    }
-
-    public int getDigit() {
-      return decimalNum;
-    }
-  }
-
   /**
    * Current version is 3.
    */

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
@@ -57,13 +57,13 @@ public class TSFileConfig {
     NS("ns", 1000_000_000, 9);
 
     private String precisionName;
-    private int orderofnum;
-    private int digit;
+    private int orderOfnum;
+    private int decimalNum;
 
-    PrecisionType(String precisionName, int orderofnum, int digit) {
+    PrecisionType(String precisionName, int orderOfnum, int decimalNum) {
       this.precisionName = precisionName;
-      this.orderofnum = orderofnum;
-      this.digit = digit;
+      this.orderOfnum = orderOfnum;
+      this.decimalNum = decimalNum;
     }
 
     public static PrecisionType valueofKey(String precisionName) {
@@ -80,11 +80,11 @@ public class TSFileConfig {
     }
 
     public int getOrder() {
-      return orderofnum;
+      return orderOfnum;
     }
 
     public int getDigit() {
-      return digit;
+      return decimalNum;
     }
   }
 


### PR DESCRIPTION
IoTDB only supports millisecond timestamp-precision. Therefore, I add microsecond and nanosecond to help users have more choice in timestamp precision while inserting or querying data.