### PR TITLE
fix start-walchecker scripts for leting user define the wal folder

### DIFF
--- a/server/src/assembly/resources/tools/start-WalChecker.bat
+++ b/server/src/assembly/resources/tools/start-WalChecker.bat
@@ -85,8 +85,12 @@ REM ----------------------------------------------------------------------------
 :okClasspath
 
 rem echo CLASSPATH: %CLASSPATH%
-set IOTDB_DATA=%IOTDB_HOME%\data
-set IOTDB_WAL=%IOTDB_DATA%\wal
+set IOTDB_WAL=%1
+
+IF "%IOTDB_WAL%"=="" (
+    echo "please input the wal folder."
+    goto finally
+    )
 
 IF EXIST "%IOTDB_WAL%" (
     "%JAVA_HOME%\bin\java" %JAVA_OPTS% %IOTDB_HEAP_OPTS% -cp %CLASSPATH% %IOTDB_JMX_OPTS% %MAIN_CLASS% %IOTDB_WAL%

--- a/server/src/assembly/resources/tools/start-WalChecker.sh
+++ b/server/src/assembly/resources/tools/start-WalChecker.sh
@@ -74,11 +74,16 @@ launch_service()
 # Start up the service
 #launch_service "$classname"
 
-if [ ! -d ${IOTDB_HOME}/data/wal ]; then
-    echo "Can't find wal directory." 
+if [ $# -ne 1 ]; then
+    echo "please input the wal folder."
+exit 1;
+fi
+
+if [ ! -d ${1} ]; then
+    echo "Can't find wal directory. ${1}" 
     exit 1;
 else
-    WALPATH=${IOTDB_HOME}/data/wal
+    WALPATH=${1}
     launch_service "$classname"    
 fi
 


### PR DESCRIPTION
As many users do not set IoTDB_HOME... the script will fail. Therefore, letting user assign the folder is better.

The better way is if $IOTDB_HOME is empty, then let user assign that.. 