### PR TITLE
[IOTDB-257] makes the client stop fetch when dataSize equals maxPrintRowCount and change client fetchSize less than maxPrintRowCount

### DIFF
--- a/client/src/main/java/org/apache/iotdb/client/AbstractClient.java
+++ b/client/src/main/java/org/apache/iotdb/client/AbstractClient.java
@@ -89,8 +89,8 @@ public abstract class AbstractClient {
   private static final String NEED_NOT_TO_PRINT_TIMESTAMP = "AGGREGATION";
   private static final String DEFAULT_TIME_FORMAT = "default";
   private static String timeFormat = DEFAULT_TIME_FORMAT;
-  static int maxPrintRowCount = 1000;
-  private static int fetchSize = maxPrintRowCount;
+  static int maxPrintRowCount = 100000;
+  private static int fetchSize = 10000;
   static int maxTimeLength = ISO_DATETIME_LEN;
   static int maxValueLength = 15;
   private static int deviceColumnLength = 20; // for GROUP_BY_DEVICE sql

--- a/client/src/main/java/org/apache/iotdb/client/AbstractClient.java
+++ b/client/src/main/java/org/apache/iotdb/client/AbstractClient.java
@@ -221,6 +221,7 @@ public abstract class AbstractClient {
       }
       if (displayCnt == maxPrintRowCount) {
         println(String.format("Reach maxPrintRowCount = %s lines", maxPrintRowCount));
+        return;
       }
     }
 

--- a/client/src/main/java/org/apache/iotdb/client/AbstractClient.java
+++ b/client/src/main/java/org/apache/iotdb/client/AbstractClient.java
@@ -90,7 +90,7 @@ public abstract class AbstractClient {
   private static final String DEFAULT_TIME_FORMAT = "default";
   private static String timeFormat = DEFAULT_TIME_FORMAT;
   static int maxPrintRowCount = 1000;
-  private static int fetchSize = 10000;
+  private static int fetchSize = maxPrintRowCount;
   static int maxTimeLength = ISO_DATETIME_LEN;
   static int maxValueLength = 15;
   private static int deviceColumnLength = 20; // for GROUP_BY_DEVICE sql
@@ -203,7 +203,7 @@ public abstract class AbstractClient {
     }
 
     // Output values
-    while (res.next()) {
+    while (cnt < maxPrintRowCount && res.next()) {
       printRow(printTimestamp, colCount, resultSetMetaData, isShow, res, zoneId);
       cnt++;
       if (!printToConsole && cnt % 10000 == 0) {

--- a/client/src/main/java/org/apache/iotdb/client/AbstractClient.java
+++ b/client/src/main/java/org/apache/iotdb/client/AbstractClient.java
@@ -219,13 +219,14 @@ public abstract class AbstractClient {
       } else {
         printBlockLine(printTimestamp, colCount, resultSetMetaData, isShow);
       }
-      if (displayCnt == maxPrintRowCount) {
-        println(String.format("Reach maxPrintRowCount = %s lines", maxPrintRowCount));
-        return;
-      }
+
     }
 
-    printCount(isShow, res, cnt);
+    if(!res.next()){
+        printCount(isShow, res, cnt);
+    } else {
+        println(String.format("Reach maxPrintRowCount = %s lines", maxPrintRowCount));
+    }
   }
 
   private static String getTimestampPrecision() {


### PR DESCRIPTION
make client default fetchSize  = maxPrintRowCount, and don't need to fetching all data.
old versions have a problem , max to print 1000 lines ,but traversal server all data by 10000 lines every time。
in old :
```
IoTDB> select * from root
select * from root
+-----------------------------------+--------------+--------------+--------------+
|                               Time|root.sg1.d1.s1|root.sg1.d1.s2|root.sg1.d1.s3|
+-----------------------------------+--------------+--------------+--------------+
|      1970-01-01T08:00:00.000+08:00|             1|             1|             1|
|      1970-01-01T08:00:00.001+08:00|             1|             1|             1|
......
+-----------------------------------+--------------+--------------+--------------+
Reach maxPrintRowCount = 1000 lines
Total line number = 5947304
It costs 3.524s
```
in new :
```
IoTDB> select * from root
select * from root
+-----------------------------------+--------------+--------------+--------------+
|                               Time|root.sg1.d1.s1|root.sg1.d1.s2|root.sg1.d1.s3|
+-----------------------------------+--------------+--------------+--------------+
|      1970-01-01T08:00:00.000+08:00|             1|             1|             1|
|      1970-01-01T08:00:00.001+08:00|             1|             1|             1|
......
+-----------------------------------+--------------+--------------+--------------+
Reach maxPrintRowCount = 1000 lines
Total line number = 1000
It costs 3.524s

```