### PR TITLE
[IOTDB-174] Fix querying timeseries interface cannot make a query by the specified path prefix

### DIFF
--- a/docs/Documentation-CHN/UserGuide/4-Operation Manual/7-IoTDB Query Language.md
+++ b/docs/Documentation-CHN/UserGuide/4-Operation Manual/7-IoTDB Query Language.md
@@ -88,6 +88,38 @@ Eg: IoTDB > SHOW STORAGE GROUP
 Note: This statement can be used in IoTDB Client and JDBC.
 ```
 
+* 显示指定路径下时间序列数语句
+
+```
+COUNT TIMESERIES <Path>
+Eg: IoTDB > COUNT TIMESERIES root
+Eg: IoTDB > COUNT TIMESERIES root.ln
+Eg: IoTDB > COUNT TIMESERIES root.ln.*.*.status
+Eg: IoTDB > COUNT TIMESERIES root.ln.wf01.wt01.status
+Note: The path can be prefix path, star path or timeseries path.
+Note: This statement can be used in IoTDB Client and JDBC.
+```
+
+```
+COUNT TIMESERIES <Path> GROUP BY LEVEL=<INTEGER>
+Eg: IoTDB > COUNT TIMESERIES root GROUP BY LEVEL=1
+Eg: IoTDB > COUNT TIMESERIES root.ln GROUP BY LEVEL=2
+Eg: IoTDB > COUNT TIMESERIES root.ln.wf01 GROUP BY LEVEL=3
+Note: The path can be prefix path or timeseries path.
+Note: This statement can be used in IoTDB Client and JDBC.
+```
+
+* 显示指定路径下特定层级的节点数语句
+
+```
+COUNT NODES <Path> LEVEL=<INTEGER>
+Eg: IoTDB > COUNT NODES root LEVEL=2
+Eg: IoTDB > COUNT NODES root.ln LEVEL=2
+Eg: IoTDB > COUNT NODES root.ln.wf01 LEVEL=3
+Note: The path can be prefix path or timeseries path.
+Note: This statement can be used in IoTDB Client and JDBC.
+```
+
 ### 数据管理语句
 
 * 插入记录语句

--- a/docs/Documentation/UserGuide/4-Operation Manual/7-IoTDB Query Statement.md
+++ b/docs/Documentation/UserGuide/4-Operation Manual/7-IoTDB Query Statement.md
@@ -96,6 +96,38 @@ Eg: IoTDB > SHOW STORAGE GROUP
 Note: This statement can be used in IoTDB Client and JDBC.
 ```
 
+* Count Timeseries Statement
+
+```
+COUNT TIMESERIES <Path>
+Eg: IoTDB > COUNT TIMESERIES root
+Eg: IoTDB > COUNT TIMESERIES root.ln
+Eg: IoTDB > COUNT TIMESERIES root.ln.*.*.status
+Eg: IoTDB > COUNT TIMESERIES root.ln.wf01.wt01.status
+Note: The path can be prefix path, star path or timeseries path.
+Note: This statement can be used in IoTDB Client and JDBC.
+```
+
+```
+COUNT TIMESERIES <Path> GROUP BY LEVEL=<INTEGER>
+Eg: IoTDB > COUNT TIMESERIES root GROUP BY LEVEL=1
+Eg: IoTDB > COUNT TIMESERIES root.ln GROUP BY LEVEL=2
+Eg: IoTDB > COUNT TIMESERIES root.ln.wf01 GROUP BY LEVEL=3
+Note: The path can be prefix path or timeseries path.
+Note: This statement can be used in IoTDB Client and JDBC.
+```
+
+* Count Nodes Statement
+
+```
+COUNT NODES <Path> LEVEL=<INTEGER>
+Eg: IoTDB > COUNT NODES root LEVEL=2
+Eg: IoTDB > COUNT NODES root.ln LEVEL=2
+Eg: IoTDB > COUNT NODES root.ln.wf01 LEVEL=3
+Note: The path can be prefix path or timeseries path.
+Note: This statement can be used in IoTDB Client and JDBC.
+```
+
 ### Data Management Statement
 
 * Insert Record Statement

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -87,49 +87,63 @@ import org.apache.iotdb.jdbc.IoTDBSQLException;
     //Create time series
     //Different data type has different encoding methods. Here use INT32 as an example
     try {
-      statement.execute("CREATE TIMESERIES root.demo.s0 WITH DATATYPE=INT32,ENCODING=RLE;");
+      statement.execute("CREATE TIMESERIES root.demo.d0.s0 WITH DATATYPE=INT32,ENCODING=RLE;");
     }catch (IoTDBSQLException e){
       System.out.println(e.getMessage());
     }
     //Show time series
