### PR TITLE
generate cpp, go, and python thrift files under service-rpc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -886,7 +886,7 @@
                         <version>0.1.11</version>
                         <executions>
                             <execution>
-                                <id>generate-thrift-sources</id>
+                                <id>generate-thrift-sources-java</id>
                                 <phase>generate-sources</phase>
                                 <goals>
                                     <goal>compile</goal>
@@ -897,6 +897,49 @@
                                     <thriftSourceRoot>${basedir}/src/main/thrift</thriftSourceRoot>
                                 </configuration>
                             </execution>
+
+                            <execution>
+                                <id>generate-thrift-sources-python</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <generator>py</generator>
+                                    <thriftExecutable>${thrift.exec.absolute.path}</thriftExecutable>
+                                    <thriftSourceRoot>${basedir}/src/main/thrift</thriftSourceRoot>
+                                    <outputDirectory>${project.build.directory}/generated-sources-python</outputDirectory>
+                                </configuration>
+                            </execution>
+
+                            <execution>
+                                <id>generate-thrift-sources-go</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <generator>go</generator>
+                                    <thriftExecutable>${thrift.exec.absolute.path}</thriftExecutable>
+                                    <thriftSourceRoot>${basedir}/src/main/thrift</thriftSourceRoot>
+                                    <outputDirectory>${project.build.directory}/generated-sources-go</outputDirectory>
+                                </configuration>
+                            </execution>
+
+                            <execution>
+                                <id>generate-thrift-sources-cpp</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <generator>cpp</generator>
+                                    <thriftExecutable>${thrift.exec.absolute.path}</thriftExecutable>
+                                    <thriftSourceRoot>${basedir}/src/main/thrift</thriftSourceRoot>
+                                    <outputDirectory>${project.build.directory}/generated-sources-cpp</outputDirectory>
+                                </configuration>
+                            </execution>
+                            
                         </executions>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
after run `mvn generate-sources`, you can find cpp, python, go apis under service-rpc/target/generated-source-{language}.

So, you just need to supply how to use these APIs in other PRs.