### PR TITLE
[IOTDB-249]enable lowercase in create_timeseries sql

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -57,7 +57,6 @@ import org.apache.iotdb.db.query.fill.PreviousFill;
 import org.apache.iotdb.db.sql.parse.AstNode;
 import org.apache.iotdb.db.sql.parse.Node;
 import org.apache.iotdb.db.sql.parse.TSParser;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -392,16 +391,16 @@ public class LogicalGenerator {
   private void analyzeMetadataCreate(AstNode astNode) throws MetadataErrorException {
     Path series = parsePath(astNode.getChild(0).getChild(0));
     AstNode paramNode = astNode.getChild(1);
-    String dataType = paramNode.getChild(0).getChild(0).getText();
-    String encodingType = paramNode.getChild(1).getChild(0).getText();
+    String dataType = paramNode.getChild(0).getChild(0).getText().toUpperCase();
+    String encodingType = paramNode.getChild(1).getChild(0).getText().toUpperCase();
     String compressor;
     int offset = 2;
     if (paramNode.getChildren().size() > offset
         && paramNode.getChild(offset).getToken().getText().equals("TOK_COMPRESSOR")) {
-      compressor = paramNode.getChild(offset).getChild(0).getText();
+      compressor = paramNode.getChild(offset).getChild(0).getText().toUpperCase();
       offset++;
     } else {
-      compressor = TSFileDescriptor.getInstance().getConfig().getCompressor();
+      compressor = TSFileDescriptor.getInstance().getConfig().getCompressor().toUpperCase();
     }
     checkMetadataArgs(dataType, encodingType, compressor);
     Map<String, String> props = new HashMap<>(paramNode.getChildCount() - offset + 1, 1);

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
@@ -95,6 +95,16 @@ public class PhysicalPlanTest {
   }
 
   @Test
+  public void testMetadata2()
+      throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
+    String metadata = "create timeseries root.vehicle.d1.s2 with datatype=int32,encoding=rle";
+    QueryProcessor processor = new QueryProcessor(new MemIntQpExecutor());
+    MetadataPlan plan = (MetadataPlan) processor.parseSQLToPhysicalPlan(metadata);
+    assertEquals(String.format("seriesPath: root.vehicle.d1.s2%n" + "resultDataType: INT32%n" +
+        "encoding: RLE%nnamespace type: ADD_PATH%n" + "args: "), plan.toString());
+  }
+
+  @Test
   public void testAuthor()
       throws QueryProcessorException, ArgsErrorException, MetadataErrorException {
     String sql = "grant role xm privileges 'SET_STORAGE_GROUP','DELETE_TIMESERIES' on root.vehicle.d1.s1";


### PR DESCRIPTION
https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-249?filter=allissues

To enable sql like "create timeseries root.vehicle.d1.s1 with datatype=int32, encoding=rle" where datatype and encoding value can be lowercase.