### PR TITLE
[IOTDB-172]fix a bug of TsFileResource updateTime 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/cost/statistic/Measurement.java
+++ b/server/src/main/java/org/apache/iotdb/db/cost/statistic/Measurement.java
@@ -253,7 +253,7 @@ public class Measurement implements MeasurementMBean, IService {
       service = IoTDBThreadPoolFactory.newScheduledThreadPool(
           2, ThreadName.TIME_COST_STATSTIC.getName());
     }
-    //we have to check again because someone may channge the value.
+    //we have to check again because someone may change the value.
     isEnableStat = IoTDBDescriptor.getInstance().getConfig().isEnablePerformanceStat();
     if (isEnableStat) {
       consumeFuture = service.schedule(new QueueConsumerThread(), 0, TimeUnit.MILLISECONDS);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -170,7 +170,7 @@ public class StorageGroupProcessor {
         logger.info("Storage Group system Directory {} doesn't exist, create it",
             storageGroupSysDir.getPath());
       } else if (!storageGroupSysDir.exists()) {
-        logger.error("craete Storage Group system Directory {} failed",
+        logger.error("create Storage Group system Directory {} failed",
             storageGroupSysDir.getPath());
       }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -221,6 +221,7 @@ public class TsFileResource {
     return processor;
   }
 
+  @Deprecated
   public void updateTime(String deviceId, long time) {
     startTimeMap.putIfAbsent(deviceId, time);
     Long endTime = endTimeMap.get(deviceId);

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -220,13 +220,4 @@ public class TsFileResource {
   public TsFileProcessor getUnsealedFileProcessor() {
     return processor;
   }
-
-  @Deprecated
-  public void updateTime(String deviceId, long time) {
-    startTimeMap.putIfAbsent(deviceId, time);
-    Long endTime = endTimeMap.get(deviceId);
-    if (endTime == null || endTime < time) {
-      endTimeMap.put(deviceId, time);
-    }
-  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/writelog/recover/LogReplayer.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/recover/LogReplayer.java
@@ -103,8 +103,8 @@ public class LogReplayer {
     } finally {
       logReader.close();
     }
-    tempStartTimeMap.forEach((k, v) -> currentTsFileResource.updateTime(k, v));
-    tempEndTimeMap.forEach((k, v) -> currentTsFileResource.updateTime(k, v));
+    tempStartTimeMap.forEach((k, v) -> currentTsFileResource.updateStartTime(k, v));
+    tempEndTimeMap.forEach((k, v) -> currentTsFileResource.updateEndTime(k, v));
   }
 
   private void replayDelete(DeletePlan deletePlan) throws IOException {

--- a/server/src/main/java/org/apache/iotdb/db/writelog/recover/LogReplayer.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/recover/LogReplayer.java
@@ -24,10 +24,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.memtable.IMemTable;
 import org.apache.iotdb.db.engine.modification.Deletion;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.version.VersionController;
 import org.apache.iotdb.db.exception.ProcessorException;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
@@ -123,7 +123,10 @@ public class LogReplayer {
           !acceptDuplication) {
         return;
       }
-      tempStartTimeMap.putIfAbsent(insertPlan.getDeviceId(), insertPlan.getTime());
+      Long startTime = tempStartTimeMap.get(insertPlan.getDeviceId());
+      if (startTime == null || startTime > insertPlan.getTime()) {
+        tempStartTimeMap.put(insertPlan.getDeviceId(), insertPlan.getTime());
+      }
       Long endTime = tempEndTimeMap.get(insertPlan.getDeviceId());
       if (endTime == null || endTime < insertPlan.getTime()) {
         tempEndTimeMap.put(insertPlan.getDeviceId(), insertPlan.getTime());

--- a/server/src/test/java/org/apache/iotdb/db/writelog/recover/SeqTsFileRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/recover/SeqTsFileRecoverTest.java
@@ -48,10 +48,12 @@ import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint;
 import org.apache.iotdb.tsfile.write.schema.FileSchema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class SeqTsFileRecoverTest {
+
   private File tsF;
   private TsFileWriter writer;
   private WriteLogNode node;
@@ -60,6 +62,7 @@ public class SeqTsFileRecoverTest {
   private TsFileResource resource;
   private VersionController versionController = new VersionController() {
     private int i;
+
     @Override
     public long nextVersion() {
       return ++i;
@@ -83,9 +86,16 @@ public class SeqTsFileRecoverTest {
     }
     writer = new TsFileWriter(tsF, schema);
 
+    TSRecord tsRecord = new TSRecord(100, "device99");
+    tsRecord.addTuple(DataPoint.getDataPoint(TSDataType.INT64, "sensor4", String.valueOf(0)));
+    writer.write(tsRecord);
+    tsRecord = new TSRecord(2, "device99");
+    tsRecord.addTuple(DataPoint.getDataPoint(TSDataType.INT64, "sensor1", String.valueOf(0)));
+    writer.write(tsRecord);
+
     for (int i = 0; i < 10; i++) {
       for (int j = 0; j < 10; j++) {
-        TSRecord tsRecord = new TSRecord(i, "device" + j);
+        tsRecord = new TSRecord(i, "device" + j);
         for (int k = 0; k < 10; k++) {
           tsRecord.addTuple(DataPoint.getDataPoint(TSDataType.INT64, "sensor" + k,
               String.valueOf(k)));
@@ -126,6 +136,13 @@ public class SeqTsFileRecoverTest {
         versionController, resource, true);
     performer.recover();
 
+    assertEquals(2, (long) resource.getStartTimeMap().get("device99"));
+    assertEquals(100, (long) resource.getEndTimeMap().get("device99"));
+    for (int i = 0; i < 10; i++) {
+      assertEquals(0, (long) resource.getStartTimeMap().get("device" + i));
+      assertEquals(19, (long) resource.getEndTimeMap().get("device" + i));
+    }
+
     ReadOnlyTsFile readOnlyTsFile = new ReadOnlyTsFile(new TsFileSequenceReader(tsF.getPath()));
     List<Path> pathList = new ArrayList<>();
     for (int j = 0; j < 10; j++) {
@@ -144,6 +161,19 @@ public class SeqTsFileRecoverTest {
         assertEquals(j % 10, fields.get(j).getLongV());
       }
     }
+
+    pathList = new ArrayList<>();
+    pathList.add(new Path("device99", "sensor1"));
+    pathList.add(new Path("device99", "sensor4"));
+    queryExpression = QueryExpression.create(pathList, null);
+    dataSet = readOnlyTsFile.query(queryExpression);
+    Assert.assertTrue(dataSet.hasNext());
+    RowRecord record = dataSet.next();
+    Assert.assertEquals("2\t0\tnull", record.toString());
+    Assert.assertTrue(dataSet.hasNext());
+    record = dataSet.next();
+    Assert.assertEquals("100\tnull\t0", record.toString());
+
     readOnlyTsFile.close();
   }
 }


### PR DESCRIPTION
Bug Description: 
When recovering a TsFile's `device -> start time` and `device -> end time` map and the TsFile's resource file happens not to exist, the TsFile itself will be read to update the start and end time map instead. It is implemented by `TsFileRecoverPerformer.recover` as follows:
```
for (TsDeviceMetadataIndex index : deviceMetadataIndexList) {
  TsDeviceMetadata deviceMetadata = reader.readTsDeviceMetaData(index);
  List<ChunkGroupMetaData> chunkGroupMetaDataList = deviceMetadata.getChunkGroupMetaDataList();
  for (ChunkGroupMetaData chunkGroupMetaData : chunkGroupMetaDataList) {
    for (ChunkMetaData chunkMetaData : chunkGroupMetaData.getChunkMetaDataList()) {
      tsFileResource.updateTime(chunkGroupMetaData.getDeviceID(), chunkMetaData.getStartTime());
      tsFileResource.updateTime(chunkGroupMetaData.getDeviceID(), chunkMetaData.getEndTime());
    }
  }
}
```
The `updateTime` function uses the first-coming value as the startTime:
```
  public void updateTime(String deviceId, long time) {
    startTimeMap.putIfAbsent(deviceId, time);
    Long endTime = endTimeMap.get(deviceId);
    if (endTime == null || endTime < time) {
      endTimeMap.put(deviceId, time);
    }
  }
```
So when root.vehicle.d0 has a chunkgroup of chunkMetadata listed as:
s3: startTime=3000, endTime=10000;
s1: startTime=1000, endTime=10000;
s2: startTime=2000, endTime=10000;
By the current code, the updated start time will be the first coming 3000, which is not correct.

---

By the way, I also change `updateTime` in `LogReplayer.replayLogs` to `updateStartTime` and `updateEndTime`. If there is something I haven't noticed, please tell me.