### PR TITLE
Remove static, add getter and setter.

### DIFF
--- a/example/tsfile/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead.java
+++ b/example/tsfile/src/main/java/org/apache/iotdb/tsfile/TsFileSequenceRead.java
@@ -70,7 +70,7 @@ public class TsFileSequenceRead {
           ChunkHeader header = reader.readChunkHeader();
           System.out.println("\tMeasurement: " + header.getMeasurementID());
           Decoder defaultTimeDecoder = Decoder.getDecoderByType(
-              TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().timeEncoder),
+              TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder()),
               TSDataType.INT64);
           Decoder valueDecoder = Decoder
               .getDecoderByType(header.getEncodingType(), header.getDataType());

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 import org.apache.iotdb.db.engine.merge.selector.MergeFileStrategy;
 import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.service.TSServiceImpl;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.fileSystem.FSType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -376,8 +376,9 @@ public class IoTDBConfig {
       addHomeDir(dirs, i);
     }
 
-    if (TSFileConfig.getTSFileStorageFs().equals(FSType.HDFS)) {
-      String hdfsDir = "hdfs://" + TSFileConfig.getHdfsIp() + ":" + TSFileConfig.getHdfsPort();
+    if (TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs().equals(FSType.HDFS)) {
+      String hdfsDir = "hdfs://" + TSFileDescriptor.getInstance().getConfig().getHdfsIp() + ":"
+          + TSFileDescriptor.getInstance().getConfig().getHdfsPort();
       for (int i = 5; i < dirs.size(); i++) {
         String dir = dirs.get(i);
         dir = hdfsDir + File.separatorChar + dir;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.conf;
 
 import org.apache.iotdb.db.utils.FilePathUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -274,9 +275,9 @@ public class IoTDBDescriptor {
       conf.setHdfsPort(properties.getProperty("hdfs_port"));
 
       // At the same time, set TSFileConfig
-      TSFileConfig.setTSFileStorageFs(properties.getProperty("tsfile_storage_fs"));
-      TSFileConfig.setHdfsIp(properties.getProperty("hdfs_ip"));
-      TSFileConfig.setHdfsPort(properties.getProperty("hdfs_port"));
+      TSFileDescriptor.getInstance().getConfig().setTSFileStorageFs(properties.getProperty("tsfile_storage_fs"));
+      TSFileDescriptor.getInstance().getConfig().setHdfsIp(properties.getProperty("hdfs_ip"));
+      TSFileDescriptor.getInstance().getConfig().setHdfsPort(properties.getProperty("hdfs_port"));
 
     } catch (IOException e) {
       logger.warn("Cannot load config file because, use default configuration", e);

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.engine.memtable.IWritableMemChunk;
 import org.apache.iotdb.db.exception.FlushRunTimeException;
 import org.apache.iotdb.db.utils.datastructure.TVList;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.chunk.ChunkBuffer;
@@ -39,7 +40,7 @@ import org.slf4j.LoggerFactory;
 public class MemTableFlushTask {
 
   private static final Logger logger = LoggerFactory.getLogger(MemTableFlushTask.class);
-  private static final int PAGE_SIZE_THRESHOLD = TSFileConfig.pageSizeInByte;
+  private static final int PAGE_SIZE_THRESHOLD = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
   private static final FlushSubTaskPoolManager subTaskPoolManager = FlushSubTaskPoolManager
       .getInstance();
   private Future ioTaskFuture;

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.query.reader.IPointReader;
 import org.apache.iotdb.db.query.reader.resourceRelated.CachedUnseqResourceMergeReader;
 import org.apache.iotdb.db.utils.MergeUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetaData;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.fileSystem.TSFileFactory;
@@ -158,7 +159,8 @@ public class MergeResource {
    */
   public IChunkWriter getChunkWriter(MeasurementSchema measurementSchema) {
     return chunkWriterCache.computeIfAbsent(measurementSchema,
-        schema -> new ChunkWriterImpl(new ChunkBuffer(schema), TSFileConfig.pageCheckSizeThreshold));
+        schema -> new ChunkWriterImpl(new ChunkBuffer(schema),
+            TSFileDescriptor.getInstance().getConfig().getPageCheckSizeThreshold()));
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/engine/querycontext/ReadOnlyMemChunk.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/querycontext/ReadOnlyMemChunk.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.db.utils.TimeValuePair;
 import org.apache.iotdb.db.utils.TsPrimitiveType.TsDouble;
 import org.apache.iotdb.db.utils.TsPrimitiveType.TsFloat;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.encoding.encoder.Encoder;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
@@ -42,7 +43,7 @@ public class ReadOnlyMemChunk implements TimeValuePairSorter {
   private List<TimeValuePair> sortedTimeValuePairList;
 
   Map<String, String> props;
-  private int floatPrecision = TSFileConfig.floatPrecision;
+  private int floatPrecision = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
 
   /**
    * init by TSDataType and TimeValuePairSorter.

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.apache.iotdb.db.exception.MetadataErrorException;
 import org.apache.iotdb.db.exception.PathErrorException;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -68,7 +69,7 @@ public class MGraph implements Serializable {
       throws PathErrorException {
     TSDataType tsDataType = TSDataType.valueOf(dataType);
     TSEncoding tsEncoding = TSEncoding.valueOf(encoding);
-    CompressionType compressionType = CompressionType.valueOf(TSFileConfig.compressor);
+    CompressionType compressionType = CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor());
     addPathToMTree(path, tsDataType, tsEncoding, compressionType,
         Collections.emptyMap());
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.exception.PathErrorException;
 import org.apache.iotdb.db.monitor.MonitorConstants;
 import org.apache.iotdb.db.utils.RandomDeleteCache;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.exception.cache.CacheException;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -379,7 +380,7 @@ public class MManager {
       throws PathErrorException, IOException {
     TSDataType tsDataType = TSDataType.valueOf(dataType);
     TSEncoding tsEncoding = TSEncoding.valueOf(encoding);
-    CompressionType type = CompressionType.valueOf(TSFileConfig.compressor);
+    CompressionType type = CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor());
     addPathToMTreeInternal(path, tsDataType, tsEncoding, type, Collections.emptyMap());
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -26,6 +26,7 @@ import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import org.apache.iotdb.db.exception.PathErrorException;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -60,7 +61,7 @@ public class MTree implements Serializable {
       throws PathErrorException {
     TSDataType tsDataType = TSDataType.valueOf(dataType);
     TSEncoding tsEncoding = TSEncoding.valueOf(encoding);
-    CompressionType compressionType = CompressionType.valueOf(TSFileConfig.compressor);
+    CompressionType compressionType = CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor());
     addTimeseriesPath(timeseriesPath, tsDataType, tsEncoding, compressionType,
         Collections.emptyMap());
   }

--- a/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/monitor/StatMonitor.java
@@ -42,6 +42,7 @@ import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
 import org.apache.iotdb.db.service.IService;
 import org.apache.iotdb.db.service.ServiceType;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -165,7 +166,7 @@ public class StatMonitor implements IService {
 
         if (!mManager.pathExist(entry.getKey())) {
           mManager.addPathToMTree(new Path(entry.getKey()), TSDataType.valueOf(entry.getValue()),
-              TSEncoding.valueOf("RLE"), CompressionType.valueOf(TSFileConfig.compressor),
+              TSEncoding.valueOf("RLE"), CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor()),
               Collections.emptyMap());
         }
       }

--- a/server/src/main/java/org/apache/iotdb/db/monitor/collector/FileSize.java
+++ b/server/src/main/java/org/apache/iotdb/db/monitor/collector/FileSize.java
@@ -38,6 +38,7 @@ import org.apache.iotdb.db.monitor.MonitorConstants;
 import org.apache.iotdb.db.monitor.MonitorConstants.FileSizeConstants;
 import org.apache.iotdb.db.monitor.StatMonitor;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -79,7 +80,7 @@ public class FileSize implements IStatistic {
       Path path = new Path(seriesPath);
       try {
         storageEngine.addTimeSeries(path, TSDataType.valueOf(MonitorConstants.DATA_TYPE_INT64),
-            TSEncoding.valueOf("RLE"), CompressionType.valueOf(TSFileConfig.compressor),
+            TSEncoding.valueOf("RLE"), CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor()),
             Collections.emptyMap());
       } catch (StorageEngineException e) {
         logger.error("Register File Size Stats into storageEngine Failed.", e);

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -58,6 +58,7 @@ import org.apache.iotdb.db.sql.parse.AstNode;
 import org.apache.iotdb.db.sql.parse.Node;
 import org.apache.iotdb.db.sql.parse.TSParser;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -400,7 +401,7 @@ public class LogicalGenerator {
       compressor = paramNode.getChild(offset).getChild(0).getText();
       offset++;
     } else {
-      compressor = TSFileConfig.compressor;
+      compressor = TSFileDescriptor.getInstance().getConfig().getCompressor();
     }
     checkMetadataArgs(dataType, encodingType, compressor);
     Map<String, String> props = new HashMap<>(paramNode.getChildCount() - offset + 1, 1);

--- a/server/src/main/java/org/apache/iotdb/db/utils/MathUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/MathUtils.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.utils;
 
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 
 public class MathUtils {
 
@@ -40,12 +41,12 @@ public class MathUtils {
   }
 
   public static float roundWithGivenPrecision(float data) {
-    if (TSFileConfig.floatPrecision == 0) {
+    if (TSFileDescriptor.getInstance().getConfig().getFloatPrecision() == 0) {
       return Math.round(data);
     }
     return Math.round(data)
-        + Math.round(((data - Math.round(data)) * (float) Math.pow(10, TSFileConfig.floatPrecision)))
-        / (float) Math.pow(10,  TSFileConfig.floatPrecision);
+        + Math.round(((data - Math.round(data)) * (float) Math.pow(10, TSFileDescriptor.getInstance().getConfig().getFloatPrecision())))
+        / (float) Math.pow(10,  TSFileDescriptor.getInstance().getConfig().getFloatPrecision());
   }
 
   /**
@@ -66,11 +67,11 @@ public class MathUtils {
    * value.
    */
   public static double roundWithGivenPrecision(double data) {
-    if (TSFileConfig.floatPrecision == 0) {
+    if (TSFileDescriptor.getInstance().getConfig().getFloatPrecision() == 0) {
       return Math.round(data);
     }
     return Math.round(data)
-        + Math.round(((data - Math.round(data)) * Math.pow(10, TSFileConfig.floatPrecision)))
-        / Math.pow(10, TSFileConfig.floatPrecision);
+        + Math.round(((data - Math.round(data)) * Math.pow(10, TSFileDescriptor.getInstance().getConfig().getFloatPrecision())))
+        / Math.pow(10, TSFileDescriptor.getInstance().getConfig().getFloatPrecision());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/MetadataManagerHelper.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/MetadataManagerHelper.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.engine;
 import java.util.Collections;
 import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -43,7 +44,8 @@ public class MetadataManagerHelper {
       mmanager.setStorageLevelToMTree("root.vehicle.d1");
       mmanager.setStorageLevelToMTree("root.vehicle.d2");
 
-      CompressionType compressionType =CompressionType.valueOf(TSFileConfig.compressor);
+      CompressionType compressionType =CompressionType.valueOf(
+          TSFileDescriptor.getInstance().getConfig().getCompressor());
 
       mmanager.addPathToMTree(new Path("root.vehicle.d0.s0"), TSDataType.valueOf("INT32"),
           TSEncoding.valueOf("RLE"), compressionType,
@@ -101,7 +103,7 @@ public class MetadataManagerHelper {
     mmanager.clear();
     try {
       mmanager.setStorageLevelToMTree("root.vehicle");
-      CompressionType compressionType =CompressionType.valueOf(TSFileConfig.compressor);
+      CompressionType compressionType =CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor());
 
       mmanager.addPathToMTree(new Path("root.vehicle.d0.s0"), TSDataType.valueOf("INT32"), TSEncoding.valueOf("RLE"), compressionType, Collections.emptyMap());
       mmanager.addPathToMTree(new Path("root.vehicle.d0.s1"), TSDataType.valueOf("INT64"), TSEncoding.valueOf("RLE"), compressionType, Collections.emptyMap());

--- a/server/src/test/java/org/apache/iotdb/db/engine/memtable/PrimitiveMemTableTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/memtable/PrimitiveMemTableTest.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.db.utils.TimeValuePair;
 import org.apache.iotdb.db.utils.TsPrimitiveType;
 import org.apache.iotdb.db.utils.datastructure.TVList;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.Binary;
@@ -40,7 +41,7 @@ public class PrimitiveMemTableTest {
 
   @Before
   public void setUp() {
-    delta = Math.pow(0.1, TSFileConfig.floatPrecision);
+    delta = Math.pow(0.1, TSFileDescriptor.getInstance().getConfig().getFloatPrecision());
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionFileNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionFileNodeTest.java
@@ -44,6 +44,7 @@ import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.db.utils.TimeValuePair;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -81,7 +82,7 @@ public class DeletionFileNodeTest {
           encoding);
       StorageEngine.getInstance()
           .addTimeSeries(new Path(processorName, measurements[i]), TSDataType.valueOf(dataType),
-              TSEncoding.valueOf(encoding), CompressionType.valueOf(TSFileConfig.compressor),
+              TSEncoding.valueOf(encoding), CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor()),
               Collections.emptyMap());
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionQueryTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionQueryTest.java
@@ -36,6 +36,7 @@ import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
 import org.apache.iotdb.db.query.executor.EngineQueryRouter;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -76,7 +77,7 @@ public class  DeletionQueryTest {
           encoding);
       StorageEngine.getInstance()
           .addTimeSeries(new Path(processorName, measurements[i]), TSDataType.valueOf(dataType),
-              TSEncoding.valueOf(encoding), CompressionType.valueOf(TSFileConfig.compressor),
+              TSEncoding.valueOf(encoding), CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor()),
               Collections.emptyMap());
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
@@ -68,14 +68,14 @@ public class IoTDBEngineTimeGeneratorIT {
 
     // use small page setting
     // origin value
-    maxNumberOfPointsInPage = tsFileConfig.maxNumberOfPointsInPage;
-    pageSizeInByte = tsFileConfig.pageSizeInByte;
-    groupSizeInByte = tsFileConfig.groupSizeInByte;
+    maxNumberOfPointsInPage = tsFileConfig.getMaxNumberOfPointsInPage();
+    pageSizeInByte = tsFileConfig.getPageSizeInByte();
+    groupSizeInByte = tsFileConfig.getGroupSizeInByte();
 
     // new value
-    tsFileConfig.maxNumberOfPointsInPage = 100;
-    tsFileConfig.pageSizeInByte = 1024 * 1024 * 150;
-    tsFileConfig.groupSizeInByte = 1024 * 1024 * 100;
+    tsFileConfig.setMaxNumberOfPointsInPage(100);
+    tsFileConfig.setPageSizeInByte(1024 * 1024 * 150);
+    tsFileConfig.setGroupSizeInByte(1024 * 1024 * 100);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(1024 * 1024 * 100);
 
     daemon = IoTDB.getInstance();
@@ -90,9 +90,9 @@ public class IoTDBEngineTimeGeneratorIT {
   public static void tearDown() throws Exception {
     daemon.stop();
     // recovery value
-    tsFileConfig.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
-    tsFileConfig.pageSizeInByte = pageSizeInByte;
-    tsFileConfig.groupSizeInByte = groupSizeInByte;
+    tsFileConfig.setMaxNumberOfPointsInPage(maxNumberOfPointsInPage);
+    tsFileConfig.setPageSizeInByte(pageSizeInByte);
+    tsFileConfig.setGroupSizeInByte(groupSizeInByte);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(groupSizeInByte);
 
     EnvironmentUtils.cleanEnv();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLargeDataIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLargeDataIT.java
@@ -57,14 +57,14 @@ public class IoTDBLargeDataIT {
 
     // use small page setting
     // origin value
-    maxNumberOfPointsInPage = tsFileConfig.maxNumberOfPointsInPage;
-    pageSizeInByte = tsFileConfig.pageSizeInByte;
-    groupSizeInByte = tsFileConfig.groupSizeInByte;
+    maxNumberOfPointsInPage = tsFileConfig.getMaxNumberOfPointsInPage();
+    pageSizeInByte = tsFileConfig.getPageSizeInByte();
+    groupSizeInByte = tsFileConfig.getGroupSizeInByte();
 
     // new value
-    tsFileConfig.maxNumberOfPointsInPage = 1000;
-    tsFileConfig.pageSizeInByte = 1024 * 150;
-    tsFileConfig.groupSizeInByte = 1024 * 1000;
+    tsFileConfig.setMaxNumberOfPointsInPage(1000);
+    tsFileConfig.setPageSizeInByte(1024 * 150);
+    tsFileConfig.setGroupSizeInByte(1024 * 1000);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(1024 * 1000);
 
     daemon = IoTDB.getInstance();
@@ -79,9 +79,9 @@ public class IoTDBLargeDataIT {
     daemon.stop();
 
     // recovery value
-    tsFileConfig.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
-    tsFileConfig.pageSizeInByte = pageSizeInByte;
-    tsFileConfig.groupSizeInByte = groupSizeInByte;
+    tsFileConfig.setMaxNumberOfPointsInPage(maxNumberOfPointsInPage);
+    tsFileConfig.setPageSizeInByte(pageSizeInByte);
+    tsFileConfig.setGroupSizeInByte(groupSizeInByte);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(groupSizeInByte);
 
     EnvironmentUtils.cleanEnv();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMultiSeriesIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMultiSeriesIT.java
@@ -59,14 +59,14 @@ public class IoTDBMultiSeriesIT {
 
     // use small page setting
     // origin value
-    maxNumberOfPointsInPage = tsFileConfig.maxNumberOfPointsInPage;
-    pageSizeInByte = tsFileConfig.pageSizeInByte;
-    groupSizeInByte = tsFileConfig.groupSizeInByte;
+    maxNumberOfPointsInPage = tsFileConfig.getMaxNumberOfPointsInPage();
+    pageSizeInByte = tsFileConfig.getPageSizeInByte();
+    groupSizeInByte = tsFileConfig.getGroupSizeInByte();
 
     // new value
-    tsFileConfig.maxNumberOfPointsInPage = 1000;
-    tsFileConfig.pageSizeInByte = 1024 * 150;
-    tsFileConfig.groupSizeInByte = 1024 * 1000;
+    tsFileConfig.setMaxNumberOfPointsInPage(1000);
+    tsFileConfig.setPageSizeInByte(1024 * 150);
+    tsFileConfig.setGroupSizeInByte(1024 * 1000);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(1024 * 1000);
 
     daemon = IoTDB.getInstance();
@@ -80,9 +80,9 @@ public class IoTDBMultiSeriesIT {
   public static void tearDown() throws Exception {
     daemon.stop();
     // recovery value
-    tsFileConfig.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
-    tsFileConfig.pageSizeInByte = pageSizeInByte;
-    tsFileConfig.groupSizeInByte = groupSizeInByte;
+    tsFileConfig.setMaxNumberOfPointsInPage(maxNumberOfPointsInPage);
+    tsFileConfig.setPageSizeInByte(pageSizeInByte);
+    tsFileConfig.setGroupSizeInByte(groupSizeInByte);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(groupSizeInByte);
 
     EnvironmentUtils.cleanEnv();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
@@ -71,14 +71,14 @@ public class IoTDBSequenceDataQueryIT {
 
     // use small page setting
     // origin value
-    maxNumberOfPointsInPage = tsFileConfig.maxNumberOfPointsInPage;
-    pageSizeInByte = tsFileConfig.pageSizeInByte;
-    groupSizeInByte = tsFileConfig.groupSizeInByte;
+    maxNumberOfPointsInPage = tsFileConfig.getMaxNumberOfPointsInPage();
+    pageSizeInByte = tsFileConfig.getPageSizeInByte();
+    groupSizeInByte = tsFileConfig.getGroupSizeInByte();
 
     // new value
-    tsFileConfig.maxNumberOfPointsInPage = 100;
-    tsFileConfig.pageSizeInByte = 1024 * 1024 * 150;
-    tsFileConfig.groupSizeInByte = 1024 * 1024 * 100;
+    tsFileConfig.setMaxNumberOfPointsInPage(100);
+    tsFileConfig.setPageSizeInByte(1024 * 1024 * 150);
+    tsFileConfig.setGroupSizeInByte(1024 * 1024 * 100);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(1024 * 1024 * 100);
 
     daemon = IoTDB.getInstance();
@@ -92,9 +92,9 @@ public class IoTDBSequenceDataQueryIT {
   public static void tearDown() throws Exception {
     daemon.stop();
     // recovery value
-    tsFileConfig.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
-    tsFileConfig.pageSizeInByte = pageSizeInByte;
-    tsFileConfig.groupSizeInByte = groupSizeInByte;
+    tsFileConfig.setMaxNumberOfPointsInPage(maxNumberOfPointsInPage);
+    tsFileConfig.setPageSizeInByte(pageSizeInByte);
+    tsFileConfig.setGroupSizeInByte(groupSizeInByte);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(groupSizeInByte);
 
     EnvironmentUtils.cleanEnv();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
@@ -72,14 +72,14 @@ public class IoTDBSeriesReaderIT {
 
     // use small page setting
     // origin value
-    maxNumberOfPointsInPage = tsFileConfig.maxNumberOfPointsInPage;
-    pageSizeInByte = tsFileConfig.pageSizeInByte;
-    groupSizeInByte = tsFileConfig.groupSizeInByte;
+    maxNumberOfPointsInPage = tsFileConfig.getMaxNumberOfPointsInPage();
+    pageSizeInByte = tsFileConfig.getPageSizeInByte();
+    groupSizeInByte = tsFileConfig.getGroupSizeInByte();
 
     // new value
-    tsFileConfig.maxNumberOfPointsInPage = 1000;
-    tsFileConfig.pageSizeInByte = 1024 * 1024 * 150;
-    tsFileConfig.groupSizeInByte = 1024 * 1024 * 1000;
+    tsFileConfig.setMaxNumberOfPointsInPage(1000);
+    tsFileConfig.setPageSizeInByte(1024 * 1024 * 150);
+    tsFileConfig.setGroupSizeInByte(1024 * 1024 * 150);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(1024 * 1024 * 1000);
 
     daemon = IoTDB.getInstance();
@@ -97,9 +97,9 @@ public class IoTDBSeriesReaderIT {
     connection.close();
     daemon.stop();
     // recovery value
-    tsFileConfig.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
-    tsFileConfig.pageSizeInByte = pageSizeInByte;
-    tsFileConfig.groupSizeInByte = groupSizeInByte;
+    tsFileConfig.setMaxNumberOfPointsInPage(1024 * 1024 * 150);
+    tsFileConfig.setPageSizeInByte(pageSizeInByte);
+    tsFileConfig.setGroupSizeInByte(groupSizeInByte);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(groupSizeInByte);
 
     EnvironmentUtils.cleanEnv();

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MManagerBasicTest.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.exception.MetadataErrorException;
 import org.apache.iotdb.db.exception.PathErrorException;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -45,7 +46,7 @@ public class MManagerBasicTest {
 
   @Before
   public void setUp() throws Exception {
-    compressionType = CompressionType.valueOf(TSFileConfig.compressor);
+    compressionType = CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor());
     EnvironmentUtils.envSetUp();
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/qp/QueryProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/QueryProcessorTest.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.db.qp.executor.QueryProcessExecutor;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -36,7 +36,8 @@ import org.junit.Test;
 
 public class QueryProcessorTest {
 
-  private CompressionType compressionType = CompressionType.valueOf(TSFileConfig.compressor);
+  private CompressionType compressionType = CompressionType.valueOf(
+      TSFileDescriptor.getInstance().getConfig().getCompressor());
   private MManager mManager = MManager.getInstance();
   private QueryProcessor processor = new QueryProcessor(new QueryProcessExecutor());
 

--- a/server/src/test/java/org/apache/iotdb/db/writelog/IoTDBLogFileSizeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/IoTDBLogFileSizeTest.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.db.writelog.node.ExclusiveWriteLogNode;
 import org.apache.iotdb.db.writelog.node.WriteLogNode;
 import org.apache.iotdb.jdbc.Config;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,8 +60,8 @@ public class IoTDBLogFileSizeTest {
     if (skip) {
       return;
     }
-    groupSize = TSFileConfig.groupSizeInByte;
-    TSFileConfig.groupSizeInByte = 8 * 1024 * 1024;
+    groupSize = TSFileDescriptor.getInstance().getConfig().getGroupSizeInByte();
+    TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte( 8 * 1024 * 1024);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(8 * 1024 * 1024);
     EnvironmentUtils.closeStatMonitor();
     daemon = IoTDB.getInstance();
@@ -74,7 +75,7 @@ public class IoTDBLogFileSizeTest {
     if (skip) {
       return;
     }
-    TSFileConfig.groupSizeInByte = groupSize;
+    TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(groupSize);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(groupSize);
     executeSQL(tearDownSqls);
     daemon.stop();

--- a/spark-tsfile/src/test/scala/org/apache/iotdb/tool/TsFileWriteTool.java
+++ b/spark-tsfile/src/test/scala/org/apache/iotdb/tool/TsFileWriteTool.java
@@ -233,7 +233,7 @@ public class TsFileWriteTool {
    *
    */
   public void create4(String tsfilePath) throws Exception {
-    TSFileDescriptor.getInstance().getConfig().groupSizeInByte = 1024 * 1024;
+    TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(1024 * 1024);
     File f = new File(tsfilePath);
     if (f.exists()) {
       f.delete();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
@@ -61,129 +61,266 @@ public class TSFileConfig {
    * The default grow size of class BatchData.
    */
   public static final int DYNAMIC_DATA_SIZE = 1000;
+
+  public int getGroupSizeInByte() {
+    return groupSizeInByte;
+  }
+
+  public void setGroupSizeInByte(int groupSizeInByte) {
+    this.groupSizeInByte = groupSizeInByte;
+  }
+
+  public int getPageSizeInByte() {
+    return pageSizeInByte;
+  }
+
+  public void setPageSizeInByte(int pageSizeInByte) {
+    this.pageSizeInByte = pageSizeInByte;
+  }
+
+  public int getMaxNumberOfPointsInPage() {
+    return maxNumberOfPointsInPage;
+  }
+
+  public void setMaxNumberOfPointsInPage(int maxNumberOfPointsInPage) {
+    this.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
+  }
+
+  public String getTimeSeriesDataType() {
+    return timeSeriesDataType;
+  }
+
+  public void setTimeSeriesDataType(String timeSeriesDataType) {
+    this.timeSeriesDataType = timeSeriesDataType;
+  }
+
+  public int getMaxStringLength() {
+    return maxStringLength;
+  }
+
+  public void setMaxStringLength(int maxStringLength) {
+    this.maxStringLength = maxStringLength;
+  }
+
+  public int getFloatPrecision() {
+    return floatPrecision;
+  }
+
+  public void setFloatPrecision(int floatPrecision) {
+    this.floatPrecision = floatPrecision;
+  }
+
+  public String getTimeEncoder() {
+    return timeEncoder;
+  }
+
+  public void setTimeEncoder(String timeEncoder) {
+    this.timeEncoder = timeEncoder;
+  }
+
+  public String getValueEncoder() {
+    return valueEncoder;
+  }
+
+  public void setValueEncoder(String valueEncoder) {
+    this.valueEncoder = valueEncoder;
+  }
+
+  public int getRleBitWidth() {
+    return rleBitWidth;
+  }
+
+  public void setRleBitWidth(int rleBitWidth) {
+    this.rleBitWidth = rleBitWidth;
+  }
+
+  public int getDeltaBlockSize() {
+    return deltaBlockSize;
+  }
+
+  public void setDeltaBlockSize(int deltaBlockSize) {
+    this.deltaBlockSize = deltaBlockSize;
+  }
+
+  public String getFreqType() {
+    return freqType;
+  }
+
+  public void setFreqType(String freqType) {
+    this.freqType = freqType;
+  }
+
+  public double getPlaMaxError() {
+    return plaMaxError;
+  }
+
+  public void setPlaMaxError(double plaMaxError) {
+    this.plaMaxError = plaMaxError;
+  }
+
+  public double getSdtMaxError() {
+    return sdtMaxError;
+  }
+
+  public void setSdtMaxError(double sdtMaxError) {
+    this.sdtMaxError = sdtMaxError;
+  }
+
+  public double getDftSatisfyRate() {
+    return dftSatisfyRate;
+  }
+
+  public void setDftSatisfyRate(double dftSatisfyRate) {
+    this.dftSatisfyRate = dftSatisfyRate;
+  }
+
+  public String getCompressor() {
+    return compressor;
+  }
+
+  public void setCompressor(String compressor) {
+    this.compressor = compressor;
+  }
+
+  public int getPageCheckSizeThreshold() {
+    return pageCheckSizeThreshold;
+  }
+
+  public void setPageCheckSizeThreshold(int pageCheckSizeThreshold) {
+    this.pageCheckSizeThreshold = pageCheckSizeThreshold;
+  }
+
+  public String getEndian() {
+    return endian;
+  }
+
+  public void setEndian(String endian) {
+    this.endian = endian;
+  }
+
   /**
    * Memory size threshold for flushing to disk, default value is 128MB.
    */
-  public static int groupSizeInByte = 128 * 1024 * 1024;
+  private int groupSizeInByte = 128 * 1024 * 1024;
   /**
    * The memory size for each series writer to pack page, default value is 64KB.
    */
-  public static int pageSizeInByte = 64 * 1024;
+  private int pageSizeInByte = 64 * 1024;
 
   // TS_2DIFF configuration
   /**
    * The maximum number of data points in a page, default value is 1024 * 1024.
    */
-  public static int maxNumberOfPointsInPage = 1024 * 1024;
+  private int maxNumberOfPointsInPage = 1024 * 1024;
   /**
    * Data type for input timestamp, TsFile supports INT32 or INT64.
    */
-  public static String timeSeriesDataType = "INT64";
+  private String timeSeriesDataType = "INT64";
 
   // Freq encoder configuration
   /**
    * Max length limitation of input string.
    */
-  public static int maxStringLength = 128;
+  private int maxStringLength = 128;
   /**
    * Floating-point precision.
    */
-  public static int floatPrecision = 2;
+  private int floatPrecision = 2;
   /**
    * Encoder of time column, TsFile supports TS_2DIFF, PLAIN and RLE(run-length encoding) Default
    * value is TS_2DIFF.
    */
-  public static String timeEncoder = "TS_2DIFF";
+  private String timeEncoder = "TS_2DIFF";
   /**
    * Encoder of value series. default value is PLAIN. For int, long data type, TsFile also supports
    * TS_2DIFF and RLE(run-length encoding). For float, double data type, TsFile also supports
    * TS_2DIFF, RLE(run-length encoding) and GORILLA. For text data type, TsFile only supports
    * PLAIN.
    */
-  public static String valueEncoder = "PLAIN";
+  private String valueEncoder = "PLAIN";
 
   // Compression configuration
   /**
    * Default bit width of RLE encoding is 8.
    */
-  public static int rleBitWidth = 8;
+  private int rleBitWidth = 8;
 
   // Don't change the following configuration
   /**
    * Default block size of two-diff. delta encoding is 128
    */
-  public static int deltaBlockSize = 128;
+  private int deltaBlockSize = 128;
   /**
    * Default frequency type is SINGLE_FREQ.
    */
-  public static String freqType = "SINGLE_FREQ";
+  private String freqType = "SINGLE_FREQ";
   /**
    * Default PLA max error is 100.
    */
-  public static double plaMaxError = 100;
+  private double plaMaxError = 100;
   /**
    * Default SDT max error is 100.
    */
-  public static double sdtMaxError = 100;
+  private double sdtMaxError = 100;
   /**
    * Default DFT satisfy rate is 0.1
    */
-  public static double dftSatisfyRate = 0.1;
+  private double dftSatisfyRate = 0.1;
   /**
    * Data compression method, TsFile supports UNCOMPRESSED or SNAPPY. Default value is UNCOMPRESSED
    * which means no compression
    */
-  public static String compressor = "UNCOMPRESSED";
+  private String compressor = "UNCOMPRESSED";
   /**
    * Line count threshold for checking page memory occupied size.
    */
-  public static int pageCheckSizeThreshold = 100;
+  private int pageCheckSizeThreshold = 100;
   /**
    * Default endian value is BIG_ENDIAN.
    */
-  public static String endian = "BIG_ENDIAN";
+  private String endian = "BIG_ENDIAN";
 
   /**
    * Default storage is in local file system
    */
-  public static FSType TSFileStorageFs = FSType.LOCAL;
+  private FSType TSFileStorageFs = FSType.LOCAL;
 
   /**
    * Default hdfs ip is localhost
    */
-  public static String hdfsIp = "localhost";
+  private String hdfsIp = "localhost";
 
   /**
    * Default hdfs port is 9000
    */
-  public static String hdfsPort = "9000";
+  private String hdfsPort = "9000";
 
   public TSFileConfig() {
 
   }
 
 
-  public static FSType getTSFileStorageFs() {
-    return TSFileStorageFs;
+  public FSType getTSFileStorageFs() {
+    return this.TSFileStorageFs;
   }
 
-  public static void setTSFileStorageFs(String TSFileStorageFs) {
-    TSFileConfig.TSFileStorageFs = FSType.valueOf(TSFileStorageFs);
+  public void setTSFileStorageFs(String TSFileStorageFs) {
+    this.TSFileStorageFs = FSType.valueOf(TSFileStorageFs);
   }
 
-  public static String getHdfsIp() {
-    return hdfsIp;
+  public String getHdfsIp() {
+    return this.hdfsIp;
   }
 
-  public static void setHdfsIp(String hdfsIp) {
-    TSFileConfig.hdfsIp = hdfsIp;
+  public void setHdfsIp(String hdfsIp) {
+    this.hdfsIp = hdfsIp;
   }
 
-  public static String getHdfsPort() {
-    return hdfsPort;
+  public String getHdfsPort() {
+    return this.hdfsPort;
   }
 
-  public static void setHdfsPort(String hdfsPort) {
-    TSFileConfig.hdfsPort = hdfsPort;
+  public void setHdfsPort(String hdfsPort) {
+    this.hdfsPort = hdfsPort;
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileDescriptor.java
@@ -106,34 +106,30 @@ public class TSFileDescriptor {
     Properties properties = new Properties();
     try {
       properties.load(inputStream);
-      TSFileConfig.groupSizeInByte = Integer
-          .parseInt(
-              properties.getProperty("group_size_in_byte",
-                  Integer.toString(TSFileConfig.groupSizeInByte)));
-      TSFileConfig.pageSizeInByte = Integer
-          .parseInt(properties
-              .getProperty("page_size_in_byte", Integer.toString(TSFileConfig.pageSizeInByte)));
-      if (TSFileConfig.pageSizeInByte > TSFileConfig.groupSizeInByte) {
+      conf.setGroupSizeInByte(Integer
+          .parseInt(properties.getProperty("group_size_in_byte",
+                  Integer.toString(conf.getGroupSizeInByte()))));
+      conf.setPageSizeInByte(Integer
+          .parseInt(properties.getProperty("page_size_in_byte",
+              Integer.toString(conf.getPageSizeInByte()))));
+      if (conf.getPageSizeInByte() > conf.getGroupSizeInByte()) {
         logger.warn("page_size is greater than group size, will set it as the same with group size");
-        TSFileConfig.pageSizeInByte = TSFileConfig.groupSizeInByte;
+        conf.setPageSizeInByte(conf.getGroupSizeInByte());
       }
-      TSFileConfig.maxNumberOfPointsInPage = Integer.parseInt(
-          properties
-              .getProperty("max_number_of_points_in_page",
-                  Integer.toString(TSFileConfig.maxNumberOfPointsInPage)));
-      TSFileConfig.timeSeriesDataType = properties
-          .getProperty("time_series_data_type", TSFileConfig.timeSeriesDataType);
-      TSFileConfig.maxStringLength = Integer
+      conf.setMaxNumberOfPointsInPage(Integer
+          .parseInt(properties.getProperty("max_number_of_points_in_page",
+                  Integer.toString(conf.getMaxNumberOfPointsInPage()))));
+      conf.setTimeSeriesDataType(properties
+          .getProperty("time_series_data_type", conf.getTimeSeriesDataType()));
+      conf.setMaxStringLength(Integer
+          .parseInt(properties.getProperty("max_string_length",
+              Integer.toString(conf.getMaxStringLength()))));
+      conf.setFloatPrecision(Integer
           .parseInt(properties
-              .getProperty("max_string_length", Integer.toString(TSFileConfig.maxStringLength)));
-      TSFileConfig.floatPrecision = Integer
-          .parseInt(properties
-              .getProperty("float_precision", Integer.toString(TSFileConfig.floatPrecision)));
-      TSFileConfig.timeEncoder = properties
-          .getProperty("time_encoder", TSFileConfig.timeEncoder);
-      TSFileConfig.valueEncoder = properties
-          .getProperty("value_encoder", TSFileConfig.valueEncoder);
-      TSFileConfig.compressor = properties.getProperty("compressor", TSFileConfig.compressor);
+              .getProperty("float_precision", Integer.toString(conf.getFloatPrecision()))));
+      conf.setTimeEncoder(properties.getProperty("time_encoder", conf.getTimeEncoder()));
+      conf.setValueEncoder(properties.getProperty("value_encoder", conf.getValueEncoder()));
+      conf.setCompressor(properties.getProperty("compressor", conf.getCompressor()));
     } catch (IOException e) {
       logger.warn("Cannot load config file, use default configuration", e);
     } catch (Exception e) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/TSEncodingBuilder.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/TSEncodingBuilder.java
@@ -97,7 +97,7 @@ public abstract class TSEncodingBuilder {
    */
   public static class PLAIN extends TSEncodingBuilder {
 
-    private int maxStringLength = TSFileConfig.maxStringLength;
+    private int maxStringLength = TSFileDescriptor.getInstance().getConfig().getMaxStringLength();
 
     @Override
     public Encoder getEncoder(TSDataType type) {
@@ -108,11 +108,11 @@ public abstract class TSEncodingBuilder {
     public void initFromProps(Map<String, String> props) {
       // set max error from initialized map or default value if not set
       if (props == null || !props.containsKey(Encoder.MAX_STRING_LENGTH)) {
-        maxStringLength = TSFileConfig.maxStringLength;
+        maxStringLength = TSFileDescriptor.getInstance().getConfig().getMaxStringLength();
       } else {
         maxStringLength = Integer.valueOf(props.get(Encoder.MAX_STRING_LENGTH));
         if (maxStringLength < 0) {
-          maxStringLength = TSFileConfig.maxStringLength;
+          maxStringLength = TSFileDescriptor.getInstance().getConfig().getMaxStringLength();
           logger.warn(
               "cannot set max string length to negative value, replaced with default value:{}",
               maxStringLength);
@@ -126,7 +126,7 @@ public abstract class TSEncodingBuilder {
    */
   public static class RLE extends TSEncodingBuilder {
 
-    private int maxPointNumber = TSFileConfig.floatPrecision;
+    private int maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
 
     @Override
     public Encoder getEncoder(TSDataType type) {
@@ -152,11 +152,11 @@ public abstract class TSEncodingBuilder {
     public void initFromProps(Map<String, String> props) {
       // set max error from initialized map or default value if not set
       if (props == null || !props.containsKey(Encoder.MAX_POINT_NUMBER)) {
-        maxPointNumber = TSFileConfig.floatPrecision;
+        maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
       } else {
         maxPointNumber = Integer.valueOf(props.get(Encoder.MAX_POINT_NUMBER));
         if (maxPointNumber < 0) {
-          maxPointNumber = TSFileConfig.floatPrecision;
+          maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
           logger
               .warn("cannot set max point number to negative value, replaced with default value:{}",
                   maxPointNumber);
@@ -200,11 +200,11 @@ public abstract class TSEncodingBuilder {
     public void initFromProps(Map<String, String> props) {
       // set max error from initialized map or default value if not set
       if (props == null || !props.containsKey(Encoder.MAX_POINT_NUMBER)) {
-        maxPointNumber = TSFileConfig.floatPrecision;
+        maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
       } else {
         maxPointNumber = Integer.valueOf(props.get(Encoder.MAX_POINT_NUMBER));
         if (maxPointNumber < 0) {
-          maxPointNumber = TSFileConfig.floatPrecision;
+          maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
           logger
               .warn("cannot set max point number to negative value, replaced with default value:{}",
                   maxPointNumber);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/ChunkReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/ChunkReader.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.compress.IUnCompressor;
 import org.apache.iotdb.tsfile.encoding.decoder.Decoder;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
@@ -42,7 +43,7 @@ public abstract class ChunkReader {
   private IUnCompressor unCompressor;
   private Decoder valueDecoder;
   private Decoder timeDecoder = Decoder.getDecoderByType(
-      TSEncoding.valueOf(TSFileConfig.timeEncoder),
+      TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder()),
       TSDataType.INT64);
 
   private Filter filter;

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/TsFileWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/TsFileWriter.java
@@ -140,8 +140,8 @@ public class TsFileWriter implements AutoCloseable{
     this.fileWriter = fileWriter;
     this.schema = schema;
     this.schema.registerMeasurements(fileWriter.getKnownSchema());
-    this.pageSize = TSFileConfig.pageSizeInByte;
-    this.chunkGroupSizeThreshold = TSFileConfig.groupSizeInByte;
+    this.pageSize = conf.getPageSizeInByte();
+    this.chunkGroupSizeThreshold = conf.getGroupSizeInByte();
     config.setTSFileStorageFs(conf.getTSFileStorageFs().name());
     if (this.pageSize >= chunkGroupSizeThreshold) {
       LOG.warn(

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.tsfile.write.chunk;
 import java.io.IOException;
 import java.math.BigDecimal;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.exception.write.PageException;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -100,7 +101,7 @@ public class ChunkWriterImpl implements IChunkWriter {
     resetPageStatistics();
 
     this.dataPageWriter = new PageWriter();
-    this.pageCountUpperBound = TSFileConfig.maxNumberOfPointsInPage;
+    this.pageCountUpperBound = TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
 
     this.dataPageWriter.setTimeEncoder(measurementSchema.getTimeEncoder());
     this.dataPageWriter.setValueEncoder(measurementSchema.getValueEncoder());

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/MeasurementSchema.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/schema/MeasurementSchema.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.encoding.encoder.Encoder;
 import org.apache.iotdb.tsfile.encoding.encoder.TSEncodingBuilder;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
@@ -62,7 +63,7 @@ public class MeasurementSchema implements Comparable<MeasurementSchema>, Seriali
    */
   public MeasurementSchema(String measurementId, TSDataType type, TSEncoding encoding) {
     this(measurementId, type, encoding,
-        CompressionType.valueOf(TSFileConfig.compressor),
+        CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor()),
         Collections.emptyMap());
   }
 
@@ -188,7 +189,7 @@ public class MeasurementSchema implements Comparable<MeasurementSchema>, Seriali
       case TEXT:
         // 4 is the length of string in type of Integer.
         // Note that one char corresponding to 3 byte is valid only in 16-bit BMP
-        return TSFileConfig.maxStringLength * TSFileConfig.BYTE_SIZE_PER_CHAR + 4;
+        return TSFileDescriptor.getInstance().getConfig().getMaxStringLength() * TSFileConfig.BYTE_SIZE_PER_CHAR + 4;
       default:
         throw new UnSupportedDataTypeException(type.toString());
     }
@@ -199,8 +200,8 @@ public class MeasurementSchema implements Comparable<MeasurementSchema>, Seriali
    * TODO can I be optimized?
    */
   public Encoder getTimeEncoder() {
-    TSEncoding timeSeriesEncoder = TSEncoding.valueOf(TSFileConfig.timeEncoder);
-    TSDataType timeType = TSDataType.valueOf(TSFileConfig.timeSeriesDataType);
+    TSEncoding timeSeriesEncoder = TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
+    TSDataType timeType = TSDataType.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType());
     return TSEncodingBuilder.getConverter(timeSeriesEncoder).getEncoder(timeType);
   }
 

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/ReadOnlyTsFileTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/ReadOnlyTsFileTest.java
@@ -47,7 +47,7 @@ public class ReadOnlyTsFileTest {
 
   @Test
   public void test1() throws InterruptedException, WriteProcessException, IOException {
-    TSFileDescriptor.getInstance().getConfig().timeEncoder = "TS_2DIFF";
+    TSFileDescriptor.getInstance().getConfig().setTimeEncoder("TS_2DIFF");
     int rowCount = 1000;
     TsFileGeneratorForTest.generateFile(rowCount, 16 * 1024 * 1024, 10000);
     fileReader = new TsFileSequenceReader(FILE_PATH);
@@ -111,7 +111,7 @@ public class ReadOnlyTsFileTest {
   @Test
   public void test2() throws InterruptedException, WriteProcessException, IOException {
     int minRowCount = 1000, maxRowCount=100000;
-    TSFileDescriptor.getInstance().getConfig().timeEncoder = "TS_2DIFF";
+    TSFileDescriptor.getInstance().getConfig().setTimeEncoder("TS_2DIFF");
     TsFileGeneratorForTest.generateFile(minRowCount, maxRowCount, 16 * 1024 * 1024, 10000);
     fileReader = new TsFileSequenceReader(FILE_PATH);
     tsFile = new ReadOnlyTsFile(fileReader);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimePlainEncodeReadTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimePlainEncodeReadTest.java
@@ -50,7 +50,7 @@ public class TimePlainEncodeReadTest {
 
   @Before
   public void prepare() throws IOException, InterruptedException, WriteProcessException {
-    TSFileDescriptor.getInstance().getConfig().timeEncoder = "PLAIN";
+    TSFileDescriptor.getInstance().getConfig().setTimeEncoder("PLAIN");
     FileGenerator.generateFile();
     TsFileSequenceReader reader = new TsFileSequenceReader(fileName);
     roTsFile = new ReadOnlyTsFile(reader);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/executor/QueryExecutorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/executor/QueryExecutorTest.java
@@ -55,7 +55,7 @@ public class QueryExecutorTest {
 
   @Before
   public void before() throws InterruptedException, WriteProcessException, IOException {
-    TSFileDescriptor.getInstance().getConfig().timeEncoder = "TS_2DIFF";
+    TSFileDescriptor.getInstance().getConfig().setTimeEncoder("TS_2DIFF");
     TsFileGeneratorForTest.generateFile(rowCount, 16 * 1024 * 1024, 10000);
     fileReader = new TsFileSequenceReader(FILE_PATH);
     metadataQuerierByFile = new MetadataQuerierByFileImpl(fileReader);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/ReaderByTimestampTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/ReaderByTimestampTest.java
@@ -46,7 +46,7 @@ public class ReaderByTimestampTest {
 
   @Before
   public void before() throws InterruptedException, WriteProcessException, IOException {
-    TSFileDescriptor.getInstance().getConfig().timeEncoder = "TS_2DIFF";
+    TSFileDescriptor.getInstance().getConfig().setTimeEncoder("TS_2DIFF");
     TsFileGeneratorForSeriesReaderByTimestamp.generateFile(rowCount, 10 * 1024 * 1024, 10000);
     fileReader = new TsFileSequenceReader(FILE_PATH);// TODO remove this class
     metadataQuerierByFile = new MetadataQuerierByFileImpl(fileReader);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/TimeGeneratorTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/TimeGeneratorTest.java
@@ -49,7 +49,7 @@ public class TimeGeneratorTest {
 
   @Before
   public void before() throws InterruptedException, WriteProcessException, IOException {
-    TSFileDescriptor.getInstance().getConfig().timeEncoder = "TS_2DIFF";
+    TSFileDescriptor.getInstance().getConfig().setTimeEncoder("TS_2DIFF");
     TsFileGeneratorForTest.generateFile(1000, 10 * 1024 * 1024, 10000);
     fileReader = new TsFileSequenceReader(FILE_PATH);
     metadataQuerierByFile = new MetadataQuerierByFileImpl(fileReader);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/TsFileGeneratorForSeriesReaderByTimestamp.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/query/timegenerator/TsFileGeneratorForSeriesReaderByTimestamp.java
@@ -76,8 +76,8 @@ public class TsFileGeneratorForSeriesReaderByTimestamp {
   }
 
   public static void after() {
-    TSFileDescriptor.getInstance().getConfig().groupSizeInByte = preChunkGroupSize;
-    TSFileDescriptor.getInstance().getConfig().maxNumberOfPointsInPage = prePageSize;
+    TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(preChunkGroupSize);
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(prePageSize);
     File file = new File(inputDataFile);
     if (file.exists()) {
       Assert.assertTrue(file.delete());
@@ -156,10 +156,10 @@ public class TsFileGeneratorForSeriesReaderByTimestamp {
     }
 
     // LOG.info(jsonSchema.toString());
-    preChunkGroupSize = TSFileDescriptor.getInstance().getConfig().groupSizeInByte;
-    prePageSize = TSFileDescriptor.getInstance().getConfig().maxNumberOfPointsInPage;
-    TSFileDescriptor.getInstance().getConfig().groupSizeInByte = chunkGroupSize;
-    TSFileDescriptor.getInstance().getConfig().maxNumberOfPointsInPage = pageSize;
+    preChunkGroupSize = TSFileDescriptor.getInstance().getConfig().getGroupSizeInByte();
+    prePageSize = TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
+    TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(chunkGroupSize);
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(pageSize);
     innerWriter = new TsFileWriter(file, schema, TSFileDescriptor.getInstance().getConfig());
 
     // write
@@ -174,9 +174,9 @@ public class TsFileGeneratorForSeriesReaderByTimestamp {
   private static void generateTestData() {
     TSFileConfig conf = TSFileDescriptor.getInstance().getConfig();
     schema = new Schema();
-    schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT32, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.valueOf(conf.valueEncoder), CompressionType.UNCOMPRESSED));
-    schema.registerMeasurement(new MeasurementSchema("s3", TSDataType.INT64, TSEncoding.valueOf(conf.valueEncoder), CompressionType.SNAPPY));
+    schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT32, TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.valueOf(conf.getValueEncoder()), CompressionType.UNCOMPRESSED));
+    schema.registerMeasurement(new MeasurementSchema("s3", TSDataType.INT64, TSEncoding.valueOf(conf.getValueEncoder()), CompressionType.SNAPPY));
     schema.registerMeasurement(new MeasurementSchema("s4", TSDataType.TEXT, TSEncoding.PLAIN));
     schema.registerMeasurement(new MeasurementSchema("s5", TSDataType.BOOLEAN, TSEncoding.PLAIN));
     schema.registerMeasurement(new MeasurementSchema("s6", TSDataType.FLOAT, TSEncoding.RLE));

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/reader/ReaderTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/reader/ReaderTest.java
@@ -51,7 +51,7 @@ public class ReaderTest {
 
   @Before
   public void before() throws InterruptedException, WriteProcessException, IOException {
-    TSFileDescriptor.getInstance().getConfig().timeEncoder = "TS_2DIFF";
+    TSFileDescriptor.getInstance().getConfig().setTimeEncoder("TS_2DIFF");
     TsFileGeneratorForTest.generateFile(rowCount, 10 * 1024 * 1024, 10000);
     fileReader = new TsFileSequenceReader(FILE_PATH);
     metadataQuerierByFile = new MetadataQuerierByFileImpl(fileReader);

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileGenerator.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/FileGenerator.java
@@ -51,12 +51,12 @@ public class FileGenerator {
       throws IOException, InterruptedException, WriteProcessException {
     ROW_COUNT = rowCount;
     TSFileConfig config = TSFileDescriptor.getInstance().getConfig();
-    oldMaxNumberOfPointsInPage = config.maxNumberOfPointsInPage;
-    config.maxNumberOfPointsInPage = maxNumberOfPointsInPage;
+    oldMaxNumberOfPointsInPage = config.getMaxNumberOfPointsInPage();
+    config.setMaxNumberOfPointsInPage(maxNumberOfPointsInPage);
 
     prepare();
     write();
-    config.maxNumberOfPointsInPage = oldMaxNumberOfPointsInPage;
+    config.setMaxNumberOfPointsInPage(oldMaxNumberOfPointsInPage);
   }
 
   public static void generateFile()
@@ -168,9 +168,12 @@ public class FileGenerator {
   private static void generateTestData() {
     schema = new Schema();
     TSFileConfig conf = TSFileDescriptor.getInstance().getConfig();
-    schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT32, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s3", TSDataType.INT64, TSEncoding.valueOf(conf.valueEncoder)));
+    schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT32,
+        TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64,
+        TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s3", TSDataType.INT64,
+        TSEncoding.valueOf(conf.getValueEncoder())));
     schema.registerMeasurement(new MeasurementSchema("s4", TSDataType.TEXT, TSEncoding.PLAIN));
     schema.registerMeasurement(new MeasurementSchema("s5", TSDataType.BOOLEAN, TSEncoding.PLAIN));
     schema.registerMeasurement(new MeasurementSchema("s6", TSDataType.FLOAT, TSEncoding.RLE));

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/RecordUtilsTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/RecordUtilsTest.java
@@ -46,10 +46,14 @@ public class RecordUtilsTest {
   private static Schema generateTestData() {
     Schema schema = new Schema();
     TSFileConfig conf = TSFileDescriptor.getInstance().getConfig();
-    schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT32, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s3", TSDataType.FLOAT, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s4", TSDataType.DOUBLE, TSEncoding.valueOf(conf.valueEncoder)));
+    schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT32,
+        TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64,
+        TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s3", TSDataType.FLOAT,
+        TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s4", TSDataType.DOUBLE,
+        TSEncoding.valueOf(conf.getValueEncoder())));
     schema.registerMeasurement(new MeasurementSchema("s5", TSDataType.BOOLEAN, TSEncoding.PLAIN));
     schema.registerMeasurement(new MeasurementSchema("s6", TSDataType.TEXT, TSEncoding.PLAIN));
     return schema;

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/TsFileGeneratorForTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/utils/TsFileGeneratorForTest.java
@@ -157,8 +157,8 @@ public class TsFileGeneratorForTest {
 
     Schema schema = generateTestSchema();
 
-    TSFileDescriptor.getInstance().getConfig().groupSizeInByte = chunkGroupSize;
-    TSFileDescriptor.getInstance().getConfig().maxNumberOfPointsInPage = pageSize;
+    TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(chunkGroupSize);
+    TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(pageSize);
     innerWriter = new TsFileWriter(file, schema, TSFileDescriptor.getInstance().getConfig());
 
     // write
@@ -181,15 +181,15 @@ public class TsFileGeneratorForTest {
     JSONObject s1 = new JSONObject();
     s1.put(JsonFormatConstant.MEASUREMENT_UID, "s1");
     s1.put(JsonFormatConstant.DATA_TYPE, TSDataType.INT32.toString());
-    s1.put(JsonFormatConstant.MEASUREMENT_ENCODING, conf.valueEncoder);
+    s1.put(JsonFormatConstant.MEASUREMENT_ENCODING, conf.getValueEncoder());
     JSONObject s2 = new JSONObject();
     s2.put(JsonFormatConstant.MEASUREMENT_UID, "s2");
     s2.put(JsonFormatConstant.DATA_TYPE, TSDataType.INT64.toString());
-    s2.put(JsonFormatConstant.MEASUREMENT_ENCODING, conf.valueEncoder);
+    s2.put(JsonFormatConstant.MEASUREMENT_ENCODING, conf.getValueEncoder());
     JSONObject s3 = new JSONObject();
     s3.put(JsonFormatConstant.MEASUREMENT_UID, "s3");
     s3.put(JsonFormatConstant.DATA_TYPE, TSDataType.INT64.toString());
-    s3.put(JsonFormatConstant.MEASUREMENT_ENCODING, conf.valueEncoder);
+    s3.put(JsonFormatConstant.MEASUREMENT_ENCODING, conf.getValueEncoder());
     JSONObject s4 = new JSONObject();
     s4.put(JsonFormatConstant.MEASUREMENT_UID, "s4");
     s4.put(JsonFormatConstant.DATA_TYPE, TSDataType.TEXT.toString());

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/PerfTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/PerfTest.java
@@ -153,9 +153,12 @@ public class PerfTest {
   private static Schema generateTestData() {
     Schema schema = new Schema();
     TSFileConfig conf = TSFileDescriptor.getInstance().getConfig();
-    schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s3", TSDataType.INT64, TSEncoding.valueOf(conf.valueEncoder)));
+    schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT64,
+        TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64,
+        TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s3", TSDataType.INT64,
+        TSEncoding.valueOf(conf.getValueEncoder())));
     schema.registerMeasurement(new MeasurementSchema("s4", TSDataType.TEXT, TSEncoding.PLAIN));
     JSONObject s4 = new JSONObject();
     s4.put(JsonFormatConstant.MEASUREMENT_UID, "s4");

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/ReadPageInMemTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/ReadPageInMemTest.java
@@ -52,24 +52,28 @@ public class ReadPageInMemTest {
   private static Schema getSchema() {
     Schema schema = new Schema();
     TSFileConfig conf = TSFileDescriptor.getInstance().getConfig();
-    schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT32, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s3", TSDataType.FLOAT, TSEncoding.valueOf(conf.valueEncoder)));
-    schema.registerMeasurement(new MeasurementSchema("s4", TSDataType.DOUBLE, TSEncoding.valueOf(conf.valueEncoder)));
+    schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT32,
+        TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64,
+        TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s3", TSDataType.FLOAT,
+        TSEncoding.valueOf(conf.getValueEncoder())));
+    schema.registerMeasurement(new MeasurementSchema("s4", TSDataType.DOUBLE,
+        TSEncoding.valueOf(conf.getValueEncoder())));
     return schema;
   }
 
   @Before
   public void setUp() throws Exception {
     file.delete();
-    pageSize = conf.pageSizeInByte;
-    conf.pageSizeInByte = 200;
-    ChunkGroupSize = conf.groupSizeInByte;
-    conf.groupSizeInByte = 100000;
-    pageCheckSizeThreshold = conf.pageCheckSizeThreshold;
-    conf.pageCheckSizeThreshold = 1;
-    defaultMaxStringLength = conf.maxStringLength;
-    conf.maxStringLength = 2;
+    pageSize = conf.getPageSizeInByte();
+    conf.setPageSizeInByte(200);
+    ChunkGroupSize = conf.getGroupSizeInByte();
+    conf.setGroupSizeInByte(100000);
+    pageCheckSizeThreshold = conf.getPageCheckSizeThreshold();
+    conf.setPageCheckSizeThreshold(1);
+    defaultMaxStringLength = conf.getMaxStringLength();
+    conf.setMaxStringLength(2);
     schema = getSchema();
     innerWriter = new TsFileWriter(new File(filePath), schema, conf);
   }
@@ -77,10 +81,10 @@ public class ReadPageInMemTest {
   @After
   public void tearDown() throws Exception {
     file.delete();
-    conf.pageSizeInByte = pageSize;
-    conf.groupSizeInByte = ChunkGroupSize;
-    conf.pageCheckSizeThreshold = pageCheckSizeThreshold;
-    conf.maxStringLength = defaultMaxStringLength;
+    conf.setPageSizeInByte(pageSize);
+    conf.setGroupSizeInByte(ChunkGroupSize);
+    conf.setPageCheckSizeThreshold(pageCheckSizeThreshold);
+    conf.setMaxStringLength(defaultMaxStringLength);
   }
 
   @Test

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/TsFileReadWriteTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/TsFileReadWriteTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -126,10 +127,10 @@ public class TsFileReadWriteTest {
 
   @Test
   public void readMeasurementWithRegularEncodingTest() throws IOException, WriteProcessException {
-    TSFileConfig.timeEncoder = "REGULAR";
+    TSFileDescriptor.getInstance().getConfig().setTimeEncoder("REGULAR");
     writeDataByTSRecord(TSDataType.INT64, (i) -> new LongDataPoint("sensor_1", i), TSEncoding.REGULAR);
     readData((i, field, delta) -> assertEquals(i, field.getLongV()));
-    TSFileConfig.timeEncoder = "TS_2DIFF";
+    TSFileDescriptor.getInstance().getConfig().setTimeEncoder("TS_2DIFF");
   }
 
   private void writeDataByTSRecord(TSDataType dataType, DataPointProxy proxy, TSEncoding encodingType)

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/write/WriteTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/write/WriteTest.java
@@ -80,10 +80,10 @@ public class WriteTest {
     outputDataFile = "target/writeTestOutputData.tsfile";
     errorOutputDataFile = "target/writeTestErrorOutputData.tsfile";
     // for each row, flush page forcely
-    prePageSize = conf.pageSizeInByte;
-    conf.pageSizeInByte = 0;
-    prePageCheckThres = conf.pageCheckSizeThreshold;
-    conf.pageCheckSizeThreshold = 0;
+    prePageSize = conf.getPageSizeInByte();
+    conf.setPageSizeInByte(0);
+    prePageCheckThres = conf.getPageCheckSizeThreshold();
+    conf.setPageCheckSizeThreshold(0);
 
     try {
       generateSampleInputDataFile();
@@ -104,11 +104,11 @@ public class WriteTest {
     HashMap<String,String> props = new HashMap<>();
     props.put("max_point_number", "2");
     measurementArray.add(new MeasurementSchema("s2", TSDataType.FLOAT, TSEncoding.RLE,
-                              CompressionType.valueOf(TSFileConfig.compressor), props));
+                              CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor()), props));
     props = new HashMap<>();
     props.put("max_point_number", "3");
     measurementArray.add(new MeasurementSchema("s3", TSDataType.DOUBLE, TSEncoding.TS_2DIFF,
-            CompressionType.valueOf(TSFileConfig.compressor), props));
+            CompressionType.valueOf(TSFileDescriptor.getInstance().getConfig().getCompressor()), props));
     measurementArray.add(new MeasurementSchema("s4", TSDataType.BOOLEAN, TSEncoding.PLAIN));
     schema = new Schema();
     LOG.info(schema.toString());
@@ -133,8 +133,8 @@ public class WriteTest {
 
   @After
   public void end() {
-    conf.pageSizeInByte = prePageSize;
-    conf.pageCheckSizeThreshold = prePageCheckThres;
+    conf.setPageSizeInByte(prePageSize);
+    conf.setPageCheckSizeThreshold(prePageCheckThres);
   }
 
   private void generateSampleInputDataFile() throws IOException {


### PR DESCRIPTION
There are many codes like the following codes.
```java
TSFileDescriptor.getInstance().getConfig().groupSizeInByte = preChunkGroupSize;
TSFileDescriptor.getInstance().getConfig().timeEncoder = "TS_2DIFF";
```
1. Create an object to assign static member value is meaningless because you can access it through class name.
2. It’s also dangerous to access directly a member can be changed.

I apply the design idea of IoTDBConfig to TsFileConfig.