### PR TITLE
increase configuration parameters of cache

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -157,6 +157,16 @@ concurrent_flush_thread=0
 # (i.e., whether use ChunkBufferPool), value true, false
 chunk_buffer_pool_enable = false
 
+####################
+### Metadata Cache Configuration
+####################
+
+# whether to cache meta data(ChunkMetaData and TsFileMetaData) or not.
+meta_data_cache_enable=true
+# Read memory Allocation Ratio: FileMetaDataCache, ChunkMetaDataCache, and Free Memory Used in Query.
+# The parameter form is a:b:c, where a, b and c are integers. for example: 1:1:1 , 3:6:10
+filemeta_chunkmeta_free_memory_proportion=3:6:10
+
 
 ####################
 ### Statistics Monitor configuration

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -99,7 +99,7 @@ public class IoTDBConfig {
   private String systemDir = "data/system";
 
   /**
-   *  Schema directory, including storage set of values.
+   * Schema directory, including storage set of values.
    */
   private String schemaDir = "data/system/schema";
 
@@ -155,6 +155,20 @@ public class IoTDBConfig {
    * When a memTable's size (in byte) exceeds this, the memtable is flushed to disk.
    */
   private long memtableSizeThreshold = 128 * 1024 * 1024L;
+
+  /**
+   * whether to cache meta data(ChunkMetaData and TsFileMetaData) or not.
+   */
+  private boolean metaDataCacheEnable = true;
+  /**
+   * Memory allocated for fileMetaData cache in read process
+   */
+  private long allocateMemoryForFileMetaDataCache = allocateMemoryForRead * 3 / 19;
+
+  /**
+   * Memory allocated for chunkMetaData cache in read process
+   */
+  private long allocateMemoryForChumkMetaDataCache = allocateMemoryForRead * 6 / 19;
 
   /**
    * The statMonitor writes statistics info into IoTDB every backLoopPeriodSec secs. The default
@@ -617,5 +631,29 @@ public class IoTDBConfig {
 
   public void setMemtableSizeThreshold(long memtableSizeThreshold) {
     this.memtableSizeThreshold = memtableSizeThreshold;
+  }
+
+  public boolean isMetaDataCacheEnable() {
+    return metaDataCacheEnable;
+  }
+
+  public void setMetaDataCacheEnable(boolean metaDataCacheEnable) {
+    this.metaDataCacheEnable = metaDataCacheEnable;
+  }
+
+  public long getAllocateMemoryForFileMetaDataCache() {
+    return allocateMemoryForFileMetaDataCache;
+  }
+
+  public void setAllocateMemoryForFileMetaDataCache(long allocateMemoryForFileMetaDataCache) {
+    this.allocateMemoryForFileMetaDataCache = allocateMemoryForFileMetaDataCache;
+  }
+
+  public long getAllocateMemoryForChumkMetaDataCache() {
+    return allocateMemoryForChumkMetaDataCache;
+  }
+
+  public void setAllocateMemoryForChumkMetaDataCache(long allocateMemoryForChumkMetaDataCache) {
+    this.allocateMemoryForChumkMetaDataCache = allocateMemoryForChumkMetaDataCache;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -281,10 +281,17 @@ public class IoTDBDescriptor {
         proportionSum += Integer.parseInt(proportion.trim());
       }
       long maxMemoryAvailable = conf.getAllocateMemoryForRead();
-      conf.setAllocateMemoryForFileMetaDataCache(
-          maxMemoryAvailable * Integer.parseInt(proportions[0].trim()) / proportionSum);
-      conf.setAllocateMemoryForChumkMetaDataCache(
-          maxMemoryAvailable * Integer.parseInt(proportions[1].trim()) / proportionSum);
+      try {
+        conf.setAllocateMemoryForFileMetaDataCache(
+            maxMemoryAvailable * Integer.parseInt(proportions[0].trim()) / proportionSum);
+        conf.setAllocateMemoryForChumkMetaDataCache(
+            maxMemoryAvailable * Integer.parseInt(proportions[1].trim()) / proportionSum);
+      } catch (Exception e) {
+        throw new RuntimeException(
+            "Each subsection of configuration item filemeta_chunkmeta_free_memory_proportion should be an integer, which is "
+                + queryMemoryAllocateProportion);
+      }
+
     }
 
   }

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -130,6 +130,10 @@ public class IoTDBDescriptor {
           Boolean.parseBoolean(properties.getProperty("enable_parameter_adapter",
               Boolean.toString(conf.isEnableParameterAdapter()))));
 
+      conf.setMetaDataCacheEnable(
+          Boolean.parseBoolean(properties.getProperty("meta_data_cache_enable",
+              Boolean.toString(conf.isMetaDataCacheEnable()))));
+
       initMemoryAllocate(properties);
 
       conf.setEnableWal(Boolean.parseBoolean(properties.getProperty("enable_wal",
@@ -263,6 +267,26 @@ public class IoTDBDescriptor {
       conf.setAllocateMemoryForRead(
           maxMemoryAvailable * Integer.parseInt(proportions[1].trim()) / proportionSum);
     }
+
+    if (!conf.isMetaDataCacheEnable()) {
+      return;
+    }
+
+    String queryMemoryAllocateProportion = properties
+        .getProperty("filemeta_chunkmeta_free_memory_proportion");
+    if (queryMemoryAllocateProportion != null) {
+      String[] proportions = queryMemoryAllocateProportion.split(":");
+      int proportionSum = 0;
+      for (String proportion : proportions) {
+        proportionSum += Integer.parseInt(proportion.trim());
+      }
+      long maxMemoryAvailable = conf.getAllocateMemoryForRead();
+      conf.setAllocateMemoryForFileMetaDataCache(
+          maxMemoryAvailable * Integer.parseInt(proportions[0].trim()) / proportionSum);
+      conf.setAllocateMemoryForChumkMetaDataCache(
+          maxMemoryAvailable * Integer.parseInt(proportions[1].trim()) / proportionSum);
+    }
+
   }
 
   private static class IoTDBDescriptorHolder {

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/DeviceMetaDataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/DeviceMetaDataCache.java
@@ -46,8 +46,8 @@ public class DeviceMetaDataCache {
 
   private static StorageEngine storageEngine = StorageEngine.getInstance();
 
-  private static final long MEMORY_THRESHOLD_IN_B = (long) (0.3 * config
-      .getAllocateMemoryForRead());
+  private static boolean cacheEnable = config.isMetaDataCacheEnable();
+  private static final long MEMORY_THRESHOLD_IN_B = config.getAllocateMemoryForChumkMetaDataCache();
   /**
    * key: file path dot deviceId dot sensorId.
    * <p>
@@ -64,6 +64,9 @@ public class DeviceMetaDataCache {
   private long chunkMetaDataSize = 0;
 
   private DeviceMetaDataCache(long memoryThreshold) {
+    if (!cacheEnable) {
+      return;
+    }
     lruCache = new LRULinkedHashMap<String, List<ChunkMetaData>>(memoryThreshold, true) {
       @Override
       protected long calEntrySize(String key, List<ChunkMetaData> value) {
@@ -84,6 +87,13 @@ public class DeviceMetaDataCache {
    */
   public List<ChunkMetaData> get(String filePath, Path seriesPath)
       throws IOException {
+    if (!cacheEnable) {
+      TsFileMetaData fileMetaData = TsFileMetaDataCache.getInstance().get(filePath);
+      TsDeviceMetadata deviceMetaData = TsFileMetadataUtils
+          .getTsDeviceMetaData(filePath, seriesPath, fileMetaData);
+      return TsFileMetadataUtils.getChunkMetaDataList(seriesPath.getMeasurement(), deviceMetaData);
+    }
+
     StringBuilder builder = new StringBuilder(filePath).append(".").append(seriesPath.getDevice());
     String pathDeviceStr = builder.toString();
     String key = builder.append(".").append(seriesPath.getMeasurement()).toString();
@@ -117,7 +127,7 @@ public class DeviceMetaDataCache {
       TsDeviceMetadata deviceMetaData = TsFileMetadataUtils
           .getTsDeviceMetaData(filePath, seriesPath, fileMetaData);
       // If measurement isn't included in the tsfile, empty list is returned.
-      if(deviceMetaData == null){
+      if (deviceMetaData == null) {
         return new ArrayList<>();
       }
       Map<Path, List<ChunkMetaData>> chunkMetaData = TsFileMetadataUtils
@@ -169,7 +179,9 @@ public class DeviceMetaDataCache {
    */
   public void clear() {
     synchronized (lruCache) {
-      lruCache.clear();
+      if (lruCache != null) {
+        lruCache.clear();
+      }
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TsFileMetadataUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TsFileMetadataUtils.java
@@ -98,4 +98,20 @@ public class TsFileMetadataUtils {
     return pathToChunkMetaDataList;
   }
 
+  public static List<ChunkMetaData> getChunkMetaDataList(String sensor,
+      TsDeviceMetadata tsDeviceMetadata) {
+    List<ChunkMetaData> chunkMetaDataList = new ArrayList<>();
+    for (ChunkGroupMetaData chunkGroupMetaData : tsDeviceMetadata.getChunkGroupMetaDataList()) {
+      List<ChunkMetaData> chunkMetaDataListInOneChunkGroup = chunkGroupMetaData
+          .getChunkMetaDataList();
+
+      for (ChunkMetaData chunkMetaData : chunkMetaDataListInOneChunkGroup) {
+        if (sensor.equals(chunkMetaData.getMeasurementUid())) {
+          chunkMetaData.setVersion(chunkGroupMetaData.getVersion());
+          chunkMetaDataList.add(chunkMetaData);
+        }
+      }
+    }
+    return chunkMetaDataList;
+  }
 }


### PR DESCRIPTION
Adding configuration parameters to metadata caching module：
1、Is enable cache  parameter.
2、Memory occupancy ratio parameters of tsFileMetaData cache and chunkMetaData cache.