### PR TITLE
[IOTDB-267]reduce IO operations in deserializing chunk header

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -94,7 +94,7 @@ public abstract class PhysicalPlan {
     if (valueLen == NULL_VALUE_LEN) {
       return null;
     }
-    return ReadWriteIOUtils.readStringWithoutLength(buffer, valueLen);
+    return ReadWriteIOUtils.readStringWithLength(buffer, valueLen);
   }
 
   public static class Factory {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/footer/ChunkGroupFooter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/footer/ChunkGroupFooter.java
@@ -106,7 +106,7 @@ public class ChunkGroupFooter {
     buffer = ByteBuffer.allocate(getSerializedSize(size));
     ReadWriteIOUtils.readAsPossible(input, offsetVar, buffer);
     buffer.flip();
-    String deviceID = ReadWriteIOUtils.readStringWithoutLength(buffer, size);
+    String deviceID = ReadWriteIOUtils.readStringWithLength(buffer, size);
     long dataSize = ReadWriteIOUtils.readLong(buffer);
     int numOfChunks = ReadWriteIOUtils.readInt(buffer);
     return new ChunkGroupFooter(deviceID, dataSize, numOfChunks);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/header/ChunkHeader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/header/ChunkHeader.java
@@ -76,7 +76,8 @@ public class ChunkHeader {
   }
 
   public static int getSerializedSize(String measurementID) {
-      return Byte.BYTES + Integer.BYTES + getSerializedSize(measurementID.getBytes(TSFileConfig.STRING_CHARSET).length);
+    return Byte.BYTES + Integer.BYTES + getSerializedSize(
+        measurementID.getBytes(TSFileConfig.STRING_CHARSET).length);
   }
 
   private static int getSerializedSize(int measurementIdLength) {
@@ -135,29 +136,29 @@ public class ChunkHeader {
    *
    * @param input TsFileInput
    * @param offset offset
+   * @param chunkHeaderSize the size of chunk's header
    * @param markerRead read marker (boolean type)
    * @return CHUNK_HEADER object
    * @throws IOException IOException
    */
-  public static ChunkHeader deserializeFrom(TsFileInput input, long offset, boolean markerRead)
+  public static ChunkHeader deserializeFrom(TsFileInput input, long offset, int chunkHeaderSize,
+      boolean markerRead)
       throws IOException {
     long offsetVar = offset;
     if (!markerRead) {
       offsetVar++;
     }
-    ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES);
+    ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES + chunkHeaderSize);
     input.read(buffer, offsetVar);
     buffer.flip();
+
     int size = buffer.getInt();
-    offsetVar += Integer.BYTES;
-    buffer = ByteBuffer.allocate(getSerializedSize(size));
-    ReadWriteIOUtils.readAsPossible(input, offsetVar, buffer);
-    buffer.flip();
     String measurementID = ReadWriteIOUtils.readStringWithoutLength(buffer, size);
     return deserializePartFrom(measurementID, buffer);
   }
 
-  private static ChunkHeader deserializePartFrom(String measurementID, ByteBuffer buffer) throws UnsupportedEncodingException {
+  private static ChunkHeader deserializePartFrom(String measurementID, ByteBuffer buffer)
+      throws UnsupportedEncodingException {
     int dataSize = ReadWriteIOUtils.readInt(buffer);
     TSDataType dataType = TSDataType.deserialize(ReadWriteIOUtils.readShort(buffer));
     int numOfPages = ReadWriteIOUtils.readInt(buffer);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/header/ChunkHeader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/header/ChunkHeader.java
@@ -160,7 +160,7 @@ public class ChunkHeader {
     if (!markerRead) {
       offsetVar++;
     }
-    ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES + chunkHeaderSize);
+    ByteBuffer buffer = ByteBuffer.allocate(chunkHeaderSize);
     input.read(buffer, offsetVar);
     buffer.flip();
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -333,10 +333,12 @@ public class TsFileSequenceReader implements AutoCloseable {
    * read the chunk's header.
    *
    * @param position the file offset of this chunk's header
+   * @param chunkHeaderSize the size of chunk's header
    * @param markerRead true if the offset does not contains the marker , otherwise false
    */
-  private ChunkHeader readChunkHeader(long position, boolean markerRead) throws IOException {
-    return ChunkHeader.deserializeFrom(tsFileInput, position, markerRead);
+  private ChunkHeader readChunkHeader(long position, int chunkHeaderSize, boolean markerRead)
+      throws IOException {
+    return ChunkHeader.deserializeFrom(tsFileInput, position, chunkHeaderSize, markerRead);
   }
 
   /**
@@ -377,7 +379,8 @@ public class TsFileSequenceReader implements AutoCloseable {
    * @return -chunk
    */
   public Chunk readMemChunk(ChunkMetaData metaData) throws IOException {
-    ChunkHeader header = readChunkHeader(metaData.getOffsetOfChunkHeader(), false);
+    int chunkHeadSize = ChunkHeader.getSerializedSize(metaData.getMeasurementUid());
+    ChunkHeader header = readChunkHeader(metaData.getOffsetOfChunkHeader(), chunkHeadSize, false);
     ByteBuffer buffer = readChunk(metaData.getOffsetOfChunkHeader() + header.getSerializedSize(),
         header.getDataSize());
     return new Chunk(header, buffer, metaData.getDeletedAt());

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
@@ -471,7 +471,7 @@ public class ReadWriteIOUtils {
   /**
    * read string from byteBuffer with user define length.
    */
-  public static String readStringWithoutLength(ByteBuffer buffer, int length) {
+  public static String readStringWithLength(ByteBuffer buffer, int length) {
     byte[] bytes = new byte[length];
     buffer.get(bytes, 0, length);
     return new String(bytes, 0, length);


### PR DESCRIPTION
Currently, deserializing the chunk header requires 2 disk read operations. One is reading chunkheader length, the other is reading chunkheader content. So this pr is for reducing IO operations in  chunk header deserialization.