### PR TITLE
[IOTDB-151]modify antlr3 to support timeseries path in the number format

### DIFF
--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TSLexer.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TSLexer.g
@@ -146,25 +146,51 @@ StringLiteral
     )
     ;
 
-//2016-11-16T16:22:33+0800
-DATETIME
-    : Digit+ (MINUS | DIVIDE | DOT) Digit+ (MINUS | DIVIDE | DOT) Digit+ ('T' | WS) Digit+ COLON Digit+ COLON Digit+ (DOT Digit+)? ((PLUS | MINUS) Digit+ COLON Digit+)?
-    ;
-
 NegativeInteger
     :
     '-' Digit+
     ;
 
-NonNegativeInteger
+PositiveInteger
     :
-    ('+')? Digit+
+    '+' Digit+
     ;
 
-Float
-	:
-	('+'|'-')? Digit+ DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?
-	;
+NegativeFloat
+    :
+    '-' Digit+ DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?
+    ;
+
+PositiveFloat
+    :
+    '+' Digit+ DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?
+    ;
+
+UnsignedInteger
+    :
+    Digit+
+    ;
+
+DoubleInScientificNotationSuffix
+    :
+    DOT
+    (
+      (Digit+ ('e'|'E') ('+'|'-')? Digit+) => Digit+ ('e'|'E') ('+'|'-')? Digit+
+    |
+      (){$type=DOT;}
+    )
+    ;
+
+// 2017-11-1T00:15:00+08:00
+DATETIME
+    :
+    Digit+
+    (
+      ((MINUS | DIVIDE | DOT) Digit+ (MINUS | DIVIDE | DOT) Digit+ ('T' | WS) Digit+ COLON Digit+ COLON Digit+ (DOT Digit+)? ((PLUS | MINUS) Digit+ COLON Digit+)?)=>(MINUS | DIVIDE | DOT) Digit+ (MINUS | DIVIDE | DOT) Digit+ ('T' | WS) Digit+ COLON Digit+ COLON Digit+ (DOT Digit+)? ((PLUS | MINUS) Digit+ COLON Digit+)?
+    |
+      (){$type=UnsignedInteger;}
+    )
+    ;
 
 Boolean
     :

--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TSLexer.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TSLexer.g
@@ -158,17 +158,24 @@ PositiveInteger
 
 NegativeFloat
     :
-    '-' Digit+ DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?
+    '-' Digit+
+    (
+      (DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?) => DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?
+    |
+      (){$type=NegativeInteger;}
+    )
+    | '-' DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?
     ;
 
 PositiveFloat
     :
-    '+' Digit+ DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?
-    ;
-
-UnsignedInteger
-    :
-    Digit+
+    '+' Digit+
+    (
+      (DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?) => DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?
+    |
+      (){$type=PositiveInteger;}
+    )
+    | '+' DOT Digit+ (('e' | 'E') ('+'|'-')? Digit+)?
     ;
 
 DoubleInScientificNotationSuffix
@@ -179,6 +186,11 @@ DoubleInScientificNotationSuffix
     |
       (){$type=DOT;}
     )
+    ;
+
+UnsignedInteger
+    :
+    Digit+
     ;
 
 // 2017-11-1T00:15:00+08:00

--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TSParser.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TSParser.g
@@ -77,6 +77,7 @@ TOK_ALL;
 TOK_SLIMIT;
 TOK_SOFFSET;
 TOK_LIMIT;
