### PR TITLE
Avoid creating a new ChunkGroupFooter object.

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/TsFileWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/TsFileWriter.java
@@ -22,19 +22,17 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.exception.write.NoMeasurementException;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
-import org.apache.iotdb.tsfile.file.footer.ChunkGroupFooter;
 import org.apache.iotdb.tsfile.write.chunk.ChunkGroupWriterImpl;
 import org.apache.iotdb.tsfile.write.chunk.IChunkGroupWriter;
 import org.apache.iotdb.tsfile.write.record.RowBatch;
 import org.apache.iotdb.tsfile.write.record.TSRecord;
 import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint;
-import org.apache.iotdb.tsfile.write.schema.Schema;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+import org.apache.iotdb.tsfile.write.schema.Schema;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 import org.apache.iotdb.tsfile.write.writer.TsFileOutput;
 import org.slf4j.Logger;
@@ -303,11 +301,11 @@ public class TsFileWriter implements AutoCloseable{
         String deviceId = entry.getKey();
         IChunkGroupWriter groupWriter = entry.getValue();
         fileWriter.startChunkGroup(deviceId);
-        ChunkGroupFooter chunkGroupFooter = groupWriter.flushToFileWriter(fileWriter);
-        if (fileWriter.getPos() - pos != chunkGroupFooter.getDataSize()) {
+        long dataSize = groupWriter.flushToFileWriter(fileWriter);
+        if (fileWriter.getPos() - pos != dataSize) {
           throw new IOException(String.format(
               "Flushed data size is inconsistent with computation! Estimated: %d, Actual: %d",
-              chunkGroupFooter.getDataSize(), fileWriter.getPos() - pos));
+              dataSize, fileWriter.getPos() - pos));
         }
         fileWriter.endChunkGroup(0);
       }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkGroupWriterImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkGroupWriterImpl.java
@@ -118,17 +118,16 @@ public class ChunkGroupWriterImpl implements IChunkGroupWriter {
   }
 
   @Override
-  public ChunkGroupFooter flushToFileWriter(TsFileIOWriter fileWriter) throws IOException {
+  public long flushToFileWriter(TsFileIOWriter fileWriter) throws IOException {
     LOG.debug("start flush device id:{}", deviceId);
     // make sure all the pages have been compressed into buffers, so that we can get correct
     // groupWriter.getCurrentChunkGroupSize().
     sealAllChunks();
-    ChunkGroupFooter footer = new ChunkGroupFooter(deviceId, getCurrentChunkGroupSize(),
-        getSeriesNumber());
+    long currentChunkGroupSize = getCurrentChunkGroupSize();
     for (IChunkWriter seriesWriter : chunkWriters.values()) {
       seriesWriter.writeToFileWriter(fileWriter);
     }
-    return footer;
+    return currentChunkGroupSize;
   }
 
   @Override

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/IChunkGroupWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/IChunkGroupWriter.java
@@ -69,6 +69,7 @@ public interface IChunkGroupWriter {
    *            - TSFileIOWriter
    * @throws IOException
    *             exception in IO
+   * @return current ChunkGroupDataSize
    */
   long flushToFileWriter(TsFileIOWriter tsfileWriter) throws IOException;
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/IChunkGroupWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/IChunkGroupWriter.java
@@ -70,7 +70,7 @@ public interface IChunkGroupWriter {
    * @throws IOException
    *             exception in IO
    */
-  ChunkGroupFooter flushToFileWriter(TsFileIOWriter tsfileWriter) throws IOException;
+  long flushToFileWriter(TsFileIOWriter tsfileWriter) throws IOException;
 
   /**
    * get the max memory occupied at this time.


### PR DESCRIPTION
Avoid creating a new ChunkGroupFooter object which wastes memory. In endChunkGroup method, it creates a new ChunkGroupFooter object again.