### PR TITLE
[IOTDB-231] Fix data cannot be found when restarting server in HDFS

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -252,8 +252,8 @@ public class StorageGroupProcessor {
       // the process was interrupted before the merged files could be named
       continueFailedRenames(fileFolder, MERGE_SUFFIX);
 
-      Collections
-          .addAll(tsFiles, fileFolder.listFiles(file -> file.getName().endsWith(TSFILE_SUFFIX)));
+      Collections.addAll(tsFiles,
+          TSFileFactory.INSTANCE.listFilesBySuffix(fileFolder.getAbsolutePath(), TSFILE_SUFFIX));
     }
     tsFiles.sort(this::compareFileName);
     List<TsFileResource> ret = new ArrayList<>();
@@ -262,7 +262,7 @@ public class StorageGroupProcessor {
   }
 
   private void continueFailedRenames(File fileFolder, String suffix) {
-    File[] files = fileFolder.listFiles(file -> file.getName().endsWith(suffix));
+    File[] files = TSFileFactory.INSTANCE.listFilesBySuffix(fileFolder.getAbsolutePath(), suffix);
     if (files != null) {
       for (File tempResource : files) {
         File originResource = TSFileFactory.INSTANCE.getFile(tempResource.getPath().replace(suffix, ""));

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileResourcePrinter.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileResourcePrinter.java
@@ -27,6 +27,7 @@ import java.util.Comparator;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.qp.constant.DatetimeUtils;
 import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
+import org.apache.iotdb.tsfile.fileSystem.TSFileFactory;
 
 /**
  * this tool can analyze the tsfile.resource files from a folder.
@@ -40,7 +41,7 @@ public class TsFileResourcePrinter {
       folder = args[0];
     }
     File folderFile = SystemFileFactory.INSTANCE.getFile(folder);
-    File[] files = folderFile.listFiles(file -> file.getName().endsWith(".tsfile.resource"));
+    File[] files = TSFileFactory.INSTANCE.listFilesBySuffix(folderFile.getAbsolutePath(), ".tsfile.resource");
     Arrays.sort(files, Comparator.comparingLong(x -> Long.valueOf(x.getName().split("-")[0])));
 
     for (File file : files) {

--- a/server/src/main/java/org/apache/iotdb/db/writelog/recover/LogReplayer.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/recover/LogReplayer.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
 import org.apache.iotdb.db.engine.memtable.IMemTable;
 import org.apache.iotdb.db.engine.modification.Deletion;
 import org.apache.iotdb.db.engine.modification.ModificationFile;
@@ -39,6 +38,7 @@ import org.apache.iotdb.db.writelog.io.ILogReader;
 import org.apache.iotdb.db.writelog.manager.MultiFileLogNodeManager;
 import org.apache.iotdb.db.writelog.node.WriteLogNode;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.fileSystem.TSFileFactory;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.write.schema.Schema;
 
@@ -85,7 +85,7 @@ public class LogReplayer {
    */
   public void replayLogs() throws ProcessorException {
     WriteLogNode logNode = MultiFileLogNodeManager.getInstance().getNode(
-        logNodePrefix + SystemFileFactory.INSTANCE.getFile(insertFilePath).getName());
+        logNodePrefix + TSFileFactory.INSTANCE.getFile(insertFilePath).getName());
 
     ILogReader logReader = logNode.getLogReader();
     try {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/FileInputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/FileInputFactory.java
@@ -34,7 +34,7 @@ public enum FileInputFactory {
   INSTANCE;
 
   private static FSType fsType = TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs();
-  private static final Logger logger = LoggerFactory.getLogger(TsFileIOWriter.class);
+  private static final Logger logger = LoggerFactory.getLogger(FileInputFactory.class);
 
   public TsFileInput getTsFileInput(String filePath) {
     try {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/FileOutputFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/FileOutputFactory.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.tsfile.fileSystem;
 
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.write.writer.DefaultTsFileOutput;
-import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 import org.apache.iotdb.tsfile.write.writer.TsFileOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,12 +33,12 @@ public enum FileOutputFactory {
   INSTANCE;
 
   private static FSType fsType = TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs();
-  private static final Logger logger = LoggerFactory.getLogger(TsFileIOWriter.class);
+  private static final Logger logger = LoggerFactory.getLogger(FileOutputFactory.class);
 
   public TsFileOutput getTsFileOutput(String filePath, boolean append) {
     try {
       if (fsType.equals(FSType.HDFS)) {
-        return new HDFSOutput(filePath, append);
+        return new HDFSOutput(filePath, !append);
       } else {
         return new DefaultTsFileOutput(new FileOutputStream(filePath, append));
       }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/TSFileFactory.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/fileSystem/TSFileFactory.java
@@ -19,29 +19,42 @@
 
 package org.apache.iotdb.tsfile.fileSystem;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
-import org.apache.iotdb.tsfile.write.TsFileWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.*;
-import java.net.URI;
 
 public enum TSFileFactory {
 
   INSTANCE;
 
   private static FSType fSType = TSFileDescriptor.getInstance().getConfig().getTSFileStorageFs();
-  private static final Logger logger = LoggerFactory.getLogger(TsFileWriter.class);
+  private static final Logger logger = LoggerFactory.getLogger(TSFileFactory.class);
   private FileSystem fs;
   private Configuration conf = new Configuration();
 
   public File getFile(String pathname) {
-    if (fSType.equals(fSType.HDFS)) {
+    if (fSType.equals(FSType.HDFS)) {
       return new HDFSFile(pathname);
     } else {
       return new File(pathname);
@@ -49,7 +62,7 @@ public enum TSFileFactory {
   }
 
   public File getFile(String parent, String child) {
-    if (fSType.equals(fSType.HDFS)) {
+    if (fSType.equals(FSType.HDFS)) {
       return new HDFSFile(parent, child);
     } else {
       return new File(parent, child);
@@ -57,7 +70,7 @@ public enum TSFileFactory {
   }
 
   public File getFile(File parent, String child) {
-    if (fSType.equals(fSType.HDFS)) {
+    if (fSType.equals(FSType.HDFS)) {
       return new HDFSFile(parent, child);
     } else {
       return new File(parent, child);
@@ -65,7 +78,7 @@ public enum TSFileFactory {
   }
 
   public File getFile(URI uri) {
-    if (fSType.equals(fSType.HDFS)) {
+    if (fSType.equals(FSType.HDFS)) {
       return new HDFSFile(uri);
     } else {
       return new File(uri);
@@ -74,7 +87,7 @@ public enum TSFileFactory {
 
   public BufferedReader getBufferedReader(String filePath) {
     try {
-      if (fSType.equals(fSType.HDFS)) {
+      if (fSType.equals(FSType.HDFS)) {
         Path path = new Path(filePath);
         fs = path.getFileSystem(conf);
         return new BufferedReader(new InputStreamReader(fs.open(path)));
@@ -89,7 +102,7 @@ public enum TSFileFactory {
 
   public BufferedWriter getBufferedWriter(String filePath, boolean append) {
     try {
-      if (fSType.equals(fSType.HDFS)) {
+      if (fSType.equals(FSType.HDFS)) {
         Path path = new Path(filePath);
         fs = path.getFileSystem(conf);
         return new BufferedWriter(new OutputStreamWriter(fs.create(path)));
@@ -104,7 +117,7 @@ public enum TSFileFactory {
 
   public BufferedInputStream getBufferedInputStream(String filePath) {
     try {
-      if (fSType.equals(fSType.HDFS)) {
+      if (fSType.equals(FSType.HDFS)) {
         Path path = new Path(filePath);
         fs = path.getFileSystem(conf);
         return new BufferedInputStream(fs.open(path));
@@ -119,7 +132,7 @@ public enum TSFileFactory {
 
   public BufferedOutputStream getBufferedOutputStream(String filePath) {
     try {
-      if (fSType.equals(fSType.HDFS)) {
+      if (fSType.equals(FSType.HDFS)) {
         Path path = new Path(filePath);
         fs = path.getFileSystem(conf);
         return new BufferedOutputStream(fs.create(path));
@@ -134,16 +147,55 @@ public enum TSFileFactory {
 
   public void moveFile(File srcFile, File destFile) {
     try {
-      if (fSType.equals(fSType.HDFS)) {
+      if (fSType.equals(FSType.HDFS)) {
         boolean rename = srcFile.renameTo(destFile);
         if (!rename) {
-          logger.error("Failed to rename file from {} to {}. ", srcFile.getName(), destFile.getName());
+          logger.error("Failed to rename file from {} to {}. ", srcFile.getName(),
+              destFile.getName());
         }
       } else {
         FileUtils.moveFile(srcFile, destFile);
       }
     } catch (IOException e) {
-      logger.error("Failed to move file from {} to {}. ", srcFile.getAbsolutePath(), destFile.getAbsolutePath(), e);
+      logger.error("Failed to move file from {} to {}. ", srcFile.getAbsolutePath(),
+          destFile.getAbsolutePath(), e);
     }
+  }
+
+  public File[] listFilesBySuffix(String fileFolder, String suffix) {
+    if (fSType.equals(FSType.HDFS)) {
+      PathFilter pathFilter = path -> path.toUri().toString().endsWith(suffix);
+      List<HDFSFile> files = listFiles(fileFolder, pathFilter);
+      return files.toArray(new HDFSFile[files.size()]);
+    } else {
+      return new File(fileFolder).listFiles(file -> file.getName().endsWith(suffix));
+    }
+  }
+
+  public File[] listFilesByPrefix(String fileFolder, String prefix) {
+    if (fSType.equals(FSType.HDFS)) {
+      PathFilter pathFilter = path -> path.toUri().toString().startsWith(prefix);
+      List<HDFSFile> files = listFiles(fileFolder, pathFilter);
+      return files.toArray(new HDFSFile[files.size()]);
+    } else {
+      return new File(fileFolder).listFiles(file -> file.getName().startsWith(prefix));
+    }
+  }
+
+  private List<HDFSFile> listFiles(String fileFolder, PathFilter pathFilter) {
+    List<HDFSFile> files = new ArrayList<>();
+    try {
+      Path path = new Path(fileFolder);
+      fs = path.getFileSystem(conf);
+      for (FileStatus fileStatus: fs.listStatus(path)) {
+        Path filePath = fileStatus.getPath();
+        if (pathFilter.accept(filePath)) {
+          files.add(new HDFSFile(filePath.toUri().toString()));
+        }
+      }
+    } catch (IOException e) {
+      logger.error("Failed to list files in {}. ", fileFolder);
+    }
+    return files;
   }
 }


### PR DESCRIPTION
Fix data cannot be found when restarting server in HDFS.
* [HDFS truncate function](https://issues.apache.org/jira/browse/HDFS-3107) is developed after 2.7.0, so if users have installed previous Hadoop version, they will get errors "truncate function is not supported" in server.
* In HDFS, appending and creating are totally different operations. In Java File System, we use `new FileOutputStream(file, append)` to **create**(`append` = false) or **append**(`append` = true) FileOutputStream. However in HDFS, `fs.append(path)` is used to **append** FSDataOutputStream  when the path exists, and `fs.create(path, overwrite)` is used to **create or overwrite** FSDataOutputStream. If a file with this name already exists, then if true, the file will be overwritten, and if false an exception will be thrown.
* HDFS uses **lease** mechanism to maintain data consistency, which means when each client program writes data to a file, other client programs are not allowed to write data to the file at the same time. This affects appending and truncating a lot, because every time calling truncate method, an AlreadyBeenCreatedException will be thrown. So here I change the codes to: 
```
    if (fs.exists(path)) {
      fsDataOutputStream.close(); // close stream first
    }
    fs.truncate(path, position); // truncate
    if (fs.exists(path)) {
      fsDataOutputStream = fs.append(path); // open stream again
    }
```