### PR TITLE
fix number path insert bug

### DIFF
--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlParser.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlParser.g
@@ -386,8 +386,8 @@ deleteStatement
     ;
 
 insertColumnSpec
-    : LR_BRACKET K_TIMESTAMP (COMMA ID)* RR_BRACKET
-    -> ^(TOK_INSERT_COLUMNS TOK_TIME ID*)
+    : LR_BRACKET K_TIMESTAMP (COMMA nodeNameWithoutStar)* RR_BRACKET
+    -> ^(TOK_INSERT_COLUMNS TOK_TIME nodeNameWithoutStar*)
     ;
 
 insertValuesSpec


### PR DESCRIPTION
There's a bug in previous project. Insert statement failed to support number path in `insertColumnSpec`. It is fixed now. 