+TOK_FLOAT_COMB;
 
 /*
   BELOW IS THE METADATA TOKEN
@@ -308,17 +309,30 @@ statement
 	: execStatement (SEMICOLON)? EOF
 	;
 
+nonNegativeInteger
+    : PositiveInteger
+    | UnsignedInteger
+    ;
+
 integer
     : NegativeInteger
-    | NonNegativeInteger
+    | nonNegativeInteger
+    ;
+
+// ATTENTION: DO NOT USE NAME 'float'!
+floatValue
+    : PositiveFloat
+    | NegativeFloat
+    | UnsignedInteger DOT UnsignedInteger -> ^(TOK_FLOAT_COMB UnsignedInteger DOT UnsignedInteger)
+    | UnsignedInteger DoubleInScientificNotationSuffix -> ^(TOK_FLOAT_COMB UnsignedInteger DoubleInScientificNotationSuffix)
     ;
 
 number
-    : integer | Float | Boolean
+    : integer | floatValue | Boolean
     ;
 
 numberOrString // identifier is string or integer
-    : Boolean | Float | identifier
+    : Boolean | floatValue | identifier
     ;
 
 numberOrStringWidely
@@ -608,8 +622,8 @@ Assit to multi insert, target grammar:  insert into root.<deviceType>.<deviceNam
 
 multidentifier
 	:
-	LPAREN KW_TIMESTAMP (COMMA Identifier)* RPAREN
-	-> ^(TOK_MULT_IDENTIFIER TOK_TIME Identifier*)
+	LPAREN KW_TIMESTAMP (COMMA identifier)* RPAREN
+	-> ^(TOK_MULT_IDENTIFIER TOK_TIME identifier*)
 	;
 multiValue
 	:
@@ -704,7 +718,7 @@ identifier
 //    ;
 
 selectClause
-    : KW_SELECT KW_INDEX func=Identifier LPAREN p1=timeseries COMMA p2=timeseries COMMA n1=dateFormatWithNumber COMMA n2=dateFormatWithNumber COMMA epsilon=Float (COMMA alpha=Float COMMA beta=Float)? RPAREN (fromClause)?
+    : KW_SELECT KW_INDEX func=Identifier LPAREN p1=timeseries COMMA p2=timeseries COMMA n1=dateFormatWithNumber COMMA n2=dateFormatWithNumber COMMA epsilon=floatValue (COMMA alpha=floatValue COMMA beta=floatValue)? RPAREN (fromClause)?
     -> ^(TOK_SELECT_INDEX $func $p1 $p2 $n1 $n2 $epsilon ($alpha $beta)?) fromClause?
     | KW_SELECT clusteredPath (COMMA clusteredPath)* fromClause
     -> ^(TOK_SELECT clusteredPath+) fromClause
@@ -742,24 +756,24 @@ fillClause
 
 limitClause
     :
-    KW_LIMIT N=NonNegativeInteger offsetClause?
+    KW_LIMIT N=nonNegativeInteger offsetClause?
     -> ^(TOK_LIMIT $N)
     ;
 
 offsetClause
     :
-    KW_OFFSET OFFSETValue=NonNegativeInteger
+    KW_OFFSET OFFSETValue=nonNegativeInteger
     ;
 
 slimitClause
     :
-    KW_SLIMIT SN=NonNegativeInteger soffsetClause?
+    KW_SLIMIT SN=nonNegativeInteger soffsetClause?
     -> ^(TOK_SLIMIT $SN) soffsetClause?
     ;
 
 soffsetClause
     :
-    KW_SOFFSET SOFFSETValue=NonNegativeInteger
+    KW_SOFFSET SOFFSETValue=nonNegativeInteger
     -> ^(TOK_SOFFSET $SOFFSETValue)
     ;
 
@@ -813,7 +827,7 @@ precedenceNotExpression
 
 precedenceEqualExpressionSingle
     :
-    (left=atomExpression -> $left)
+    (left=atomExpressionWithNumberPath -> $left)
     (
     	(precedenceEqualOperator equalExpr=atomExpression)
        -> ^(precedenceEqualOperator $precedenceEqualExpressionSingle $equalExpr)
@@ -834,6 +848,16 @@ nullCondition
     | KW_NOT KW_NULL -> ^(TOK_ISNOTNULL)
     ;
 
+
+atomExpressionWithNumberPath
+    :
+    (KW_NULL) => KW_NULL -> TOK_NULL
+    | (KW_TIME) => KW_TIME -> ^(TOK_PATH KW_TIME)
+    | (constant) => constant -> ^(TOK_PATH constant)
+    | prefixPath
+    | suffixPath
+    | LPAREN! expression RPAREN!
+    ;
 
 
 atomExpression

--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TSParser.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TSParser.g
@@ -323,8 +323,13 @@ integer
 floatValue
     : PositiveFloat
     | NegativeFloat
-    | UnsignedInteger DOT UnsignedInteger -> ^(TOK_FLOAT_COMB UnsignedInteger DOT UnsignedInteger)
+    | PositiveInteger DOT -> PositiveInteger
+    | NegativeInteger DOT -> NegativeInteger
+    | (UnsignedInteger DOT UnsignedInteger)=>UnsignedInteger DOT UnsignedInteger -> ^(TOK_FLOAT_COMB UnsignedInteger DOT UnsignedInteger)
+    | UnsignedInteger DOT -> UnsignedInteger
+    | DOT UnsignedInteger -> ^(TOK_FLOAT_COMB DOT UnsignedInteger)
     | UnsignedInteger DoubleInScientificNotationSuffix -> ^(TOK_FLOAT_COMB UnsignedInteger DoubleInScientificNotationSuffix)
+    | DoubleInScientificNotationSuffix
     ;
 
 number

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -464,9 +464,15 @@ public class LogicalGenerator {
     }
     insertOp.setMeasurementList(measurementList);
 
-    String[] valueList = new String[astNode.getChild(2).getChildCount() - 1];
-    for (int i = 1; i < astNode.getChild(2).getChildCount(); i++) {
-      valueList[i - 1] = astNode.getChild(2).getChild(i).getText();
+    AstNode valueKey = astNode.getChild(2);
+    String[] valueList = new String[valueKey.getChildCount() - 1];
+    for (int i = 1; i < valueKey.getChildCount(); i++) {
+      AstNode node = valueKey.getChild(i);
+      if (node.getType() == TSParser.TOK_FLOAT_COMB) {
+        valueList[i - 1] = parseTokens(node);
+      } else {
+        valueList[i - 1] = node.getText();
+      }
     }
     insertOp.setValueList(valueList);
   }
@@ -840,6 +846,8 @@ public class LogicalGenerator {
         throw new LogicalOperatorException("Date can only be used to time");
       }
       seriesValue = parseTokenTime(rightKey);
+    } else if (rightKey.getType() == TSParser.TOK_FLOAT_COMB) {
+      seriesValue = parseTokens(rightKey);
     } else {
       seriesValue = rightKey.getText();
     }
@@ -847,11 +855,15 @@ public class LogicalGenerator {
   }
 
   private String parseTokenTime(AstNode astNode) throws LogicalOperatorException {
+    return parseTimeFormat(parseTokens(astNode)) + "";
+  }
+
+  private String parseTokens(AstNode astNode) throws LogicalOperatorException {
     StringContainer sc = new StringContainer();
     for (int i = 0; i < astNode.getChildCount(); i++) {
       sc.addTail(astNode.getChild(i).getText());
     }
-    return parseTimeFormat(sc.toString()) + "";
+    return sc.toString();
   }
 
   /**
@@ -1121,7 +1133,7 @@ public class LogicalGenerator {
     boolean throwExp = false;
     switch (tsDataType) {
       case BOOLEAN:
-        if (!(tsEncoding.equals(TSEncoding.RLE) || tsEncoding.equals(TSEncoding.PLAIN))){
+        if (!(tsEncoding.equals(TSEncoding.RLE) || tsEncoding.equals(TSEncoding.PLAIN))) {
           throwExp = true;
         }
         break;

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBNumberPathIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBNumberPathIT.java
@@ -1,0 +1,434 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.integration;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.apache.iotdb.db.service.IoTDB;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Notice that, all test begins with "IoTDB" is integration test. All test which will start the IoTDB server should be
+ * defined as integration test.
+ */
+public class IoTDBNumberPathIT {
+
+  private IoTDB daemon;
+
+  @Before
+  public void setUp() throws Exception {
+    EnvironmentUtils.closeStatMonitor();
+    daemon = IoTDB.getInstance();
+    daemon.active();
+    EnvironmentUtils.envSetUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    daemon.stop();
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void test() throws ClassNotFoundException, SQLException {
+    String[] sqls = {"SET STORAGE GROUP TO root.123"};
+    executeSQL(sqls);
+    //simpleTest();
+//    insertTest();
+    selectTest();
+//    deleteTest();
+//    groupByTest();
+//    funcTest();
+
+//    funcTestWithOutTimeGenerator();
+  }
+
+  public void simpleTest() throws ClassNotFoundException, SQLException {
+    String[] sqlS = {"CREATE TIMESERIES root.123.456.789 WITH DATATYPE=INT32,ENCODING=RLE",
+        "SHOW TIMESERIES",
+        "===  Timeseries Tree  ===\n"
+            + "\n"
+            + "{\n"
+            + "\t\"root\":{\n"
+            + "\t\t\"123\":{\n"
+            + "\t\t\t\"456\":{\n"
+            + "\t\t\t\t\"789\":{\n"
+            + "\t\t\t\t\t\"args\":\"{}\",\n"
+            + "\t\t\t\t\t\"StorageGroup\":\"root.123\",\n"
+            + "\t\t\t\t\t\"DataType\":\"INT32\",\n"
+            + "\t\t\t\t\t\"Compressor\":\"UNCOMPRESSED\",\n"
+            + "\t\t\t\t\t\"Encoding\":\"RLE\"\n"
+            + "\t\t\t\t}\n"
+            + "\t\t\t}\n"
+            + "\t\t}\n"
+            + "\t}\n"
+            + "}",
+        "DELETE TIMESERIES root.123.456.789",
+        "SHOW TIMESERIES",
+        "===  Timeseries Tree  ===\n"
+            + "\n"
+            + "{\n"
+            + "\t\"root\":{\n"
+            + "\t\t\"123\":{}\n"
+            + "\t}\n"
+            + "}",
+        "CREATE TIMESERIES root.123.456.789 WITH DATATYPE=BOOLEAN,ENCODING=PLAIN",
+        "CREATE TIMESERIES root.123.456.000 WITH DATATYPE=INT64,ENCODING=TS_2DIFF",
+        "CREATE TIMESERIES root.123.456.1111 WITH DATATYPE=FLOAT,ENCODING=GORILLA",
+        "CREATE TIMESERIES root.123.456.4444 WITH DATATYPE=DOUBLE,ENCODING=RLE",
+        "CREATE TIMESERIES root.123.d1.555 WITH DATATYPE=TEXT,ENCODING=PLAIN",
+        "CREATE TIMESERIES root.123.d2.666 WITH DATATYPE=INT32,ENCODING=TS_2DIFF,compressor=UNCOMPRESSED",
+        "CREATE TIMESERIES root.123.d3.77777 WITH DATATYPE=INT32,ENCODING=RLE,compressor=SNAPPY",
+        "CREATE TIMESERIES root.123.d4.888 WITH DATATYPE=INT32,ENCODING=RLE,MAX_POINT_NUMBER=100",
+        "CREATE TIMESERIES root.123.d5.s9 WITH DATATYPE=FLOAT,ENCODING=PLAIN,compressor=SNAPPY,MAX_POINT_NUMBER=10",
+        "CREATE TIMESERIES root.123.d6.0000 WITH DATATYPE=DOUBLE,ENCODING=RLE,compressor=UNCOMPRESSED,MAX_POINT_NUMBER=10",
+        "DELETE TIMESERIES root.123.456.*",
+        "SHOW TIMESERIES",
+        "===  Timeseries Tree  ===\n"
+            + "\n"
+            + "{\n"
+            + "\t\"root\":{\n"
+            + "\t\t\"123\":{\n"
+            + "\t\t\t\"d4\":{\n"
+            + "\t\t\t\t\"888\":{\n"
+            + "\t\t\t\t\t\"args\":\"{max_point_number=100}\",\n"
+            + "\t\t\t\t\t\"StorageGroup\":\"root.123\",\n"
+            + "\t\t\t\t\t\"DataType\":\"INT32\",\n"
+            + "\t\t\t\t\t\"Compressor\":\"UNCOMPRESSED\",\n"
+            + "\t\t\t\t\t\"Encoding\":\"RLE\"\n"
+            + "\t\t\t\t}\n"
+            + "\t\t\t},\n"
+            + "\t\t\t\"d5\":{\n"
+            + "\t\t\t\t\"s9\":{\n"
+            + "\t\t\t\t\t\"args\":\"{max_point_number=10}\",\n"
+            + "\t\t\t\t\t\"StorageGroup\":\"root.123\",\n"
+            + "\t\t\t\t\t\"DataType\":\"FLOAT\",\n"
+            + "\t\t\t\t\t\"Compressor\":\"SNAPPY\",\n"
+            + "\t\t\t\t\t\"Encoding\":\"PLAIN\"\n"
+            + "\t\t\t\t}\n"
+            + "\t\t\t},\n"
+            + "\t\t\t\"d6\":{\n"
+            + "\t\t\t\t\"0000\":{\n"
+            + "\t\t\t\t\t\"args\":\"{max_point_number=10}\",\n"
+            + "\t\t\t\t\t\"StorageGroup\":\"root.123\",\n"
+            + "\t\t\t\t\t\"DataType\":\"DOUBLE\",\n"
+            + "\t\t\t\t\t\"Compressor\":\"UNCOMPRESSED\",\n"
+            + "\t\t\t\t\t\"Encoding\":\"RLE\"\n"
+            + "\t\t\t\t}\n"
+            + "\t\t\t},\n"
+            + "\t\t\t\"d1\":{\n"
+            + "\t\t\t\t\"555\":{\n"
+            + "\t\t\t\t\t\"args\":\"{}\",\n"
+            + "\t\t\t\t\t\"StorageGroup\":\"root.123\",\n"
+            + "\t\t\t\t\t\"DataType\":\"TEXT\",\n"
+            + "\t\t\t\t\t\"Compressor\":\"UNCOMPRESSED\",\n"
+            + "\t\t\t\t\t\"Encoding\":\"PLAIN\"\n"
+            + "\t\t\t\t}\n"
+            + "\t\t\t},\n"
+            + "\t\t\t\"d2\":{\n"
+            + "\t\t\t\t\"666\":{\n"
+            + "\t\t\t\t\t\"args\":\"{}\",\n"
+            + "\t\t\t\t\t\"StorageGroup\":\"root.123\",\n"
+            + "\t\t\t\t\t\"DataType\":\"INT32\",\n"
+            + "\t\t\t\t\t\"Compressor\":\"UNCOMPRESSED\",\n"
+            + "\t\t\t\t\t\"Encoding\":\"TS_2DIFF\"\n"
+            + "\t\t\t\t}\n"
+            + "\t\t\t},\n"
+            + "\t\t\t\"d3\":{\n"
+            + "\t\t\t\t\"77777\":{\n"
+            + "\t\t\t\t\t\"args\":\"{}\",\n"
+            + "\t\t\t\t\t\"StorageGroup\":\"root.123\",\n"
+            + "\t\t\t\t\t\"DataType\":\"INT32\",\n"
+            + "\t\t\t\t\t\"Compressor\":\"SNAPPY\",\n"
+            + "\t\t\t\t\t\"Encoding\":\"RLE\"\n"
+            + "\t\t\t\t}\n"
+            + "\t\t\t}\n"
+            + "\t\t}\n"
+            + "\t}\n"
+            + "}",
+        "DELETE TIMESERIES root.123.*",
+        "SHOW TIMESERIES",
+        "===  Timeseries Tree  ===\n"
+            + "\n"
+            + "{\n"
+            + "\t\"root\":{\n"
+            + "\t\t\"123\":{}\n"
+            + "\t}\n"
+            + "}"
+    };
+    executeSQL(sqlS);
+  }
+
+  public void insertTest() throws ClassNotFoundException, SQLException {
+    String[] sqlS = {"CREATE TIMESERIES root.123.456.789 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,789) values(1,101)",
+        "CREATE TIMESERIES root.123.456.000 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,789,000) values(2,102,202)",
+        "INSERT INTO root.123.456(timestamp,789) values(NOW(),104)",
+        "INSERT INTO root.123.456(timestamp,789) values(2000-01-01T08:00:00+08:00,105)",
+        "SELECT * FROM root.123.456",
+        "1,101,null,\n" + "2,102,202,\n" + "946684800000,105,null,\n" + "NOW(),104,null,\n",
+        "DELETE TIMESERIES root.123.*"
+    };
+    executeSQL(sqlS);
+  }
+
+  public void deleteTest() throws ClassNotFoundException, SQLException {
+    String[] sqlS = {"CREATE TIMESERIES root.123.456.789 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,789) values(1,101)",
+        "CREATE TIMESERIES root.123.456.000 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,789,000) values(2,102,202)",
+        "INSERT INTO root.123.456(timestamp,789) values(NOW(),104)",
+        "INSERT INTO root.123.456(timestamp,789) values(2000-01-01T08:00:00+08:00,105)",
+        "SELECT * FROM root.123.456",
+        "1,101,null,\n" + "2,102,202,\n" + "946684800000,105,null,\n" + "NOW(),104,null,\n",
+        "DELETE TIMESERIES root.123.*",
+        "CREATE TIMESERIES root.123.456.789 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,789) values(1,1)",
+        "INSERT INTO root.123.456(timestamp,789) values(2,1)",
+        "INSERT INTO root.123.456(timestamp,789) values(3,1)",
+        "INSERT INTO root.123.456(timestamp,789) values(4,1)",
+        "INSERT INTO root.123.456(timestamp,789) values(5,1)",
+        "INSERT INTO root.123.456(timestamp,789) values(6,1)",
+        "INSERT INTO root.123.456(timestamp,789) values(7,1)",
+        "INSERT INTO root.123.456(timestamp,789) values(8,1)",
+        "INSERT INTO root.123.456(timestamp,789) values(9,1)",
+        "INSERT INTO root.123.456(timestamp,789) values(10,1)",
+        "SELECT * FROM root.123.456",
+        "1,1,\n" + "2,1,\n" + "3,1,\n" + "4,1,\n" + "5,1,\n" + "6,1,\n" + "7,1,\n" + "8,1,\n"
+            + "9,1,\n" + "10,1,\n",
+        "DELETE FROM root.123.456.789 WHERE time < 8", "SELECT * FROM root.123.456",
+        "8,1,\n" + "9,1,\n" + "10,1,\n",
+        "INSERT INTO root.123.456(timestamp,789) values(2000-01-01T08:00:00+08:00,1)",
+        "SELECT * FROM root.123.456", "8,1,\n" + "9,1,\n" + "10,1,\n" + "946684800000,1,\n",
+        "DELETE FROM root.123.456.789 WHERE time < 2000-01-02T08:00:00+08:00",
+        "SELECT * FROM root.123.456", "",
+        "INSERT INTO root.123.456(timestamp,789) values(NOW(),1)",
+        "SELECT * FROM root.123.456", "NOW(),1,\n",
+        "DELETE FROM root.123.456.789 WHERE time <= NOW()",
+        "SELECT * FROM root.123.456", "",
+        "CREATE TIMESERIES root.123.d1.000 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,789) values(1,1)",
+        "INSERT INTO root.123.d1(timestamp,000) values(1,1)",
+        "INSERT INTO root.123.456(timestamp,789) values(5,5)",
+        "INSERT INTO root.123.d1(timestamp,000) values(5,5)",
+        "SELECT * FROM root.123",
+        "1,1,1,\n" + "5,5,5,\n",
+        "DELETE FROM root.123.456.789,root.123.d1.000 WHERE time < 3",
+        "SELECT * FROM root.123", "5,5,5,\n", "DELETE FROM root.123.* WHERE time < 7",
+        "SELECT * FROM root.123", "", "DELETE TIMESERIES root.123.*"};
+    executeSQL(sqlS);
+  }
+
+  public void selectTest() throws ClassNotFoundException, SQLException {
+    String[] sqlS = {"CREATE TIMESERIES root.123.456.789 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,789) values(1,101)",
+        "INSERT INTO root.123.456(timestamp,789) values(2,102)",
+        "INSERT INTO root.123.456(timestamp,789) values(3,103)",
+        "INSERT INTO root.123.456(timestamp,789) values(4,104)",
+        "INSERT INTO root.123.456(timestamp,789) values(5,105)",
+        "INSERT INTO root.123.456(timestamp,789) values(6,106)",
+        "INSERT INTO root.123.456(timestamp,789) values(7,107)",
+        "INSERT INTO root.123.456(timestamp,789) values(8,108)",
+        "INSERT INTO root.123.456(timestamp,789) values(9,109)",
+        "INSERT INTO root.123.456(timestamp,789) values(10,110)",
+        "SELECT * FROM root.123.456 WHERE 789 < 104", "1,101,\n" + "2,102,\n" + "3,103,\n",
+        "SELECT * FROM root.123.456 WHERE 789 > 105 and time < 8", "6,106,\n" + "7,107,\n",
+        "SELECT * FROM root.123.456",
+        "1,101,\n" + "2,102,\n" + "3,103,\n" + "4,104,\n" + "5,105,\n"
+            + "6,106,\n" + "7,107,\n" + "8,108,\n" + "9,109,\n" + "10,110,\n",
+        "DELETE TIMESERIES root.123.*"};
+    executeSQL(sqlS);
+  }
+
+  public void funcTest() throws ClassNotFoundException, SQLException {
+    String[] sqlS = {"CREATE TIMESERIES root.123.456.789 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,789) values(1,110)",
+        "INSERT INTO root.123.456(timestamp,789) values(2,109)",
+        "INSERT INTO root.123.456(timestamp,789) values(3,108)",
+        "INSERT INTO root.123.456(timestamp,789) values(4,107)",
+        "INSERT INTO root.123.456(timestamp,789) values(5,106)",
+        "INSERT INTO root.123.456(timestamp,789) values(6,105)",
+        "INSERT INTO root.123.456(timestamp,789) values(7,104)",
+        "INSERT INTO root.123.456(timestamp,789) values(8,103)",
+        "INSERT INTO root.123.456(timestamp,789) values(9,102)",
+        "INSERT INTO root.123.456(timestamp,789) values(10,101)",
+        "SELECT COUNT(789) FROM root.123.456",
+        "0,10,\n", "SELECT COUNT(789) FROM root.123.456 WHERE root.123.456.789 < 105", "0,4,\n",
+        "SELECT MAX_TIME(789) FROM root.123.456", "0,10,\n",
+        "SELECT MAX_TIME(789) FROM root.123.456 WHERE root.123.456.789 > 105", "0,5,\n",
+        "SELECT MIN_TIME(789) FROM root.123.456", "0,1,\n",
+        "SELECT MIN_TIME(789) FROM root.123.456 WHERE root.123.456.789 < 106", "0,6,\n",
+        "SELECT MAX_VALUE(789) FROM root.123.456", "0,110,\n",
+        "SELECT MAX_VALUE(789) FROM root.123.456 WHERE time > 4", "0,106,\n",
+        "SELECT MIN_VALUE(789) FROM root.123.456", "0,101,\n",
+        "SELECT MIN_VALUE(789) FROM root.123.456 WHERE time < 5", "0,107,\n",
+        "DELETE FROM root.123.456.789 WHERE time <= 10",
+        "INSERT INTO root.123.456(timestamp,789) values(NOW(),5)",
+        "SELECT * FROM root.123.456",
+        "NOW(),5,\n", "UPDATE root.123.456 SET 789 = 10 WHERE time <= NOW()",
+        "SELECT * FROM root.123.456",
+        "NOW(),10,\n", "DELETE FROM root.123.456.789 WHERE time <= NOW()",
+        "SELECT * FROM root.123.456",
+        "",
+        "DELETE TIMESERIES root.123.*"};
+    executeSQL(sqlS);
+  }
+
+  public void funcTestWithOutTimeGenerator() throws ClassNotFoundException, SQLException {
+    String[] sqlS = {"CREATE TIMESERIES root.123.456.789 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,789) values(1,110)",
+        "INSERT INTO root.123.456(timestamp,789) values(2,109)",
+        "INSERT INTO root.123.456(timestamp,789) values(3,108)",
+        "INSERT INTO root.123.456(timestamp,789) values(4,107)",
+        "INSERT INTO root.123.456(timestamp,789) values(5,106)",
+        "INSERT INTO root.123.456(timestamp,789) values(6,105)",
+        "INSERT INTO root.123.456(timestamp,789) values(7,104)",
+        "INSERT INTO root.123.456(timestamp,789) values(8,103)",
+        "INSERT INTO root.123.456(timestamp,789) values(9,102)",
+        "INSERT INTO root.123.456(timestamp,789) values(10,101)",
+        "SELECT COUNT(789) FROM root.123.456", "0,10,\n",
+        "SELECT MAX_TIME(789) FROM root.123.456", "0,10,\n",
+        "SELECT MIN_TIME(789) FROM root.123.456", "0,1,\n",
+        "SELECT MAX_VALUE(789) FROM root.123.456", "0,110,\n",
+        "SELECT MAX_VALUE(789) FROM root.123.456 WHERE time > 4", "0,106,\n",
+        "SELECT SUM(789) FROM root.123.456 WHERE time > 4", "0,621.0,\n",
+        "SELECT MIN_VALUE(789) FROM root.123.456", "0,101,\n",
+        "SELECT MIN_VALUE(789) FROM root.123.456 WHERE time < 5", "0,107,\n",
+        "DELETE FROM root.123.456.789 WHERE time <= 10",
+        "INSERT INTO root.123.456(timestamp,789) values(NOW(),5)",
+        "SELECT * FROM root.123.456",
+        "NOW(),5,\n","DELETE FROM root.123.456.789 WHERE time <= NOW()",
+        "SELECT * FROM root.123.456","",
+        "SELECT COUNT(789) FROM root.123.456", "0,0,\n",
+        "SELECT MAX_TIME(789) FROM root.123.456", "",
+        "SELECT MIN_TIME(789) FROM root.123.456", "",
+        "SELECT MAX_VALUE(789) FROM root.123.456", "",
+        "SELECT MAX_VALUE(789) FROM root.123.456 WHERE time > 4", "",
+        "SELECT MIN_VALUE(789) FROM root.123.456", "",
+        "SELECT MIN_VALUE(789) FROM root.123.456 WHERE time < 5", "",
+        "DELETE TIMESERIES root.123.*"};
+    executeSQL(sqlS);
+  }
+
+  public void groupByTest() throws ClassNotFoundException, SQLException {
+    String[] sqlS = {"CREATE TIMESERIES root.123.456.789 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,789) values(1,110)",
+        "INSERT INTO root.123.456(timestamp,789) values(2,109)",
+        "INSERT INTO root.123.456(timestamp,789) values(3,108)",
+        "INSERT INTO root.123.456(timestamp,789) values(4,107)",
+        "INSERT INTO root.123.456(timestamp,789) values(5,106)",
+        "INSERT INTO root.123.456(timestamp,789) values(6,105)",
+        "INSERT INTO root.123.456(timestamp,789) values(7,104)",
+        "INSERT INTO root.123.456(timestamp,789) values(8,103)",
+        "INSERT INTO root.123.456(timestamp,789) values(9,102)",
+        "INSERT INTO root.123.456(timestamp,789) values(10,101)",
+        "CREATE TIMESERIES root.123.456.000 WITH DATATYPE=INT32,ENCODING=RLE",
+        "INSERT INTO root.123.456(timestamp,000) values(1,101)",
+        "INSERT INTO root.123.456(timestamp,000) values(2,102)",
+        "INSERT INTO root.123.456(timestamp,000) values(3,103)",
+        "INSERT INTO root.123.456(timestamp,000) values(4,104)",
+        "INSERT INTO root.123.456(timestamp,000) values(5,105)",
+        "INSERT INTO root.123.456(timestamp,000) values(6,106)",
+        "INSERT INTO root.123.456(timestamp,000) values(7,107)",
+        "INSERT INTO root.123.456(timestamp,000) values(8,108)",
+        "INSERT INTO root.123.456(timestamp,000) values(9,109)",
+        "INSERT INTO root.123.456(timestamp,000) values(10,110)",
+        "SELECT COUNT(789), COUNT(000) FROM root.123.456 WHERE 000 < 109 GROUP BY(4ms,[1,10])",
+        "1,3,3,\n" + "4,4,4,\n" + "8,1,1,\n",
+        "SELECT COUNT(789), MAX_VALUE(000) FROM root.123.456 WHERE time < 7 GROUP BY(3ms,2,[1,5])",
+        "1,1,101,\n" + "2,3,104,\n" + "5,1,105,\n",
+        "SELECT MIN_VALUE(789), MAX_TIME(000) FROM root.123.456 WHERE 000 > 102 and time < 9 GROUP BY(3ms,1,[1,4],[6,9])",
+        "1,108,3,\n" + "4,105,6,\n" + "7,103,8,\n",
+        "DELETE TIMESERIES root.123.*"};
+    executeSQL(sqlS);
+  }
+
+  private void executeSQL(String[] sqls) throws ClassNotFoundException, SQLException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    Connection connection = null;
+    try {
+      String result = "";
+      Long now_start = 0L;
+      boolean cmp = false;
+      connection = DriverManager
+          .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+      for (String sql : sqls) {
+        if (cmp) {
+          Assert.assertEquals(sql, result);
+          cmp = false;
+        } else if (sql.equals("SHOW TIMESERIES")) {
+          DatabaseMetaData data = connection.getMetaData();
+          result = data.toString();
+          cmp = true;
+        } else {
+          if (sql.contains("NOW()") && now_start == 0L) {
+            now_start = System.currentTimeMillis();
+          }
+          Statement statement = connection.createStatement();
+          statement.execute(sql);
+          if (sql.split(" ")[0].equals("SELECT")) {
+            ResultSet resultSet = statement.getResultSet();
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            int count = metaData.getColumnCount();
+            String[] column = new String[count];
+            for (int i = 0; i < count; i++) {
+              column[i] = metaData.getColumnName(i + 1);
+            }
+            result = "";
+            while (resultSet.next()) {
+              for (int i = 1; i <= count; i++) {
+                if (now_start > 0L && column[i - 1] == Constant.TIMESTAMP_STR) {
+                  String timestr = resultSet.getString(i);
+                  Long tn = Long.valueOf(timestr);
+                  Long now = System.currentTimeMillis();
+                  if (tn >= now_start && tn <= now) {
+                    timestr = "NOW()";
+                  }
+                  result += timestr + ',';
+                } else {
+                  result += resultSet.getString(i) + ',';
+                }
+              }
+              result += '\n';
+            }
+            cmp = true;
+          }
+          statement.close();
+        }
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    } finally {
+      if (connection != null) {
+        connection.close();
+      }
+    }
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
@@ -71,25 +71,29 @@ public class PhysicalPlanTest {
     Path path4 = new Path(
         new StringContainer(new String[]{"root", "vehicle", "d4", "s1"},
             TsFileConstant.PATH_SEPARATOR));
-    processor.getExecutor().insert(new InsertPlan(path1.getDevice(), 10, path1.getMeasurement(), "10"));
-    processor.getExecutor().insert(new InsertPlan(path2.getDevice(), 10, path2.getMeasurement(), "10"));
-    processor.getExecutor().insert(new InsertPlan(path3.getDevice(), 10, path3.getMeasurement(), "10"));
-    processor.getExecutor().insert(new InsertPlan(path4.getDevice(), 10, path4.getMeasurement(), "10"));
+    processor.getExecutor()
+        .insert(new InsertPlan(path1.getDevice(), 10, path1.getMeasurement(), "10"));
+    processor.getExecutor()
+        .insert(new InsertPlan(path2.getDevice(), 10, path2.getMeasurement(), "10"));
+    processor.getExecutor()
+        .insert(new InsertPlan(path3.getDevice(), 10, path3.getMeasurement(), "10"));
+    processor.getExecutor()
+        .insert(new InsertPlan(path4.getDevice(), 10, path4.getMeasurement(), "10"));
   }
 
   @Test
   public void testMetadata()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
-    String metadata = "create timeseries root.vehicle.d1.s1 with datatype=INT32,encoding=RLE";
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String metadata = "create timeseries root.vehicle.d1.s2 with datatype=INT32,encoding=RLE";
     QueryProcessor processor = new QueryProcessor(new MemIntQpExecutor());
     MetadataPlan plan = (MetadataPlan) processor.parseSQLToPhysicalPlan(metadata);
-    assertEquals(String.format("seriesPath: root.vehicle.d1.s1%n" + "resultDataType: INT32%n" +
+    assertEquals(String.format("seriesPath: root.vehicle.d1.s2%n" + "resultDataType: INT32%n" +
         "encoding: RLE%nnamespace type: ADD_PATH%n" + "args: "), plan.toString());
   }
 
   @Test
   public void testAuthor()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sql = "grant role xm privileges 'SET_STORAGE_GROUP','DELETE_TIMESERIES' on root.vehicle.d1.s1";
     QueryProcessor processor = new QueryProcessor(new MemIntQpExecutor());
     AuthorPlan plan = (AuthorPlan) processor.parseSQLToPhysicalPlan(sql);
@@ -101,7 +105,7 @@ public class PhysicalPlanTest {
 
   @Test
   public void testProperty()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sql = "add label label1021 to property propropro";
     QueryProcessor processor = new QueryProcessor(new MemIntQpExecutor());
     PropertyPlan plan = (PropertyPlan) processor.parseSQLToPhysicalPlan(sql);
@@ -115,7 +119,7 @@ public class PhysicalPlanTest {
 
   @Test
   public void testAggregation()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr = "select sum(d1.s1) " + "from root.vehicle "
         + "where time <= 51 or !(time != 100 and time < 460)";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
@@ -128,7 +132,7 @@ public class PhysicalPlanTest {
 
   @Test
   public void testGroupBy1()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr =
         "select count(s1) " + "from root.vehicle.d1 " + "where s1 < 20 and time <= now() "
             + "group by(10m, 44, [1,3], [4,5])";
@@ -142,7 +146,7 @@ public class PhysicalPlanTest {
 
   @Test
   public void testGroupBy2()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr =
         "select count(s1) " + "from root.vehicle.d1 " + "where s1 < 20 and time <= now() "
             + "group by(111ms, [123,2017-6-2T12:00:12+07:00], [55555, now()])";
@@ -156,7 +160,7 @@ public class PhysicalPlanTest {
 
   @Test
   public void testFill1()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time = 5000 Fill(int32[linear, 5m, 5m], boolean[previous, 5m])";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     if (!plan.isQuery()) {
@@ -174,7 +178,7 @@ public class PhysicalPlanTest {
 
   @Test
   public void testFill2()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time = 5000 Fill(int32[linear], boolean[previous])";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     if (!plan.isQuery()) {
@@ -199,7 +203,7 @@ public class PhysicalPlanTest {
   }
 
   @Test
-  public void testFill4() throws QueryProcessorException, ArgsErrorException {
+  public void testFill4() {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 5000 Fill(int32[linear], boolean[previous])";
     try {
       PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
@@ -210,7 +214,7 @@ public class PhysicalPlanTest {
 
   @Test
   public void testQuery1()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 5000";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((QueryPlan) plan).getExpression();
@@ -220,7 +224,7 @@ public class PhysicalPlanTest {
 
   @Test
   public void testQuery2()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 50 and time <= 100";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((QueryPlan) plan).getExpression();
@@ -232,26 +236,26 @@ public class PhysicalPlanTest {
 
   @Test
   public void testQuery3()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 50 and time <= 100 or s1 < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((QueryPlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(
         FilterFactory.and(TimeFilter.gt(50L), TimeFilter.ltEq(100L)));
     expect = BinaryExpression.or(expect,
-        new SingleSeriesExpression(new Path("root.vehicle.d1.s1"), ValueFilter.lt(10)));
+        new SingleSeriesExpression(new Path("root.vehicle.d1.s1"), ValueFilter.lt(10.0)));
     assertEquals(expect.toString(), queryFilter.toString());
   }
 
   @Test
   public void testQuery4()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 50 and time <= 100 and s1 < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((QueryPlan) plan).getExpression();
 
     IExpression expect = BinaryExpression.and(
-        new SingleSeriesExpression(new Path("root.vehicle.d1.s1"), ValueFilter.lt(10)),
+        new SingleSeriesExpression(new Path("root.vehicle.d1.s1"), ValueFilter.lt(10.0)),
         new GlobalTimeExpression(FilterFactory.and(TimeFilter.gt(50L), TimeFilter.ltEq(100L))));
 
     assertEquals(expect.toString(), queryFilter.toString());
@@ -262,19 +266,19 @@ public class PhysicalPlanTest {
 
   @Test
   public void testQuery5()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 20 or s1 < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((QueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
-        FilterFactory.or(ValueFilter.gt(20), ValueFilter.lt(10)));
+        FilterFactory.or(ValueFilter.gt(20.0), ValueFilter.lt(10.0)));
     assertEquals(expect.toString(), queryFilter.toString());
 
   }
 
   @Test
   public void testQuery6()
-      throws QueryProcessorException, ArgsErrorException, ProcessorException, MetadataErrorException {
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 20 or time < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
     IExpression queryFilter = ((QueryPlan) plan).getExpression();
@@ -284,4 +288,80 @@ public class PhysicalPlanTest {
 
   }
 
+  @Test
+  public void testQueryFloat1()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 20.5e3";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(20.5e3));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat2()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 20.5E-3";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(20.5e-3));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat3()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.5";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(2.5));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat4()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > +2.5";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(2.5));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat5()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -2.5";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(-2.5));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat6()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -2.5E-1";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(-2.5e-1));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat7()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > +2.5E+2";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(2.5e+2));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
@@ -364,4 +364,81 @@ public class PhysicalPlanTest {
         ValueFilter.gt(2.5e+2));
     assertEquals(expect.toString(), queryFilter.toString());
   }
+
+  @Test
+  public void testQueryFloat8()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > .2e2";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(0.2e+2));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat9()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > .2";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(0.2));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat10()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(2.0));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat11()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > +2.";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(2.0));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat12()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -2.";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(-2.0));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat13()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -.2";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(-0.2));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
+
+  @Test
+  public void testQueryFloat14()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -.2e2";
+    PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
+    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
+        ValueFilter.gt(-20.0));
+    assertEquals(expect.toString(), queryFilter.toString());
+  }
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/utils/MemIntQpExecutor.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/utils/MemIntQpExecutor.java
@@ -26,11 +26,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.TreeSet;
-
 import org.apache.iotdb.db.conf.IoTDBConstant;
-import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.PathErrorException;
 import org.apache.iotdb.db.exception.ProcessorException;
+import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.db.qp.executor.AbstractQueryProcessExecutor;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
@@ -78,7 +77,7 @@ public class MemIntQpExecutor extends AbstractQueryProcessExecutor {
       return TSDataType.INT32;
     }
     if (demoMemDataBase.containsKey(fullPath.toString())) {
-      return TSDataType.INT32;
+      return TSDataType.FLOAT;
     }
     return null;
   }

--- a/server/src/test/java/org/apache/iotdb/db/sql/SQLParserTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sql/SQLParserTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import org.antlr.runtime.RecognitionException;
 import org.apache.iotdb.db.sql.parse.AstNode;
 import org.apache.iotdb.db.sql.parse.Node;
 import org.apache.iotdb.db.sql.parse.ParseException;
@@ -42,7 +41,9 @@ public class SQLParserTest {
             "TOK_CLAUSE",
             "freq_encoding", "DFT", "TOK_CLAUSE", "write_main_freq", "true", "TOK_CLAUSE",
             "dft_pack_length", "300",
-            "TOK_CLAUSE", "dft_rate", "0.4", "TOK_CLAUSE", "write_encoding", "False"));
+            "TOK_CLAUSE", "dft_rate",
+            "TOK_FLOAT_COMB", "0", ".", "4",
+            "TOK_CLAUSE", "write_encoding", "False"));
     ArrayList<String> rec = new ArrayList<>();
     AstNode astTree = ParseGenerator
         .generateAST("create timeseries root.laptop.d0.s2 with datatype=FLOAT"
@@ -395,7 +396,7 @@ public class SQLParserTest {
   // }
 
   @Test
-  public void deleteTimeseires1() throws ParseException, RecognitionException {
+  public void deleteTimeseires1() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_DELETE", "TOK_TIMESERIES", "TOK_PATH", "TOK_ROOT", "dt", "a", "b", "d1",
@@ -413,7 +414,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void deleteTimeseires2() throws ParseException, RecognitionException {
+  public void deleteTimeseires2() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_DELETE", "TOK_TIMESERIES", "TOK_PATH", "TOK_ROOT", "*"));
@@ -430,7 +431,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void deleteTimeseires3() throws ParseException, RecognitionException {
+  public void deleteTimeseires3() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_DELETE", "TOK_TIMESERIES", "TOK_PATH", "TOK_ROOT",
@@ -448,18 +449,20 @@ public class SQLParserTest {
   }
 
   @Test
-  public void query1() throws ParseException, RecognitionException {
+  public void query1() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
-        Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "device_1",
-            "sensor_1", "TOK_PATH", "device_2", "sensor_2", "TOK_FROM", "TOK_PATH", "TOK_ROOT",
-            "vehicle",
-            "TOK_WHERE", "and", "not", "<", "TOK_PATH", "TOK_ROOT", "laptop", "device_1",
-            "sensor_1", "2000", ">",
-            "TOK_PATH", "TOK_ROOT", "laptop", "device_2", "sensor_2", "1000"));
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE", "and",
+            "not", "<", "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1", "2000",
+            ">", "TOK_PATH", "TOK_ROOT", "laptop", "device_2", "sensor_2", "1000"));
     ArrayList<String> rec = new ArrayList<>();
     AstNode astTree = ParseGenerator.generateAST(
-        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle WHERE not(root.laptop.device_1.sensor_1 < 2000) and root.laptop.device_2.sensor_2 > 1000");
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle WHERE "
+            + "not(root.laptop.device_1.sensor_1 < 2000) and root.laptop.device_2.sensor_2 > 1000");
     astTree = ParseUtils.findRootNonNullToken(astTree);
     recursivePrintSon(astTree, rec);
 
@@ -471,18 +474,20 @@ public class SQLParserTest {
   }
 
   @Test
-  public void query2() throws ParseException, RecognitionException {
+  public void query2() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
-        Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "device_1",
-            "sensor_1", "TOK_PATH", "device_2", "sensor_2", "TOK_FROM", "TOK_PATH", "TOK_ROOT",
-            "vehicle",
-            "TOK_WHERE", "&&", "<", "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1",
-            "-2.2E10", ">",
-            "TOK_PATH", "time", "TOK_DATETIME", "now"));
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<", "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1", "-2.2E10"
+        ));
     ArrayList<String> rec = new ArrayList<>();
     AstNode astTree = ParseGenerator.generateAST(
-        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle WHERE root.laptop.device_1.sensor_1 < -2.2E10 && time > now();");
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < -2.2E10;");
     astTree = ParseUtils.findRootNonNullToken(astTree);
     recursivePrintSon(astTree, rec);
 
@@ -494,17 +499,19 @@ public class SQLParserTest {
   }
 
   @Test
-  public void query3() throws ParseException, RecognitionException {
+  public void query3() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
-        Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "device_1", "sensor_1", "TOK_PATH",
-            "device_2",
-            "sensor_2", "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle", "TOK_WHERE", "&", "<",
-            "TOK_PATH",
-            "time", "1234567", ">", "TOK_PATH", "time", "TOK_DATETIME", "2017-6-2T12:00:12+07:00"));
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<", "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1", "+2.2E10"));
     ArrayList<String> rec = new ArrayList<>();
     AstNode astTree = ParseGenerator.generateAST(
-        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle WHERE time < 1234567 & time > 2017-6-2T12:00:12+07:00");
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < +2.2E10");
     astTree = ParseUtils.findRootNonNullToken(astTree);
     recursivePrintSon(astTree, rec);
 
@@ -519,14 +526,19 @@ public class SQLParserTest {
   public void query4() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
-        Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "*", "TOK_FROM",
-            "TOK_PATH", "TOK_ROOT", "vehicle", "TOK_WHERE", "||", "<", "TOK_PATH", "time",
-            "1234567", ">",
-            "TOK_PATH", "time", "TOK_DATETIME", "2017-6-2T12:00:12+07:00"));
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1",
+            "TOK_FLOAT_COMB", "2", ".2E10"
+        ));
     ArrayList<String> rec = new ArrayList<>();
-    AstNode astTree = ParseGenerator
-        .generateAST(
-            "SELECT * FROM root.vehicle WHERE time < 1234567 || time > 2017-6-2T12:00:12+07:00;");
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < 2.2E10");
     astTree = ParseUtils.findRootNonNullToken(astTree);
     recursivePrintSon(astTree, rec);
 
@@ -538,15 +550,216 @@ public class SQLParserTest {
   }
 
   @Test
-  public void aggregation1() throws ParseException, RecognitionException {
+  public void query5() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1", "-2.2"
+        ));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < -2.2");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query6() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1", "+2.2"
+        ));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < +2.2");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query7() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1",
+            "TOK_FLOAT_COMB", "2", ".", "2"
+        ));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < 2.2");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query8() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE", "&&",
+            "<", "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1", "-2.2E10",
+            ">", "TOK_PATH", "time", "TOK_DATETIME", "now"));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < -2.2E10 && time > now();");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query9() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE", "&",
+            "<", "TOK_PATH", "time", "1234567",
+            ">", "TOK_PATH", "time", "TOK_DATETIME", "2017-6-2T12:00:12+07:00"));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE time < 1234567 & time > 2017-6-2T12:00:12+07:00");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query10() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "*",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE", "||",
+            "<", "TOK_PATH", "time", "1234567",
+            ">", "TOK_PATH", "time", "TOK_DATETIME", "2017.6.2 12:00:12+07:00"));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator
+        .generateAST(
+            "SELECT * FROM root.vehicle WHERE time < 1234567 || time > 2017.6.2 12:00:12+07:00;");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query11() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "456", "*", "890",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle", "123", "abc",
+            "TOK_WHERE", "<",
+            "TOK_PATH", "TOK_ROOT", "333", "222", "11"));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator
+        .generateAST(
+            "SELECT 456.*.890 FROM root.vehicle.123.abc WHERE root.333.222 < 11");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query12() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "000",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle", "123", "abc",
+            "TOK_WHERE", "<",
+            "TOK_PATH", "000", "11"));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator
+        .generateAST(
+            "SELECT 000 FROM root.vehicle.123.abc WHERE 000 < 11");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void aggregation1() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "TOK_CLUSTER",
             "TOK_PATH", "s1", "count", "TOK_PATH", "TOK_CLUSTER", "TOK_PATH", "s2", "max_time",
             "TOK_FROM",