-    statement.execute("SHOW TIMESERIES root.demo");
+    statement.execute("SHOW TIMESERIES root.demo.d0");
+    outputResult(statement.getResultSet());
+    //Show devices
+    statement.execute("SHOW DEVICES");
+    outputResult(statement.getResultSet());
+    //Count time series by given prefix
+    statement.execute("COUNT TIMESERIES root.demo.d0");
+    outputResult(statement.getResultSet());
+    //Count nodes at the given level (level count from root and start with 0) of 
+    //the specified path prefix
+    statement.execute("COUNT NODES root.demo LEVEL=2");
+    outputResult(statement.getResultSet());
+    //Count timeseries at the given level (level count from root and start with 0) group
+    //by each node under the spceified path prefix
+    statement.execute("COUNT TIMESERIES root.demo GROUP BY LEVEL=2");
     outputResult(statement.getResultSet());
 
     //Execute insert statements in batch
-    statement.addBatch("insert into root.demo(timestamp,s0) values(1,1);");
-    statement.addBatch("insert into root.demo(timestamp,s0) values(1,1);");
-    statement.addBatch("insert into root.demo(timestamp,s0) values(2,15);");
-    statement.addBatch("insert into root.demo(timestamp,s0) values(2,17);");
-    statement.addBatch("insert into root.demo(timestamp,s0) values(4,12);");
+    statement.addBatch("insert into root.demo.d0(timestamp,s0) values(1,1);");
+    statement.addBatch("insert into root.demo.d0(timestamp,s0) values(1,1);");
+    statement.addBatch("insert into root.demo.d0(timestamp,s0) values(2,15);");
+    statement.addBatch("insert into root.demo.d0(timestamp,s0) values(2,17);");
+    statement.addBatch("insert into root.demo.d0(timestamp,s0) values(4,12);");
     statement.executeBatch();
     statement.clearBatch();
 
     //Full query statement
-    String sql = "select * from root.demo";
+    String sql = "select * from root.demo.d0";
     ResultSet resultSet = statement.executeQuery(sql);
     System.out.println("sql: " + sql);
     outputResult(resultSet);
 
     //Exact query statement
-    sql = "select s0 from root.demo where time = 4;";
+    sql = "select s0 from root.demo.d0 where time = 4;";
     resultSet= statement.executeQuery(sql);
     System.out.println("sql: " + sql);
     outputResult(resultSet);
 
     //Time range query
-    sql = "select s0 from root.demo where time >= 2 and time < 5;";
+    sql = "select s0 from root.demo.d0 where time >= 2 and time < 5;";
     resultSet = statement.executeQuery(sql);
     System.out.println("sql: " + sql);
     outputResult(resultSet);
 
     //Aggregate query
-    sql = "select count(s0) from root.demo;";
+    sql = "select count(s0) from root.demo.d0;";
     resultSet = statement.executeQuery(sql);
     System.out.println("sql: " + sql);
     outputResult(resultSet);
 
     //Delete time series
-    statement.execute("delete timeseries root.demo.s0");
+    statement.execute("delete timeseries root.demo.d0.s0");
 
     //close connection
     statement.close();

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Constant.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Constant.java
@@ -48,7 +48,7 @@ public class Constant {
   public static final String CATALOG_STORAGE_GROUP = "sg";
   public static final String CATALOG_DEVICES = "devices";
   public static final String COUNT_TIMESERIES = "cntts";
-  public static final String COUNT_NODE_TIMESERIES = "cnttsbg";
+  public static final String COUNT_NODE_TIMESERIES = "cntnodets";
   public static final String COUNT_NODES = "cntnode";
 
   public static final String METHOD_NOT_SUPPORTED = "Method not supported";

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadata.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadata.java
@@ -143,7 +143,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
           } catch (IoTDBRPCException e) {
             throw new IoTDBSQLException(e.getMessage());
           }
