### PR TITLE
fix release tools

### DIFF
--- a/tools/check_sigs.sh
+++ b/tools/check_sigs.sh
@@ -54,7 +54,7 @@ function checkFile() {
        echo "${FILE} SHA OK";
     fi
 
-    gpg --verify "${FILE}.asc"
+    gpg --verify "${FILE}.asc" "${FILE}"
 
 }
 

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -28,7 +28,7 @@ BUNDLE_DIR=${IOTDB_ROOT_DIR}/target/checkout/target
 IOTDB_ASF_GIT_URL=https://git-wip-us.apache.org/repos/asf/incubator-iotdb.git
 IOTDB_ASF_DIST_URL=https://www.apache.org/dist/incubator/iotdb
 IOTDB_ASF_DIST_DYN_URL=https://www.apache.org/dyn/closer.cgi/iotdb
-IOTDB_ASF_SVN_RELEASE_URL=https://dist.apache.org/repos/dist/release/iotdb
+IOTDB_ASF_SVN_RELEASE_URL=https://dist.apache.org/repos/dist/release/incubator/iotdb
 IOTDB_ASF_SVN_RC_URL=https://dist.apache.org/repos/dist/dev/incubator/iotdb
 
 USAGE=
@@ -66,13 +66,13 @@ function noExtraArgs() { # usage: noExtraArgs "$@"
   [ $# = 0 ] || usage "extra arguments"
 }
 
-function getAbsPath() { # $1: rel-or-abs-path 
+function getAbsPath() { # $1: rel-or-abs-path
     echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
 }
 
 function confirm () {  # [$1: question]
   while true; do
-    # call with a prompt string or use a default                                                                                                                                                   
+    # call with a prompt string or use a default
     /bin/echo -n "${1:-Are you sure?}"
     read -r -p " [y/n] " response
     case $response in
@@ -99,7 +99,7 @@ function checkUsingMgmtCloneWarn() { # no args; warns if iotdb root isn't a mgmt
     return 1
   else
     return 0
-  fi 
+  fi
 }
 
 function checkBundleDir() { # no args  returns true/false (0/1)
@@ -112,9 +112,9 @@ function checkBundleDir() { # no args  returns true/false (0/1)
 
 function checkVerNum() {  #  $1: X.Y.Z  returns true/false (0/1)
   if [ `echo $1 | grep -o -E '^\d+\.\d+\.\d+$'` ]; then
-    return 0
-  else
     return 1
+  else
+    return 0
   fi
 }
 
@@ -124,9 +124,9 @@ function checkVerNumDie() { #  $1: X.Y.Z  dies if not ok
 
 function checkRcNum() {  # $1: rc-num   returns true/false (0/1)
   if [ `echo $1 | grep -o -E '^\d+$'` ] && [ $1 != 0 ]; then
-    return 0
-  else
     return 1
+  else
+    return 0
   fi
 }
 

--- a/tools/download_staged_release.sh
+++ b/tools/download_staged_release.sh
@@ -133,9 +133,11 @@ cd ${ABS_BASE_DIR}
 echo
 echo "If the following bundle gpg signature checks fail, you may need to"
 echo "import the project's list of signing keys to your keyring"
-echo "    $ gpg ${DST_BASE_DIR}/KEYS            # show the included keys"
-echo "    $ gpg --import ${DST_BASE_DIR}/KEYS"
+echo "    $ gpg ${BUILDTOOLS_DIR}/${DST_BASE_DIR}/KEYS            # show the included keys"
+echo "    $ gpg --import ${BUILDTOOLS_DIR}/${DST_BASE_DIR}/KEYS"
+gpg ${BUILDTOOLS_DIR}/${DST_BASE_DIR}/KEYS
+gpg --import ${BUILDTOOLS_DIR}/${DST_BASE_DIR}/KEYS
 
 echo
 echo "Verifying the source bundle signatures..."
-(set -x; $BUILDTOOLS_DIR/check_sigs.sh ${DST_VER_DIR})
+(set -x; bash $BUILDTOOLS_DIR/check_sigs.sh ${BUILDTOOLS_DIR}/${DST_BASE_DIR}/${DST_VER_DIR})


### PR DESCRIPTION
Hi, because the original release tool cannot run directly on my computer, I fix some problems in it and make it works.
- common.sh
  - flip the returned result of `checkVerNum` and `checkRcNum`
- download_staged_release.sh
  - fix some paths

Execute the following command and it will download the release package and verify the reported signature and hashes automatically. 
```
bash download_staged_release.sh 0.8.1 1
```