### PR TITLE
set the timeout of Travis on Win as 20 min

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ matrix:
       script:
         - java -version
         - mvn -version
-        - mvn -B clean integration-test
+        - travis_wait mvn -B clean integration-test
 
     - os: linux
       name: linux-openjdk11


### PR DESCRIPTION
Reference: 
https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received