### PR TITLE
[IOTDB-261]Check path validity in session

### DIFF
--- a/session/src/main/java/org/apache/iotdb/session/Config.java
+++ b/session/src/main/java/org/apache/iotdb/session/Config.java
@@ -18,9 +18,15 @@
  */
 package org.apache.iotdb.session;
 
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_ROOT;
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
+
 public class Config {
 
   public static final String DEFAULT_USER = "user";
   public static final String DEFAULT_PASSWORD = "password";
+
+  public static final String PATH_MATCHER =
+      PATH_ROOT + "([" + PATH_SEPARATOR + "](([a-zA-Z_][a-zA-Z0-9_-]*)|([+-]?[0-9]+)))+";
 
 }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -18,11 +18,14 @@
  */
 package org.apache.iotdb.session;
 
+import static org.apache.iotdb.session.Config.PATH_MATCHER;
+
 import java.sql.SQLException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
 import org.apache.iotdb.rpc.IoTDBRPCException;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -257,6 +260,7 @@ public class Session {
   }
 
   public synchronized TSStatus setStorageGroup(String storageGroupId) throws IoTDBSessionException {
+    checkPathValidity(storageGroupId);
     try {
       return checkAndReturn(client.setStorageGroup(storageGroupId));
     } catch (TException e) {
@@ -283,6 +287,7 @@ public class Session {
 
   public synchronized TSStatus createTimeseries(String path, TSDataType dataType,
       TSEncoding encoding, CompressionType compressor) throws IoTDBSessionException {
+    checkPathValidity(path);
     TSCreateTimeseriesReq request = new TSCreateTimeseriesReq();
     request.setPath(path);
     request.setDataType(dataType.ordinal());
@@ -376,4 +381,18 @@ public class Session {
 
     RpcUtils.verifySuccess(execResp.getStatus());
   }
+
+  private void checkPathValidity(String path) throws IoTDBSessionException {
+    if (!Pattern.matches(PATH_MATCHER, path)) {
+      throw new IoTDBSessionException(String.format("Path %s is invalid", path));
+    }
+  }
+
+
+  public static void main(String[] args) {
+    System.out.println(
+        Pattern.matches("root([.](([a-zA-Z_][a-zA-Z0-9_-]*)|([+-]?[0-9]+)))+", "root.\tvehicle"));
+  }
+
+
 }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -388,11 +388,4 @@ public class Session {
     }
   }
 
-
-  public static void main(String[] args) {
-    System.out.println(
-        Pattern.matches("root([.](([a-zA-Z_][a-zA-Z0-9_-]*)|([+-]?[0-9]+)))+", "root.\tvehicle"));
-  }
-
-
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/constant/TsFileConstant.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/constant/TsFileConstant.java
@@ -23,6 +23,7 @@ public class TsFileConstant {
   public static final String TSFILE_SUFFIX = ".tsfile";
   public static final String TSFILE_HOME = "TSFILE_HOME";
   public static final String TSFILE_CONF = "TSFILE_CONF";
+  public static final String PATH_ROOT = "root";
   public static final String PATH_SEPARATOR = ".";
   public static final String PATH_SEPARATER_NO_REGEX = "\\.";
   public static final String DEFAULT_DELTA_TYPE = "default_delta_type";


### PR DESCRIPTION
When using Session to set storage group or create time series, the path needs to be checked in order to reject this creation if it contains special characters.