### PR TITLE
[IOTDB-157]Add show dynamic parameters

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -59,6 +59,8 @@ public class IoTDBConstant {
 
   public static final String SHOW_FLUSH_TASK_INFO = "show\\s+flush\\s+task\\s+info";
 
+  public static final String SHOW_DYNAMIC_PARAMETERS = "show\\s+dynamic\\s+parameters";
+
   public static final String ROLE = "Role";
   public static final String USER = "User";
   public static final String PRIVILEGE = "Privilege";

--- a/server/src/main/java/org/apache/iotdb/db/conf/adapter/CompressionRatio.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/adapter/CompressionRatio.java
@@ -95,7 +95,7 @@ public class CompressionRatio {
   /**
    * Get the average compression ratio for all closed files
    */
-  synchronized double getRatio() {
+  public synchronized double getRatio() {
     return calcTimes == 0 ? DEFAULT_COMPRESSION_RATIO : compressionRatioSum / calcTimes;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/adapter/IoTDBConfigDynamicAdapter.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/adapter/IoTDBConfigDynamicAdapter.java
@@ -241,7 +241,7 @@ public class IoTDBConfigDynamicAdapter implements IDynamicAdapter {
     return currentMemTableSize;
   }
 
-  int getTotalTimeseries() {
+  public int getTotalTimeseries() {
     return totalTimeseries;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/adapter/IoTDBConfigDynamicAdapter.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/adapter/IoTDBConfigDynamicAdapter.java
@@ -107,6 +107,8 @@ public class IoTDBConfigDynamicAdapter implements IDynamicAdapter {
    */
   private long staticMemory;
 
+  private int totalStorageGroup;
+
   private int totalTimeseries;
 
   // MemTable section
@@ -207,12 +209,14 @@ public class IoTDBConfigDynamicAdapter implements IDynamicAdapter {
    */
   @Override
   public void addOrDeleteStorageGroup(int diff) throws ConfigAdjusterException {
+    totalStorageGroup += diff;
     maxMemTableNum += 4 * diff;
     if(!CONFIG.isEnableParameterAdapter()){
       CONFIG.setMaxMemtableNumber(maxMemTableNum);
       return;
     }
     if (!tryToAdaptParameters()) {
+      totalStorageGroup -= diff;
       maxMemTableNum -= 4 * diff;
       throw new ConfigAdjusterException(
           "The IoTDB system load is too large to create storage group.");
@@ -243,6 +247,10 @@ public class IoTDBConfigDynamicAdapter implements IDynamicAdapter {
 
   public int getTotalTimeseries() {
     return totalTimeseries;
+  }
+
+  public int getTotalStorageGroup() {
+    return totalStorageGroup;
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/conf/adapter/ManageDynamicParameters.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/adapter/ManageDynamicParameters.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.conf.adapter;
+
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.exception.StartupException;
+import org.apache.iotdb.db.metadata.MManager;
+import org.apache.iotdb.db.service.IService;
+import org.apache.iotdb.db.service.JMXService;
+import org.apache.iotdb.db.service.ServiceType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is to get and set dynamic parameters through JMX.
+ */
+public class ManageDynamicParameters implements ManageDynamicParametersMBean, IService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ManageDynamicParameters.class);
+
+  private static final IoTDBConfig CONFIG = IoTDBDescriptor.getInstance().getConfig();
+
+  private final String mbeanName = String
+      .format("%s:%s=%s", IoTDBConstant.IOTDB_PACKAGE, IoTDBConstant.JMX_TYPE,
+          getID().getJmxName());
+
+  private ManageDynamicParameters() {
+
+  }
+
+  public static ManageDynamicParameters getInstance() {
+    return ManageDynamicParametersHolder.INSTANCE;
+  }
+
+  @Override
+  public void showDynamicParameters() {
+    LOGGER.info(
+        "Memtable size threshold: {}B, Memtable number: {}, Tsfile size threshold: {}B, Compression ratio: {}, "
+            + "Storage group number: {}, Timeseries number: {}, Maximal timeseries number among storage groups: {}",
+        CONFIG.getMemtableSizeThreshold(), CONFIG.getMaxMemtableNumber(),
+        CONFIG.getTsFileSizeThreshold(), CompressionRatio.getInstance().getRatio(),
+        IoTDBConfigDynamicAdapter.getInstance().getTotalStorageGroup(),
+        IoTDBConfigDynamicAdapter.getInstance().getTotalTimeseries(),
+        MManager.getInstance().getMaximalSeriesNumberAmongStorageGroups());
+  }
+
+  @Override
+  public boolean isEnableDynamicAdapter() {
+    return CONFIG.isEnableParameterAdapter();
+  }
+
+  @Override
+  public void setEnableDynamicAdapter(boolean enableDynamicAdapter) {
+    CONFIG.setEnableParameterAdapter(enableDynamicAdapter);
+  }
+
+  @Override
+  public long getMemTableSizeThreshold() {
+    return CONFIG.getMemtableSizeThreshold();
+  }
+
+  @Override
+  public void setMemTableSizeThreshold(long memTableSizeThreshold) {
+    CONFIG.setMemtableSizeThreshold(memTableSizeThreshold);
+  }
+
+  @Override
+  public int getMemTableNumber() {
+    return CONFIG.getMaxMemtableNumber();
+  }
+
+  @Override
+  public void setMemTableNumber(int memTableNumber) {
+    CONFIG.setMaxMemtableNumber(memTableNumber);
+  }
+
+  @Override
+  public long getTsfileSizeThreshold() {
+    return CONFIG.getTsFileSizeThreshold();
+  }
+
+  @Override
+  public void setTsfileSizeThreshold(long tsfileSizeThreshold) {
+    CONFIG.setTsFileSizeThreshold(tsfileSizeThreshold);
+  }
+
+  @Override
+  public void start() throws StartupException {
+    try {
+      JMXService.registerMBean(getInstance(), mbeanName);
+      LOGGER.info("{}: start {}...", IoTDBConstant.GLOBAL_DB_NAME, this.getID().getName());
+    } catch (Exception e) {
+      LOGGER.error("Failed to start {} because: ", this.getID().getName(), e);
+      throw new StartupException(e);
+    }
+  }
+
+  @Override
+  public void stop() {
+    JMXService.deregisterMBean(mbeanName);
+    LOGGER.info("{}: stop {}...", IoTDBConstant.GLOBAL_DB_NAME, this.getID().getName());
+  }
+
+  @Override
+  public ServiceType getID() {
+    return ServiceType.MANAGE_DYNAMIC_PARAMETERS_SERVICE;
+  }
+
+  private static class ManageDynamicParametersHolder {
+
+    private static final ManageDynamicParameters INSTANCE = new ManageDynamicParameters();
+
+    private ManageDynamicParametersHolder() {
+
+    }
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/conf/adapter/ManageDynamicParametersMBean.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/adapter/ManageDynamicParametersMBean.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.conf.adapter;
+
+public interface ManageDynamicParametersMBean {
+
+  /**
+   * Show all dynamic parameters, including memtable size threshold, memtable number, tsfile size
+   * threshold, compression ratio, storage group number, timeseries number, max timeseries number
+   * among storage groups.
+   */
+  void showDynamicParameters();
+
+  boolean isEnableDynamicAdapter();
+
+  void setEnableDynamicAdapter(boolean enableDynamicAdapter);
+
+  long getMemTableSizeThreshold();
+
+  void setMemTableSizeThreshold(long memTableSizeThreshold);
+
+  int getMemTableNumber();
+
+  void setMemTableNumber(int memTableNumber);
+
+  long getTsfileSizeThreshold();
+
+  void setTsfileSizeThreshold(long tsfileSizeThreshold);
+
+}

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.db.concurrent.IoTDBDefaultThreadExceptionHandler;
 import org.apache.iotdb.db.conf.IoTDBConfigCheck;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.conf.adapter.ManageDynamicParameters;
 import org.apache.iotdb.db.conf.adapter.IoTDBConfigDynamicAdapter;
 import org.apache.iotdb.db.cost.statistic.Measurement;
 import org.apache.iotdb.db.engine.StorageEngine;
@@ -98,6 +99,7 @@ public class IoTDB implements IoTDBMBean {
     registerManager.register(Monitor.getInstance());
     registerManager.register(StatMonitor.getInstance());
     registerManager.register(Measurement.INSTANCE);
+    registerManager.register(ManageDynamicParameters.getInstance());
     registerManager.register(SyncServerManager.getInstance());
     registerManager.register(TVListAllocator.getInstance());
     registerManager.register(FlushManager.getInstance());

--- a/server/src/main/java/org/apache/iotdb/db/service/ServiceType.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/ServiceType.java
@@ -32,6 +32,7 @@ public enum ServiceType {
   FILE_READER_MANAGER_SERVICE("File reader manager ServerService", ""),
   SYNC_SERVICE("SYNC ServerService", ""),
   PERFORMANCE_STATISTIC_SERVICE("PERFORMANCE_STATISTIC_SERVICE","PERFORMANCE_STATISTIC_SERVICE"),
+  MANAGE_DYNAMIC_PARAMETERS_SERVICE("Manage Dynamic Parameters", "Manage Dynamic Parameters"),
   TVLIST_ALLOCATOR_SERVICE("TVList Allocator", ""),
   FLUSH_SERVICE("Flush ServerService", "");
 

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -503,8 +503,8 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
 
       if (execShowDynamicParameters(statement)) {
         String msg = String.format(
-            "Memtable size threshold: %dB , Memtable number: %d , Tsfile size threshold: %dB , Compression ratio: %f ,"
-                + "Storage group number: %d , Timeseries number: %d, Maximal timeseries number among storage groups: %d",
+            "Memtable size threshold: %dB, Memtable number: %d, Tsfile size threshold: %dB, Compression ratio: %f,"
+                + " Storage group number: %d, Timeseries number: %d, Maximal timeseries number among storage groups: %d",
             IoTDBDescriptor.getInstance().getConfig().getMemtableSizeThreshold(),
             IoTDBDescriptor.getInstance().getConfig().getMaxMemtableNumber(),
             IoTDBDescriptor.getInstance().getConfig().getTsFileSizeThreshold(),

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -42,6 +42,8 @@ import org.apache.iotdb.db.auth.authorizer.LocalFileAuthorizer;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.conf.adapter.CompressionRatio;
+import org.apache.iotdb.db.conf.adapter.IoTDBConfigDynamicAdapter;
 import org.apache.iotdb.db.cost.statistic.Measurement;
 import org.apache.iotdb.db.cost.statistic.Operation;
 import org.apache.iotdb.db.engine.StorageEngine;
@@ -499,6 +501,20 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         return getTSExecuteStatementResp(TS_StatusCode.SUCCESS_WITH_INFO_STATUS, msg);
       }
 
+      if (execShowDynamicParameters(statement)) {
+        String msg = String.format(
+            "Memtable size threshold: %dB , Memtable number: %d , Tsfile size threshold: %dB , Compression ratio: %f ,"
+                + "Storage group number: %d , Timeseries number: %d, Maximal timeseries number among storage groups: %d",
+            IoTDBDescriptor.getInstance().getConfig().getMemtableSizeThreshold(),
+            IoTDBDescriptor.getInstance().getConfig().getMaxMemtableNumber(),
+            IoTDBDescriptor.getInstance().getConfig().getTsFileSizeThreshold(),
+            CompressionRatio.getInstance().getRatio(),
+            MManager.getInstance().getAllStorageGroup().size(),
+            IoTDBConfigDynamicAdapter.getInstance().getTotalTimeseries(),
+            MManager.getInstance().getMaximalSeriesNumberAmongStorageGroups());
+        return getTSExecuteStatementResp(TS_StatusCode.SUCCESS_WITH_INFO_STATUS, msg);
+      }
+
       if (execSetConsistencyLevel(statement)) {
         return getTSExecuteStatementResp(TS_StatusCode.SUCCESS_WITH_INFO_STATUS,
             "Execute set consistency level successfully");
@@ -522,7 +538,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
   }
 
   /**
-   * Set consistency level
+   * Show flush info
    */
   private boolean execShowFlushInfo(String statement) {
     if (statement == null) {
@@ -530,6 +546,21 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     }
     statement = statement.toLowerCase().trim();
     if (Pattern.matches(IoTDBConstant.SHOW_FLUSH_TASK_INFO, statement)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Show dynamic parameters
+   */
+  private boolean execShowDynamicParameters(String statement) {
+    if (statement == null) {
+      return false;
+    }
+    statement = statement.toLowerCase().trim();
+    if (Pattern.matches(IoTDBConstant.SHOW_DYNAMIC_PARAMETERS, statement)) {
       return true;
     } else {
       return false;


### PR DESCRIPTION
Add show dynamic parameters through JDBC and JMX while IoTDB is running, including memtable size threshold, memtable number, tsfile size threshold, compression ratio, storage group number, timeseries number, max timeseries number among storage groups.

1. JDBC:
Usage: show dynamic parameters
Example:
![image](https://user-images.githubusercontent.com/26211279/61991082-e885e380-b07d-11e9-8af2-e925ca447ecf.png)
2. JMX:
Usage: Jconsle or other tools to connect JMX.
Example:
![image](https://user-images.githubusercontent.com/26211279/61993730-8d1a1c80-b0a2-11e9-9e72-84176cfbaf65.png)
![image](https://user-images.githubusercontent.com/26211279/61993732-9efbbf80-b0a2-11e9-87c8-e2d8818cc95f.png)

What's more, you can modify dynamic parameters through JMX, including memtable size threshold, memtable number, tsfile size threshold. 


jira link:  https://issues.apache.org/jira/browse/IOTDB-157