### PR TITLE
 Abnormal publishing of sequence and unsequence data folders  in DirectoryManager

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/directories/DirectoryManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/directories/DirectoryManager.java
@@ -117,7 +117,7 @@ public class DirectoryManager {
   }
 
   public List<String> getAllSequenceFileFolders() {
-    return sequenceFileFolders;
+    return new ArrayList<>(sequenceFileFolders);
   }
 
   private static class DirectoriesHolder {
@@ -150,7 +150,7 @@ public class DirectoryManager {
   }
 
   public List<String> getAllUnSequenceFileFolders() {
-    return unsequenceFileFolders;
+    return new ArrayList<>(unsequenceFileFolders);
   }
 
   // only used by test


### PR DESCRIPTION
In `DirectoryManager` class, sequence and unsequence data folders are returned directly when the two lists are obtained, it is possible to modify the contents of the list outside this class, which leads to problems. So these two lists should not be published and exposed to be used outside this class.  