### PR TITLE
Reduce project version declaration

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -87,13 +87,13 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-client</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <type>zip</type>
         </dependency>
     </dependencies>

--- a/example/jdbc/pom.xml
+++ b/example/jdbc/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/example/kafka/pom.xml
+++ b/example/kafka/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/example/rocketmq/pom.xml
+++ b/example/rocketmq/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rocketmq</groupId>

--- a/example/session/pom.xml
+++ b/example/session/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/example/tsfile/pom.xml
+++ b/example/tsfile/pom.xml
@@ -28,13 +28,12 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tsfile-example</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
     <name>tsfile-example</name>
     <dependencies>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>tsfile</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/grafana/pom.xml
+++ b/grafana/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -39,12 +39,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>tsfile</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
         <module>spark-tsfile</module>
         <module>spark-iotdb-connector</module>
         <!-- <module>hadoop</module> -->
-        <module>distribution</module>
+    <!-- <module>distribution</module> -->
     </modules>
-    <!-- Properties Management -->
+<!-- Properties Management -->
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -394,6 +394,17 @@
     <build>
         <pluginManagement>
             <plugins>
+                <!-- using `mvn -N versions:update-child-modules` can update the version
+                of child modules to what their parent claims -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.3</version>
+                    <configuration>
+                        <generateBackupPoms>false</generateBackupPoms>
+                    </configuration>
+                </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <module>spark-tsfile</module>
         <module>spark-iotdb-connector</module>
         <!-- <module>hadoop</module> -->
-    <!-- <module>distribution</module> -->
+        <module>distribution</module>
     </modules>
 <!-- Properties Management -->
     <properties>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -38,17 +38,17 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>tsfile</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/session/pom.xml
+++ b/session/pom.xml
@@ -69,23 +69,23 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>tsfile</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-iotdb-connector/pom.xml
+++ b/spark-iotdb-connector/pom.xml
@@ -28,7 +28,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>spark-iotdb-connector</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -49,12 +48,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spark-tsfile/pom.xml
+++ b/spark-tsfile/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>tsfile</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
1. Now, each pom file only has one declaration for the version.

2. If you need to update the version of IoTDB (e.g., from 0.9.0-SNAPSHOT to 0.9.0), you even do not need to change the version of child's module  one by one now.
  2.1 just change the version declaration in root/pom.xml;
  2.2 run `mvn  -N versions:update-child-modules` 
  2.3 bingo! the versions of all children modules are updated automatically.