-            "TOK_PATH", "TOK_ROOT", "vehicle", "d1", "TOK_WHERE", "and", "<", "TOK_PATH",
-            "TOK_ROOT", "vehicle",
-            "d1", "s1", "0.32e6", "<=", "TOK_PATH", "time", "TOK_DATETIME", "now"));
+            "TOK_PATH", "TOK_ROOT", "vehicle", "d1",
+            "TOK_WHERE", "and",
+            "<", "TOK_PATH", "TOK_ROOT", "vehicle", "d1", "s1", "TOK_FLOAT_COMB", "0", ".32e6",
+            "<=", "TOK_PATH", "time",
+            "TOK_DATETIME", "now"));
     ArrayList<String> rec = new ArrayList<>();
     AstNode astTree = ParseGenerator.generateAST(
         "select count(s1),max_time(s2) from root.vehicle.d1 where root.vehicle.d1.s1 < 0.32e6 and time <= now()");
@@ -561,7 +774,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void aggregation2() throws ParseException, RecognitionException {
+  public void aggregation2() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "TOK_CLUSTER",
@@ -582,7 +795,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void aggregation3() throws ParseException, RecognitionException {
+  public void aggregation3() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "s1", "TOK_PATH", "TOK_CLUSTER",
@@ -604,15 +817,16 @@ public class SQLParserTest {
   }
 
   @Test
-  public void groupby1() throws ParseException, RecognitionException {
+  public void groupby1() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "TOK_CLUSTER",
             "TOK_PATH", "s1", "count", "TOK_PATH", "TOK_CLUSTER", "TOK_PATH", "s2", "max_time",
             "TOK_FROM",
-            "TOK_PATH", "TOK_ROOT", "vehicle", "d1", "TOK_WHERE", "and", "<", "TOK_PATH",
-            "TOK_ROOT", "vehicle",
-            "d1", "s1", "0.32e6", "<=", "TOK_PATH", "time", "TOK_DATETIME", "now", "TOK_GROUPBY",
+            "TOK_PATH", "TOK_ROOT", "vehicle", "d1",
+            "TOK_WHERE", "and",
+            "<", "TOK_PATH", "TOK_ROOT", "vehicle", "d1", "s1", "TOK_FLOAT_COMB", "0", ".32e6",
+            "<=", "TOK_PATH", "time", "TOK_DATETIME", "now", "TOK_GROUPBY",
             "TOK_TIMEUNIT",
             "10", "w", "TOK_TIMEORIGIN", "44", "TOK_TIMEINTERVAL", "TOK_TIMEINTERVALPAIR", "1", "3",
             "TOK_TIMEINTERVALPAIR", "4", "5"));
@@ -632,7 +846,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void groupby2() throws ParseException, RecognitionException {
+  public void groupby2() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "TOK_CLUSTER",
@@ -659,7 +873,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void groupby3() throws ParseException, RecognitionException {
+  public void groupby3() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "s1", "TOK_PATH",
@@ -974,15 +1188,15 @@ public class SQLParserTest {
    *
    */
   @Test
-  public void limit6() throws ParseException, RecognitionException {
+  public void limit6() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT", "TOK_PATH", "TOK_CLUSTER",
             "TOK_PATH", "s1", "count", "TOK_PATH", "TOK_CLUSTER", "TOK_PATH", "s2", "max_time",
             "TOK_FROM",
-            "TOK_PATH", "TOK_ROOT", "vehicle", "*", "TOK_WHERE", "and", "<", "TOK_PATH", "TOK_ROOT",
-            "vehicle",
-            "d1", "s1", "0.32e6", "<=", "TOK_PATH", "time", "TOK_DATETIME", "now", "TOK_GROUPBY",
+            "TOK_PATH", "TOK_ROOT", "vehicle", "*", "TOK_WHERE", "and",
+            "<", "TOK_PATH", "TOK_ROOT", "vehicle", "d1", "s1", "TOK_FLOAT_COMB", "0", ".32e6",
+            "<=", "TOK_PATH", "time", "TOK_DATETIME", "now", "TOK_GROUPBY",
             "TOK_TIMEUNIT",
             "10", "w", "TOK_TIMEORIGIN", "44", "TOK_TIMEINTERVAL", "TOK_TIMEINTERVALPAIR", "1", "3",
             "TOK_TIMEINTERVALPAIR", "4", "5", "TOK_SLIMIT", "1", "TOK_SOFFSET", "1", "TOK_LIMIT",
@@ -1349,7 +1563,7 @@ public class SQLParserTest {
 
   // others
   @Test
-  public void describePath() throws ParseException, RecognitionException {
+  public void describePath() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(Arrays.asList("TOK_DESCRIBE", "TOK_PATH", "TOK_ROOT"));
     ArrayList<String> rec = new ArrayList<>();
@@ -1365,7 +1579,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void createIndex1() throws ParseException, RecognitionException {
+  public void createIndex1() throws ParseException {
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_CREATE", "TOK_INDEX", "TOK_PATH", "TOK_ROOT", "a",
             "b", "c", "TOK_FUNC", "kvindex", "TOK_WITH", "TOK_INDEX_KV", "window_length", "50",
@@ -1386,7 +1600,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void createIndex2() throws ParseException, RecognitionException {
+  public void createIndex2() throws ParseException {
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_CREATE", "TOK_INDEX", "TOK_PATH", "TOK_ROOT", "a",
             "b", "c", "TOK_FUNC", "kv-match2", "TOK_WITH", "TOK_INDEX_KV", "xxx", "50",
@@ -1407,11 +1621,12 @@ public class SQLParserTest {
   }
 
   @Test
-  public void selectIndex1() throws ParseException, RecognitionException {
+  public void selectIndex1() throws ParseException {
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT_INDEX", "subsequence_matching",
             "TOK_PATH", "TOK_ROOT", "a", "b", "c", "TOK_PATH", "TOK_ROOT", "a", "b", "c", "123",
-            "132", "123.1",
+            "132",
+            "TOK_FLOAT_COMB", "123", ".", "1",
             "TOK_WHERE", "<", "TOK_PATH", "time", "10"));
     ArrayList<String> rec = new ArrayList<>();
     AstNode astTree = ParseGenerator.generateAST(
@@ -1427,12 +1642,15 @@ public class SQLParserTest {
   }
 
   @Test
-  public void selectIndex2() throws ParseException, RecognitionException {
+  public void selectIndex2() throws ParseException {
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT_INDEX", "subsequence_matching",
             "TOK_PATH", "TOK_ROOT", "a", "b", "c", "TOK_PATH", "TOK_ROOT", "a", "b", "c", "123",
-            "132", "123.1",
-            "0.123", "0.5", "TOK_FROM", "TOK_PATH", "TOK_ROOT", "a", "b"));
+            "132",
+            "TOK_FLOAT_COMB", "123", ".", "1",
+            "TOK_FLOAT_COMB", "0", ".", "123",
+            "TOK_FLOAT_COMB", "0", ".", "5",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "a", "b"));
     ArrayList<String> rec = new ArrayList<>();
     // AstNode astTree = ParseGenerator.generateAST("select index kvindex(root.vehicle.d0.s0, root.vehicle.d0.s0, 1,
     // 3, 0.0, 1.0, 0.0) from root.vehicle.d0.s0");
@@ -1449,11 +1667,15 @@ public class SQLParserTest {
   }
 
   @Test
-  public void selectIndex3() throws ParseException, RecognitionException {
+  public void selectIndex3() throws ParseException {
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT_INDEX", "kvindex", "TOK_PATH",
             "TOK_ROOT", "a", "b", "c", "TOK_PATH", "TOK_ROOT", "a", "b", "c", "TOK_DATETIME",
-            "2016-11-16T16:22:33+08:00", "TOK_DATETIME", "now", "123.1", "0.123", "0.5"));
+            "2016-11-16T16:22:33+08:00", "TOK_DATETIME", "now",
+            "TOK_FLOAT_COMB", "123", ".", "1",
+            "TOK_FLOAT_COMB", "0", ".", "123",
+            "TOK_FLOAT_COMB", "0", ".", "5"
+        ));
     ArrayList<String> rec = new ArrayList<>();
     AstNode astTree = ParseGenerator.generateAST(
         "select index kvindex(root.a.b.c, root.a.b.c, 2016-11-16T16:22:33+08:00, now() , 123.1, 0.123, 0.5)");
@@ -1468,7 +1690,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void dropIndex() throws ParseException, RecognitionException {
+  public void dropIndex() throws ParseException {
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_DROP", "TOK_INDEX", "TOK_PATH", "TOK_ROOT", "a", "b", "c", "TOK_FUNC",
             "kvindex"));

--- a/server/src/test/java/org/apache/iotdb/db/sql/SQLParserTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sql/SQLParserTest.java
@@ -636,6 +636,195 @@ public class SQLParserTest {
             "TOK_PATH", "device_1", "sensor_1",
             "TOK_PATH", "device_2", "sensor_2",
             "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1",
+            ".2e2"
+        ));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < .2e2");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query9() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1",
+            "TOK_FLOAT_COMB", ".", "2"
+        ));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < .2");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query10() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1",
+            "2"
+        ));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < 2.");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query11() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1",
+            "+2"
+        ));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < +2.");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query12() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1",
+            "-2"
+        ));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < -2.");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query13() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1",
+            "-.2"
+        ));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < -.2");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query14() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
+            "TOK_WHERE",
+            "<",
+            "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1",
+            "-.2e10"
+        ));
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator.generateAST(
+        "SELECT device_1.sensor_1,device_2.sensor_2 FROM root.vehicle "
+            + "WHERE root.laptop.device_1.sensor_1 < -.2e10");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(rec.get(i), ans.get(i));
+      i++;
+    }
+  }
+
+  @Test
+  public void query15() throws ParseException {
+    // template for test case
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "device_1", "sensor_1",
+            "TOK_PATH", "device_2", "sensor_2",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "vehicle",
             "TOK_WHERE", "&&",
             "<", "TOK_PATH", "TOK_ROOT", "laptop", "device_1", "sensor_1", "-2.2E10",
             ">", "TOK_PATH", "time", "TOK_DATETIME", "now"));
