### PR TITLE
[IOTDB-211]use "%IOTDB_HOME%\lib\*" to refers to all .jar files in the directory in start-server.bat

### DIFF
--- a/server/src/assembly/resources/sbin/start-server.bat
+++ b/server/src/assembly/resources/sbin/start-server.bat
@@ -46,7 +46,7 @@ IF NOT %JAVA_VERSION% == 8 (
 		echo IoTDB only supports jdk8 or jdk11, please check your java version.
 		goto finally
 	)
-) 
+)
 
 if "%OS%" == "Windows_NT" setlocal
 
@@ -79,7 +79,7 @@ set JAVA_OPTS=-ea^
 set CLASSPATH="%IOTDB_HOME%\lib"
 
 @REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
+set CLASSPATH=%CLASSPATH%;"%IOTDB_HOME%\lib\*"
 set CLASSPATH=%CLASSPATH%;iotdb.IoTDB
 goto okClasspath
 


### PR DESCRIPTION
To fix [IOTDB-211](https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-211) "**Start command too long on windows with big classpaths in start-server.bat**", I use "%IOTDB_HOME%\lib\*" to refers to all .jar files in the directory.

>[Understanding class path wildcards](https://docs.oracle.com/javase/6/docs/technotes/tools/windows/classpath.html#Understanding):
>- Class path entries can contain the basename wildcard character *, which is considered equivalent to specifying a list of all the files in the directory with the extension .jar or .JAR. For example, the class path entry foo/* specifies all JAR files in the directory named foo. A classpath entry consisting simply of * expands to a list of all the jar files in the current directory.
>- A class path entry that contains * will not match class files. To match both classes and JAR files in a single directory foo, use either foo;foo/* or foo/*;foo. The order chosen determines whether the classes and resources in foo are loaded before JAR files in foo, or vice versa.
>- Subdirectories are not searched recursively. For example, foo/* looks for JAR files only in foo, not in foo/bar, foo/baz, etc.
>- The order in which the JAR files in a directory are enumerated in the expanded class path is not specified and may vary from platform to platform and even from moment to moment on the same machine. A well-constructed application should not depend upon any particular order. If a specific order is required then the JAR files can be enumerated explicitly in the class path.
