### PR TITLE
[IOTDB-276] Fix inconsistent ways of judging whether a Field is null

### DIFF
--- a/hadoop/src/main/java/org/apache/iotdb/hadoop/tsfile/TSFRecordReader.java
+++ b/hadoop/src/main/java/org/apache/iotdb/hadoop/tsfile/TSFRecordReader.java
@@ -191,7 +191,7 @@ public class TSFRecordReader extends RecordReader<NullWritable, MapWritable> imp
   public static void readFieldsValue(MapWritable mapWritable, List<Field> fields, List<String> measurementIds) throws InterruptedException {
     int index = 0;
     for (Field field : fields) {
-      if (field.isNull()) {
+      if (field.getDataType() == null) {
         logger.info("Current value is null");
         mapWritable.put(new Text(measurementIds.get(index)), NullWritable.get());
       } else {

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBQueryResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBQueryResultSet.java
@@ -1256,7 +1256,7 @@ public class IoTDBQueryResultSet implements ResultSet {
     for (Field field : record.getFields()) {
       i++;
       if (i == tmp - 1) {
-        return field.isNull() ? null : field.getStringValue();
+        return field.getDataType() == null ? null : field.getStringValue();
       }
     }
     return null;

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
@@ -87,7 +87,6 @@ public class Utils {
         boolean is_empty = BytesUtils.byteToBool(byteBuffer.get());
         if (is_empty) {
           field = new Field(null);
-          field.setNull();
         } else {
           TSDataType dataType = TSDataType.valueOf(type);
           field = new Field(dataType);

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
@@ -201,37 +201,37 @@ public class UtilsTest {
       for (Field f : fields) {
         if (j == 0) {
           if (input[index][3 * j + 3] == null) {
-            assertTrue(f.isNull());
+            assertTrue(f.getDataType() == null);
           } else {
             assertEquals(input[index][3 * j + 3], f.getBoolV());
           }
         } else if (j == 1) {
           if (input[index][3 * j + 3] == null) {
-            assertTrue(f.isNull());
+            assertTrue(f.getDataType() == null);
           } else {
             assertEquals(input[index][3 * j + 3], f.getIntV());
           }
         } else if (j == 2) {
           if (input[index][3 * j + 3] == null) {
-            assertTrue(f.isNull());
+            assertTrue(f.getDataType() == null);
           } else {
             assertEquals(input[index][3 * j + 3], f.getLongV());
           }
         } else if (j == 3) {
           if (input[index][3 * j + 3] == null) {
-            assertTrue(f.isNull());
+            assertTrue(f.getDataType() == null);
           } else {
             assertEquals(input[index][3 * j + 3], f.getFloatV());
           }
         } else if (j == 4) {
           if (input[index][3 * j + 3] == null) {
-            assertTrue(f.isNull());
+            assertTrue(f.getDataType() == null);
           } else {
             assertEquals(input[index][3 * j + 3], f.getDoubleV());
           }
         } else {
           if (input[index][3 * j + 3] == null) {
-            assertTrue(f.isNull());
+            assertTrue(f.getDataType() == null);
           } else {
             assertEquals(input[index][3 * j + 3], f.getStringValue());
           }

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/AbstractQueryProcessExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/AbstractQueryProcessExecutor.java
@@ -101,7 +101,6 @@ public abstract class AbstractQueryProcessExecutor implements IQueryProcessExecu
         ttl.setLongV(mNode.getDataTTL());
       } else {
         ttl = new Field(null);
-        ttl.setNull();
       }
       rowRecord.addField(sg);
       rowRecord.addField(ttl);

--- a/session/src/main/java/org/apache/iotdb/session/SessionUtils.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionUtils.java
@@ -110,7 +110,6 @@ public class SessionUtils {
         boolean is_empty = BytesUtils.byteToBool(byteBuffer.get());
         if (is_empty) {
           field = new Field(null);
-          field.setNull();
         } else {
           TSDataType dataType = TSDataType.valueOf(type);
           field = new Field(dataType);

--- a/spark-tsfile/src/main/scala/org/apache/iotdb/spark/tsfile/Converter.scala
+++ b/spark-tsfile/src/main/scala/org/apache/iotdb/spark/tsfile/Converter.scala
@@ -57,7 +57,7 @@ abstract class Converter {
   def toSqlValue(field: Field): Any = {
     if (field == null)
       return null
-    if (field.isNull)
+    if (field.getDataType == null)
       null
     else field.getDataType match {
       case TSDataType.BOOLEAN => field.getBoolV

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Field.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Field.java
@@ -35,7 +35,6 @@ public class Field {
   private float floatV;
   private double doubleV;
   private Binary binaryV;
-  private boolean isNull;
 
   public Field(TSDataType dataType) {
     this.dataType = dataType;
@@ -99,7 +98,7 @@ public class Field {
    * @return value string
    */
   public String getStringValue() {
-    if (isNull || dataType == null) {
+    if (dataType == null) {
       return "null";
     }
     switch (dataType) {
@@ -125,16 +124,8 @@ public class Field {
     return getStringValue();
   }
 
-  public void setNull() {
-    this.isNull = true;
-  }
-
-  public boolean isNull() {
-    return this.isNull;
-  }
-
   public Object getObjectValue(TSDataType dataType) {
-    if (isNull) {
+    if (this.dataType == null) {
       return null;
     }
     switch (dataType) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/DataSetWithoutTimeGenerator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/DataSetWithoutTimeGenerator.java
@@ -106,8 +106,7 @@ public class DataSetWithoutTimeGenerator extends QueryDataSet {
       Field field = new Field(dataTypes.get(i));
 
       if (!hasDataRemaining.get(i)) {
-        field.setNull();
-        record.addField(field);
+        record.addField(new Field(null));
         continue;
       }
 
@@ -135,7 +134,7 @@ public class DataSetWithoutTimeGenerator extends QueryDataSet {
         }
 
       } else {
-        field.setNull();
+        field = new Field(null);
       }
 
       record.addField(field);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/DataSetWithoutTimeGenerator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/DataSetWithoutTimeGenerator.java
@@ -132,14 +132,11 @@ public class DataSetWithoutTimeGenerator extends QueryDataSet {
         } else {
           timeHeapPut(data.currentTime());
         }
-
+        record.addField(field);
       } else {
-        field = new Field(null);
+        record.addField(new Field(null));
       }
-
-      record.addField(field);
     }
-
     return record;
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/QueryDataSet.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/QueryDataSet.java
@@ -64,12 +64,11 @@ public abstract class QueryDataSet {
   }
 
   protected Field getField(Object value, TSDataType dataType) {
-    Field field = new Field(dataType);
-
     if (value == null) {
       return new Field(null);
     }
 
+    Field field = new Field(dataType);
     switch (dataType) {
       case DOUBLE:
         field.setDoubleV((double) value);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/QueryDataSet.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/QueryDataSet.java
@@ -67,8 +67,7 @@ public abstract class QueryDataSet {
     Field field = new Field(dataType);
 
     if (value == null) {
-      field.setNull();
-      return field;
+      return new Field(null);
     }
 
     switch (dataType) {


### PR DESCRIPTION
Fix inconsistent ways of judging whether a Field is null by removing `isNull` field and `setNull` method. Only retain one way of defining a null field `new Field(null)`, and `isNull()` method can be realized by checking `this.dataType == null`.