-          return new IoTDBMetadataResultSet(resp.getColumnsList().size(), MetadataType.COUNT_TIMESERIES);
+          return new IoTDBMetadataResultSet(resp.getTimeseriesNum(), MetadataType.COUNT_TIMESERIES);
         } catch (TException e) {
           throw new TException("Connection error when fetching timeseries metadata", e);
         }
@@ -156,13 +156,13 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
   public ResultSet getNodes(String catalog, String schemaPattern, String columnPattern,
       String devicePattern, int nodeLevel) throws SQLException {
     try {
-      return getNodesFunc(catalog, nodeLevel);
+      return getNodesFunc(catalog, schemaPattern, nodeLevel);
     } catch (TException e) {
       boolean flag = connection.reconnect();
       this.client = connection.client;
       if (flag) {
         try {
-          return getNodesFunc(catalog, nodeLevel);
+          return getNodesFunc(catalog, schemaPattern, nodeLevel);
         } catch (TException e2) {
           throw new SQLException(String.format("Fail to get columns catalog=%s, schemaPattern=%s,"
                   + " columnPattern=%s, devicePattern=%s, nodeLevel=%s after reconnecting."
@@ -179,12 +179,13 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
     }
   }
 
-  private ResultSet getNodesFunc(String catalog, int nodeLevel) throws TException, SQLException {
+  private ResultSet getNodesFunc(String catalog, String schemaPattern, int nodeLevel) throws TException, SQLException {
     TSFetchMetadataReq req;
     switch (catalog) {
       case Constant.COUNT_NODES:
         req = new TSFetchMetadataReq(Constant.GLOBAL_COUNT_NODES_REQ);
         req.setNodeLevel(nodeLevel);
+        req.setColumnPath(schemaPattern);
         try {
           TSFetchMetadataResp resp = client.fetchMetadata(req);
           try {
@@ -199,6 +200,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
       case Constant.COUNT_NODE_TIMESERIES:
         req = new TSFetchMetadataReq(Constant.GLOBAL_COUNT_NODE_TIMESERIES_REQ);
         req.setNodeLevel(nodeLevel);
+        req.setColumnPath(schemaPattern);
         try {
           TSFetchMetadataResp resp = client.fetchMetadata(req);
           try {

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -277,8 +277,8 @@ public class IoTDBStatement implements Statement {
       }
     } else if (sqlToLowerCase.startsWith(COUNT_NODES_COMMAND_LOWERCASE)) {
       String[] cmdSplited = sql.split("\\s+", 4);
-      if (cmdSplited.length != 4 && !(cmdSplited[3].startsWith("level"))) {
-        throw new SQLException("Error format of \'COUNT NODES LEVEL=<INTEGER>\'");
+      if (cmdSplited.length != 4 || !(cmdSplited[3].startsWith("level"))) {
+        throw new SQLException("Error format of \'COUNT NODES <PATH> LEVEL=<INTEGER>\'");
       } else {
         String path = cmdSplited[2];
         int level = Integer.parseInt(cmdSplited[3].replaceAll(" ", "").substring(6));

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadataTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadataTest.java
@@ -123,7 +123,7 @@ public class IoTDBDatabaseMetadataTest {
     columnList.add("root.vehicle.d0.s1");
     columnList.add("root.vehicle.d0.s2");
 
-    when(fetchMetadataResp.getColumnsList()).thenReturn(columnList);
+    when(fetchMetadataResp.getTimeseriesNum()).thenReturn(columnList.size());
 
     String standard = "count,\n" + "3,\n";
     try {

--- a/pom.xml
+++ b/pom.xml
@@ -923,7 +923,6 @@
                                     <thriftSourceRoot>${basedir}/src/main/thrift</thriftSourceRoot>
                                 </configuration>
                             </execution>
-
                             <execution>
                                 <id>generate-thrift-sources-python</id>
                                 <phase>generate-sources</phase>
@@ -937,7 +936,6 @@
                                     <outputDirectory>${project.build.directory}/generated-sources-python</outputDirectory>
                                 </configuration>
                             </execution>
-
                             <execution>
                                 <id>generate-thrift-sources-go</id>
                                 <phase>generate-sources</phase>
@@ -951,7 +949,6 @@
                                     <outputDirectory>${project.build.directory}/generated-sources-go</outputDirectory>
                                 </configuration>
                             </execution>
-
                             <execution>
                                 <id>generate-thrift-sources-cpp</id>
                                 <phase>generate-sources</phase>
@@ -965,7 +962,6 @@
                                     <outputDirectory>${project.build.directory}/generated-sources-cpp</outputDirectory>
                                 </configuration>
                             </execution>
-                            
                         </executions>
                     </plugin>
                 </plugins>

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MGraph.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.metadata;
 
 import java.io.Serializable;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -262,12 +263,12 @@ public class MGraph implements Serializable {
     return mtree.getAllStorageGroup();
   }
 
-  Set<String> getAllDevices() {
+  Set<String> getAllDevices() throws SQLException {
     return mtree.getAllDevices();
   }
 
-  List<String> getNodesList(int nodeLevel) {
-    return mtree.getNodesList(nodeLevel);
+  List<String> getNodesList(String schemaPattern, int nodeLevel) throws SQLException {
+    return mtree.getNodesList(schemaPattern, nodeLevel);
   }
 
   List<String> getLeafNodePathInNextLevel(String path) throws PathErrorException {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.sql.SQLException;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
@@ -849,7 +850,7 @@ public class MManager {
    *
    * @return A HashSet instance which stores all devices info
    */
-  public Set<String> getAllDevices() throws PathErrorException {
+  public Set<String> getAllDevices() throws PathErrorException, SQLException {
 
     lock.readLock().lock();
     try {
@@ -864,11 +865,11 @@ public class MManager {
    *
    * @return A List instance which stores all node at given level
    */
-  public List<String> getNodesList(int nodeLevel) {
+  public List<String> getNodesList(String prefixPath, int nodeLevel) throws SQLException {
 
     lock.readLock().lock();
     try {
-      return mgraph.getNodesList(nodeLevel);
+      return mgraph.getNodesList(prefixPath, nodeLevel);
     } finally {
       lock.readLock().unlock();
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -22,15 +22,12 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.sql.SQLException;
+import java.util.*;
+
 import org.apache.iotdb.db.exception.PathErrorException;
 import org.apache.iotdb.db.exception.StorageGroupException;
+import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -797,7 +794,29 @@ public class MTree implements Serializable {
    * @return a list contains all distinct devices
    */
   Set<String> getAllDevices() {
-    return new HashSet<>(getNodesList(3));
+    HashSet<String> devices = new HashSet<>();
+    MNode node;
+    if ((node = getRoot()) != null) {
+      findDevices(node, SQLConstant.ROOT, devices);
+    }
+    return new LinkedHashSet<>(devices);
+  }
+
+  private void findDevices(MNode node, String path, HashSet<String> res) {
+    if (node == null) {
+      return;
+    }
+    if (node.isLeaf()) {
+      res.add(path);
+      return;
+    }
+    for (MNode child : node.getChildren().values()) {
+      if (child.isLeaf()) {
+        res.add(path);
+      } else {
+        findDevices(child, path + "." + child.toString(), res);
+      }
+    }
   }
 
   /**
@@ -805,11 +824,23 @@ public class MTree implements Serializable {
    *
    * @return a list contains all nodes at the given level
    */
-  List<String> getNodesList(int nodeLevel) {
+  List<String> getNodesList(String schemaPattern, int nodeLevel) throws SQLException {
     List<String> res = new ArrayList<>();
-    MNode rootNode;
-    if ((rootNode = getRoot()) != null) {
-      findNodes(rootNode, "root", res, nodeLevel);
+    String[] nodes = schemaPattern.split("\\.");
+    MNode node;
+    if ((node = getRoot()) != null) {
+      if (nodes[0].equals("root")) {
+        for (int i = 1; i < nodes.length; i++) {
+          if (node.getChild(nodes[i]) != null) {
+            node = node.getChild(nodes[i]);
+          } else {
+            throw new SQLException(nodes[i - 1] + " does not have the child node " + nodes[i]);
+          }
+        }
+        findNodes(node, schemaPattern, res, nodeLevel - (nodes.length - 1));
+      } else {
+        throw new SQLException("Incorrect root node " + nodes[0] + " selected");
+      }
     }
     return res;
   }
@@ -818,7 +849,7 @@ public class MTree implements Serializable {
     if (node == null) {
       return;
     }
-    if (targetLevel == 1) {
+    if (targetLevel == 0) {
       res.add(path);
       return;
     }

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -328,24 +328,27 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           resp.setDataType(getSeriesType(req.getColumnPath()).toString());
           status = new TSStatus(getStatus(TSStatusCode.SUCCESS_STATUS));
           break;
-        case "COUNT_TIMESERIES":
         case "ALL_COLUMNS":
           resp.setColumnsList(getPaths(req.getColumnPath()));
           status = new TSStatus(getStatus(TSStatusCode.SUCCESS_STATUS));
           break;
+        case "COUNT_TIMESERIES":
+          resp.setTimeseriesNum(getPaths(req.getColumnPath()).size());
+          status = new TSStatus(getStatus(TSStatusCode.SUCCESS_STATUS));
+          break;
         case "COUNT_NODES":
-          resp.setNodesList(getNodesList(req.getNodeLevel()));
+          resp.setNodesList(getNodesList(req.getColumnPath(), req.getNodeLevel()));
           status = new TSStatus(getStatus(TSStatusCode.SUCCESS_STATUS));
           break;
         case "COUNT_NODE_TIMESERIES":
-          resp.setNodeTimeseriesNum(getNodeTimeseriesNum(getNodesList(req.getNodeLevel())));
+          resp.setNodeTimeseriesNum(getNodeTimeseriesNum(getNodesList(req.getColumnPath(), req.getNodeLevel())));
           status = new TSStatus(getStatus(TSStatusCode.SUCCESS_STATUS));
           break;
         default:
           status = getStatus(TSStatusCode.FETCH_METADATA_ERROR, req.getType());
           break;
       }
-    } catch (PathErrorException | MetadataErrorException | OutOfMemoryError e) {
+    } catch (PathErrorException | MetadataErrorException | OutOfMemoryError | SQLException e) {
       logger
           .error(String.format("Failed to fetch timeseries %s's metadata", req.getColumnPath()),
               e);
@@ -367,15 +370,15 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     return nodeColumnsNum;
   }
 
-  private List<String> getNodesList(int level) throws PathErrorException {
-    return MManager.getInstance().getNodesList(level);
+  private List<String> getNodesList(String schemaPattern, int level) throws PathErrorException, SQLException {
+    return MManager.getInstance().getNodesList(schemaPattern, level);
   }
 
   private Set<String> getAllStorageGroups() throws PathErrorException {
     return MManager.getInstance().getAllStorageGroup();
   }
 
-  private Set<String> getAllDevices() throws PathErrorException {
+  private Set<String> getAllDevices() throws PathErrorException, SQLException {
     return MManager.getInstance().getAllDevices();
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMetadataFetchIT.java
@@ -230,7 +230,7 @@ public class IoTDBMetadataFetchIT {
    * get all delta objects under a given column
    */
   private void device() throws SQLException {
-    String standard = "Device,\n" + "root.ln.wf01,\n";
+    String standard = "Device,\n" + "root.ln.wf01.wt01,\n";
 
 
     try (ResultSet resultSet = databaseMetaData.getColumns(Constant.CATALOG_DEVICES, null, null,

--- a/service-rpc/src/main/thrift/rpc.thrift
+++ b/service-rpc/src/main/thrift/rpc.thrift
@@ -177,12 +177,13 @@ struct TSFetchMetadataResp{
 		1: required TSStatus status
 		2: optional string metadataInJson
 		3: optional list<string> columnsList
-		4: optional string dataType
-		5: optional list<list<string>> timeseriesList
-		6: optional set<string> storageGroups
-		7: optional set<string> devices
-		8: optional list<string> nodesList
-		9: optional map<string, string> nodeTimeseriesNum
+		4: optional i32 timeseriesNum
+		5: optional string dataType
+		6: optional list<list<string>> timeseriesList
+		7: optional set<string> storageGroups
+		8: optional set<string> devices
+		9: optional list<string> nodesList
+		10: optional map<string, string> nodeTimeseriesNum
 }
 
 struct TSFetchMetadataReq{


### PR DESCRIPTION
Corresponding to JIRA issue: https://issues.apache.org/jira/browse/IOTDB-174

1. Fix the bug which the querying timeseries number interface cannot make a query by the specified path prefix.
2. Fix the documentation corresponding to the query operation (add the device in path).