@@ -654,7 +843,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void query9() throws ParseException {
+  public void query16() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT",
@@ -679,7 +868,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void query10() throws ParseException {
+  public void query17() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT",
@@ -703,7 +892,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void query11() throws ParseException {
+  public void query18() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT",
@@ -726,7 +915,7 @@ public class SQLParserTest {
   }
 
   @Test
-  public void query12() throws ParseException {
+  public void query19() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT",


### PR DESCRIPTION
To support series path in number format, we have the following logic in TSParser.g already:
```
nodeName
    : identifier
    | STAR
    ;

identifier
    :
    Identifier | integer
    ;
```

Then the main challenge left here is to teach antlr3 to recognize `integer` in the series path, which is easy to be confused with and recognized as `Float`, `DATETIME` partly because of the "Longest match wins first" rule of Antlr3.

For example,
 
|  integer   |                           float                            |                      datetime                      | seriesPath in the number format |
|------------|------------------------------------------------------------|----------------------------------------------------|------------------------------|
| +12 / -12 / 12 | +12.233 / -12.233 / +12.3332e-1 / -12.3332e+2  / 12.3332 / 12.3332e-1 | 2017-11-1T00:15:00+08:00 / 2017.11.1 00:15:00+08:00 | 8955.1227.223        |

The solution is to do a more elaborate division and some are directly recognized in TSLexer and some are later combined in TSParser: 

In TSLexer, we have:
- PositiveInteger, e.g., `+12`
- NegativeInteger, e.g., `-12`
- PositiveFloat, e.g., `+12.233`, `+12.3332e-1 `
- NegativeFloat, e.g., `-12.233`, `-12.3332e-1 `
NOTE that the existence of '+' and '-' help ease the match rule. For those without signs, things get tricky as follows.
- UnsignedInteger, e.g., `12`
- DATETIME, e.g., `2017.11.1 00:15:00+08:00`. 
NOTE that here an critical trick is used (see code). If the first lexer rule of DATETIME is not matched, then UnsignedInteger is recognized instead.
- DoubleInScientificNotationSuffix, e.g., `.E+10`. 
NOTE that here the same critical trick is used (see code). If the first rule is not matched, then DOT is recognized instead.

In TSParser, we have:
- nonNegativeInteger (which is needed by LIMIT&SLIMIT clause)
- integer
- floatValue
NOTE that "float" shoud not be used as a name as it is reserved.
NOTE that the old FLOAT in the TSLexer is removed and floatValue in TSParser is used instead. It is because we want to support series path in the number format, **which can not be separated from the float number in the lexer level**.

As a result, 
- integer and float with signs (+ or -) will each be recognized as a single token. For example, `+12`, `-12`, `+2.3`, `-2.3e10`
- float without signs will be recognized as a set led by `TOK_FLOAT_COMB`. For example, 
  - `2.3` -> `TOK_FLOAT_COMB`, `2`, `.`, `3` (corresponding to `UnsignedInteger DOT UnsignedInteger`)
  - `2.3e10` -> `TOK_FLOAT_COMB`, `2`, `.3e10` (corresponding to `UnsignedInteger DoubleInScientificNotationSuffix`)


Lastly, some notes for user guide:
- The first nodeName of a seriesPath still must be `root`, e.g., root.123.456.789
- The other nodeNames will support three formats:
  - Identifier. i.e., string starts with letter('a'..'z' | 'A'..'Z') or  '_'
  - integer
  - STAR (i.e., *)