### PR TITLE
[IoTDB-174]Add interfaces for querying device or timeseries number

### DIFF
--- a/docs/Documentation/UserGuide/6-JDBC API/1-JDBC API.md
+++ b/docs/Documentation/UserGuide/6-JDBC API/1-JDBC API.md
@@ -63,6 +63,7 @@ Requires that you include the packages containing the JDBC classes needed for da
 import java.sql.*;
 import org.apache.iotdb.jdbc.IoTDBSQLException;
 
+public class JDBCExample {
   /**
    * Before executing a SQL statement with a Statement object, you need to create a Statement object using the createStatement() method of the Connection object.
    * After creating a Statement object, you can use its execute() method to execute a SQL statement
@@ -98,6 +99,16 @@ import org.apache.iotdb.jdbc.IoTDBSQLException;
     //Show time series
     statement.execute("SHOW TIMESERIES root.demo");
     outputResult(statement.getResultSet());
+    //Count time series
+    statement.execute("COUNT TIMESERIES root");
+    outputResult(statement.getResultSet());
+    //Count nodes at the given level
+    statement.execute("COUNT NODES root LEVEL=3");
+    outputResult(statement.getResultSet());
+    //Count timeseries group by each node at the given level
+    statement.execute("COUNT TIMESERIES root GROUP BY LEVEL=3");
+    outputResult(statement.getResultSet());
+    
 
     //Execute insert statements in batch
     statement.addBatch("insert into root.demo(timestamp,s0) values(1,1);");
@@ -187,4 +198,5 @@ import org.apache.iotdb.jdbc.IoTDBSQLException;
       System.out.println("--------------------------\n");
     }
   }
+}
 ```

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Constant.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Constant.java
@@ -32,6 +32,12 @@ public class Constant {
 
   public static final String GLOBAL_SHOW_TIMESERIES_REQ = "SHOW_TIMESERIES";
 
+  public static final String GLOBAL_COUNT_TIMESERIES_REQ = "COUNT_TIMESERIES";
+
+  public static final String GLOBAL_COUNT_NODE_TIMESERIES_REQ = "COUNT_NODE_TIMESERIES";
+
+  public static final String GLOBAL_COUNT_NODES_REQ = "COUNT_NODES";
+
   public static final String GLOBAL_SHOW_STORAGE_GROUP_REQ = "SHOW_STORAGE_GROUP";
 
   public static final String GLOBAL_COLUMNS_REQ = "ALL_COLUMNS";
@@ -41,4 +47,7 @@ public class Constant {
   public static final String CATALOG_TIMESERIES = "ts";
   public static final String CATALOG_STORAGE_GROUP = "sg";
   public static final String CATALOG_DEVICE = "delta";
+  public static final String COUNT_TIMESERIES = "cntts";
+  public static final String COUNT_NODE_TIMESERIES = "cnttsbg";
+  public static final String COUNT_NODES = "cntnode";
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBMetadataResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBMetadataResultSet.java
@@ -20,19 +20,17 @@ package org.apache.iotdb.jdbc;
 
 import java.math.BigDecimal;
 import java.sql.Date;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.SQLWarning;
-import java.sql.Statement;
-import java.sql.Time;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.sql.*;
+import java.util.*;
 
 public class IoTDBMetadataResultSet extends IoTDBQueryResultSet {
 
   public static final String GET_STRING_COLUMN = "COLUMN";
   public static final String GET_STRING_STORAGE_GROUP = "STORAGE_GROUP";
+  public static final String GET_STRING_TIMESERIES_NUM = "TIMESERIES_NUM";
+  public static final String GET_STRING_NODES_NUM = "NODE_NUM";
+  public static final String GET_STRING_NODE_PATH = "NODE_PATH";
+  public static final String GET_STRING_NODE_TIMESERIES_NUM = "NODE_TIMESERIES_NUM";
   public static final String GET_STRING_TIMESERIES_NAME = "Timeseries";
   public static final String GET_STRING_TIMESERIES_STORAGE_GROUP = "Storage Group";
   public static final String GET_STRING_TIMESERIES_DATATYPE = "DataType";
@@ -42,6 +40,13 @@ public class IoTDBMetadataResultSet extends IoTDBQueryResultSet {
   private String currentColumn;
   private String currentStorageGroup;
   private List<String> currentTimeseries;
+  private List<String> timeseriesNumList;
+  private List<String> nodesNumList;
+  private Map<String, String> nodeTimeseriesNumMap;
+  private String timeseriesNum;
+  private String nodesNum;
+  private String currentNode;
+  private String currentNodeTimeseriesNum;
   // for display
   private int colCount; // the number of columns for show
   private String[] showLabels; // headers for show
@@ -51,26 +56,52 @@ public class IoTDBMetadataResultSet extends IoTDBQueryResultSet {
   /**
    * Constructor used for the result of DatabaseMetadata.getColumns()
    */
-  public IoTDBMetadataResultSet(List<String> columns, Set<String> storageGroupSet,
-      List<List<String>> showTimeseriesList) throws SQLException {
-    if (columns != null) {
-      type = MetadataType.COLUMN;
-      colCount = 1;
-      showLabels = new String[]{"Column"};
-      columnItr = columns.iterator();
-    } else if (storageGroupSet != null) {
-      type = MetadataType.STORAGE_GROUP;
-      colCount = 1;
-      showLabels = new String[]{"Storage Group"};
-      columnItr = storageGroupSet.iterator();
-    } else if (showTimeseriesList != null) {
-      type = MetadataType.TIMESERIES;
-      colCount = 4;
-      showLabels = new String[]{GET_STRING_TIMESERIES_NAME, GET_STRING_TIMESERIES_STORAGE_GROUP,
+  public IoTDBMetadataResultSet(Object object, MetadataType type) throws SQLException {
+    this.type = type;
+    switch (type) {
+      case COLUMN:
+        List<String> columns = (List<String>) object;
+        colCount = 1;
+        showLabels = new String[]{"column"};
+        columnItr = columns.iterator();
+        break;
+      case STORAGE_GROUP:
+        Set<String> storageGroupSet = (Set<String>) object;
+        colCount = 1;
+        showLabels = new String[]{"Storage Group"};
+        columnItr = storageGroupSet.iterator();
+        break;
+      case TIMESERIES:
+        List<List<String>> showTimeseriesList = (List<List<String>>) object;
+        colCount = 4;
+        showLabels = new String[]{GET_STRING_TIMESERIES_NAME, GET_STRING_TIMESERIES_STORAGE_GROUP,
           GET_STRING_TIMESERIES_DATATYPE, GET_STRING_TIMESERIES_ENCODING};
-      columnItr = showTimeseriesList.iterator();
-    } else {
-      throw new SQLException("TsfileMetadataResultSet constructor is wrongly used.");
+        columnItr = showTimeseriesList.iterator();
+        break;
+      case COUNT_TIMESERIES:
+        String tsNum = (String) object.toString();
+        timeseriesNumList = new ArrayList<>();
+        timeseriesNumList.add(tsNum);
+        colCount = 1;
+        showLabels = new String[]{"count"};
+        columnItr = timeseriesNumList.iterator();
+        break;
+      case COUNT_NODES:
+        String ndNum = (String) object.toString();
+        nodesNumList = new ArrayList<>();
+        nodesNumList.add(ndNum);
+        colCount = 1;
+        showLabels = new String[]{"count"};
+        columnItr = nodesNumList.iterator();
+        break;
+      case COUNT_NODE_TIMESERIES:
+        nodeTimeseriesNumMap = (Map<String, String>) object;
+        colCount = 2;
+        showLabels = new String[]{"column", "count"};
+        columnItr = nodeTimeseriesNumMap.entrySet().iterator();
+        break;
+      default:
+        throw new SQLException("TsfileMetadataResultSet constructor is wrongly used.");
     }
   }
 
@@ -198,12 +229,29 @@ public class IoTDBMetadataResultSet extends IoTDBQueryResultSet {
   public boolean next() throws SQLException {
     boolean hasNext = columnItr.hasNext();
     if (hasNext) {
-      if (type == MetadataType.STORAGE_GROUP) {
-        currentStorageGroup = (String) columnItr.next();
-      } else if (type == MetadataType.COLUMN) {
-        currentColumn = (String) columnItr.next();
-      } else {
-        currentTimeseries = (List<String>) columnItr.next();
+      switch (type) {
+        case STORAGE_GROUP:
+          currentStorageGroup = (String) columnItr.next();
+          break;
+        case TIMESERIES:
+          currentTimeseries = (List<String>) columnItr.next();
+          break;
+        case COLUMN:
+          currentColumn = (String) columnItr.next();
+          break;
+        case COUNT_TIMESERIES:
+          timeseriesNum = (String) columnItr.next();
+          break;
+        case COUNT_NODES:
+          nodesNum = (String) columnItr.next();
+          break;
+        case COUNT_NODE_TIMESERIES:
+          Map.Entry pair = (Map.Entry) columnItr.next();
+          currentNode = (String) pair.getKey();
+          currentNodeTimeseriesNum = (String) pair.getValue();
+          break;
+        default:
+          break;
       }
     }
     return hasNext;
@@ -252,6 +300,17 @@ public class IoTDBMetadataResultSet extends IoTDBQueryResultSet {
           return getString(GET_STRING_COLUMN);
         }
         break;
+      case COUNT_TIMESERIES:
+        if (columnIndex == 1) {
+          return getString(GET_STRING_TIMESERIES_NUM);
+        }
+        break;
+      case COUNT_NODES:
+        if (columnIndex == 1) {
+          return getString(GET_STRING_NODES_NUM);
+        }
+      case COUNT_NODE_TIMESERIES:
+        return columnIndex == 1 ? getString(GET_STRING_NODE_PATH) : getString(GET_STRING_NODE_TIMESERIES_NUM);
       default:
         break;
     }
@@ -274,6 +333,14 @@ public class IoTDBMetadataResultSet extends IoTDBQueryResultSet {
         return currentTimeseries.get(3);
       case GET_STRING_COLUMN:
         return currentColumn;
+      case GET_STRING_TIMESERIES_NUM:
+        return timeseriesNum;
+      case GET_STRING_NODES_NUM:
+        return nodesNum;
+      case GET_STRING_NODE_PATH:
+        return currentNode;
+      case GET_STRING_NODE_TIMESERIES_NUM:
+        return currentNodeTimeseriesNum;
       default:
         break;
     }
@@ -311,6 +378,6 @@ public class IoTDBMetadataResultSet extends IoTDBQueryResultSet {
   }
 
   public enum MetadataType {
-    STORAGE_GROUP, TIMESERIES, COLUMN
+    STORAGE_GROUP, TIMESERIES, COLUMN, COUNT_TIMESERIES, COUNT_NODES, COUNT_NODE_TIMESERIES
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
@@ -247,6 +247,10 @@ public class MGraph implements Serializable {
     return mtree.getAllStorageGroup();
   }
 
+  List<String> getNodesList(String nodeLevel) {
+    return mtree.getNodesList(nodeLevel);
+  }
+
   List<String> getLeafNodePathInNextLevel(String path) throws PathErrorException {
     return mtree.getLeafNodePathInNextLevel(path);
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -18,23 +18,12 @@
  */
 package org.apache.iotdb.db.metadata;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.io.*;
+import java.util.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.adapter.IoTDBConfigDynamicAdapter;
-import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.exception.ConfigAdjusterException;
 import org.apache.iotdb.db.exception.MetadataErrorException;
 import org.apache.iotdb.db.exception.PathErrorException;
@@ -765,6 +754,21 @@ public class MManager {
     lock.readLock().lock();
     try {
       return mgraph.getAllStorageGroup();
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /**
+   * Get all nodes from the given level
+   *
+   * @return A List instance which stores all node at given level
+   */
+  public List<String> getNodesList(String nodeLevel) {
+
+    lock.readLock().lock();
+    try {
+      return mgraph.getNodesList(nodeLevel);
     } finally {
       lock.readLock().unlock();
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MNode.java
@@ -106,6 +106,16 @@ public class MNode implements Serializable {
   }
 
   /**
+   * function for checking whether the mnode has child mnode.
+   */
+  public boolean hasChildren() {
+    if (!isLeaf) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * function for checking whether mnode's children contain the given key.
    */
   public boolean hasChild(String key) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -18,17 +18,12 @@
  */
 package org.apache.iotdb.db.metadata;
 
+import java.io.Serializable;
+import java.util.*;
+
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.serializer.SerializerFeature;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.apache.iotdb.db.exception.PathErrorException;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -761,6 +756,36 @@ public class MTree implements Serializable {
     }
     for (MNode childNode : node.getChildren().values()) {
       findStorageGroup(childNode, path + "." + childNode.toString(), res);
+    }
+  }
+
+  /**
+   * Get all nodes at the given level in current Metadata Tree.
+   *
+   * @return a list contains all nodes at the given level
+   */
+  List<String> getNodesList(String nodeLevel) {
+    List<String> res = new ArrayList<>();
+    int level = Integer.parseInt(nodeLevel);
+    MNode rootNode;
+    if ((rootNode = getRoot()) != null) {
+      findNodes(rootNode, "root", res, level);
+    }
+    return res;
+  }
+
+  private void findNodes(MNode node, String path, List<String> res, int targetLevel) {
+    if (node == null) {
+      return;
+    }
+    if (targetLevel == 1) {
+      res.add(path);
+      return;
+    }
+    if (node.hasChildren()) {
+      for (MNode child : node.getChildren().values()) {
+        findNodes(child, path + "." + child.toString(), res, targetLevel - 1);
+      }
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -18,6 +18,17 @@
  */
 package org.apache.iotdb.db.service;
 
+import static org.apache.iotdb.db.conf.IoTDBConstant.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
 import org.apache.iotdb.db.auth.AuthException;
 import org.apache.iotdb.db.auth.AuthorityChecker;
 import org.apache.iotdb.db.auth.authorizer.IAuthorizer;
@@ -281,8 +292,17 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           resp.setDataType(getSeriesType(req.getColumnPath()).toString());
           status = new TS_Status(getStatus(TSStatusType.SUCCESS_STATUS));
           break;
+        case "COUNT_TIMESERIES":
         case "ALL_COLUMNS":
           resp.setColumnsList(getPaths(req.getColumnPath()));
+          status = new TS_Status(getStatus(TSStatusType.SUCCESS_STATUS));
+          break;
+        case "COUNT_NODES":
+          resp.setNodesList(getNodesList(req.getNodeLevel()));
+          status = new TS_Status(getStatus(TSStatusType.SUCCESS_STATUS));
+          break;
+        case "COUNT_NODE_TIMESERIES":
+          resp.setNodeTimeseriesNum(getNodeTimeseriesNum(getNodesList(req.getNodeLevel())));
           status = new TS_Status(getStatus(TSStatusType.SUCCESS_STATUS));
           break;
         default:
@@ -300,6 +320,18 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     }
     resp.setStatus(status);
     return resp;
+  }
+
+  private Map<String, String> getNodeTimeseriesNum(List<String> nodes) throws MetadataErrorException {
+    Map<String, String> nodeColumnsNum = new HashMap<>();
+    for (String columnPath : nodes) {
+      nodeColumnsNum.put(columnPath, Integer.toString(getPaths(columnPath).size()));
+    }
+    return nodeColumnsNum;
+  }
+
+  private List<String> getNodesList(String level) throws PathErrorException {
+    return MManager.getInstance().getNodesList(level);
   }
 
   private Set<String> getAllStorageGroups() throws PathErrorException {

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
@@ -214,7 +214,7 @@ public class IoTDBMetadataFetchIT {
    */
   private void allColumns() throws SQLException {
     String standard =
-        "Column,\n" + "root.ln.wf01.wt01.status,\n" + "root.ln.wf01.wt01.temperature,\n";
+        "column,\n" + "root.ln.wf01.wt01.status,\n" + "root.ln.wf01.wt01.temperature,\n";
 
     try (ResultSet resultSet = databaseMetaData.getColumns(Constant.CATALOG_COLUMN, "root", null, null);) {
       ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -238,7 +238,7 @@ public class IoTDBMetadataFetchIT {
    * get all delta objects under a given column
    */
   private void device() throws SQLException {
-    String standard = "Column,\n" + "root.ln.wf01.wt01,\n";
+    String standard = "column,\n" + "root.ln.wf01.wt01,\n";
 
 
     try (ResultSet resultSet = databaseMetaData.getColumns(Constant.CATALOG_DEVICE, "ln", null,

--- a/service-rpc/src/main/thrift/rpc.thrift
+++ b/service-rpc/src/main/thrift/rpc.thrift
@@ -196,11 +196,14 @@ struct TSFetchMetadataResp{
 		4: optional string dataType
 		5: optional list<list<string>> showTimeseriesList
 		7: optional set<string> showStorageGroups
+		8: optional list<string> nodesList
+		9: optional map<string, string> nodeTimeseriesNum
 }
 
 struct TSFetchMetadataReq{
 		1: required string type
 		2: optional string columnPath
+		3: optional string nodeLevel
 }
 
 struct TSColumnSchema{


### PR DESCRIPTION
The corresponding JIRA issue: https://issues.apache.org/jira/browse/IOTDB-174

1. Create an interface for querying the timeseries number under the specified path.

2. Create an interface for querying the node number at the given level in current Metadata Tree (this could be used to query the number of devices).

3. Create an interface for querying the timeseries number of each node at the given level (this could be used to query the number of sensors under each device).