### PR TITLE
[IOTDB-260] Make paths can concatenate

### DIFF
--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlLexer.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlLexer.g
@@ -257,6 +257,10 @@ K_PATH
     : P A T H
     ;
 
+K_SUBPATH
+    : S U B P A T H
+    ;
+
 K_LOAD
     : L O A D
     ;

--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlLexer.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlLexer.g
@@ -396,6 +396,14 @@ RS_BRACKET
     : ']'
     ;
 
+L_BRACKET
+    : '{'
+    ;
+
+R_BRACKET
+    : '}'
+    ;
+
 STRING_LITERAL
    : DQUOTA_STRING
    | SQUOTA_STRING

--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlParser.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlParser.g
@@ -409,7 +409,7 @@ functionCall
     ;
 
 suffixPath
-    : nodeNames (DOT nodeName | nodeNames)* | nodeName
+    : (nodeNames | nodeName) (DOT (nodeName | nodeNames))*
     -> ^(TOK_PATH nodeName+)
     ;
 
@@ -430,7 +430,7 @@ fromClause
     ;
 
 prefixPath
-    : K_ROOT (DOT nodeNames | nodeName)*
+    : K_ROOT (DOT (nodeNames | nodeName))*
     -> ^(TOK_PATH ^(TOK_ROOT nodeName*))
     ;
 

--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlParser.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlParser.g
@@ -180,6 +180,8 @@ static {
 	tokenNameMap.put("RR_BRACKET", ")");
 	tokenNameMap.put("LS_BRACKET", "[");
 	tokenNameMap.put("RS_BRACKET", "]");
+	tokenNameMap.put("L_BRACKET", "{");
+	tokenNameMap.put("R_BRACKET", "}");
 	tokenNameMap.put("OPERATOR_EQ", "=");
 	tokenNameMap.put("OPERATOR_NEQ", "<>");
 	// tokenNameMap.put("EQUAL_NS", "<=>");
@@ -407,7 +409,7 @@ functionCall
     ;
 
 suffixPath
-    : nodeName (DOT nodeName)*
+    : nodeName | nodeNames (DOT nodeName | nodeNames)*
     -> ^(TOK_PATH nodeName+)
     ;
 
@@ -418,13 +420,17 @@ nodeName
     | STRING_LITERAL
     ;
 
+nodeNames
+    : L_BRACKET nodeName (COMMA nodeName)* R_BRACKET
+    ;
+
 fromClause
     : K_FROM prefixPath (COMMA prefixPath)*
     -> ^(TOK_FROM prefixPath+)
     ;
 
 prefixPath
-    : K_ROOT (DOT nodeName)*
+    : K_ROOT (DOT nodeName | nodeNames)*
     -> ^(TOK_PATH ^(TOK_ROOT nodeName*))
     ;
 

--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlParser.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlParser.g
@@ -107,6 +107,7 @@ tokens{
     TOK_SHOW;
     TOK_DATE_EXPR;
     TOK_DURATION;
+    TOK_SUBPATH;
 }
 
 @header{
@@ -409,8 +410,13 @@ functionCall
     ;
 
 suffixPath
-    : (nodeNames | nodeName) (DOT (nodeName | nodeNames))*
-    -> ^(TOK_PATH nodeName+)
+    : node (DOT node)*
+    -> ^(TOK_PATH node+)
+    ;
+
+node
+    : nodeNames
+    | nodeName
     ;
 
 nodeName
@@ -422,6 +428,7 @@ nodeName
 
 nodeNames
     : L_BRACKET nodeName (COMMA nodeName)* R_BRACKET
+    -> ^(TOK_SUBPATH nodeName+)
     ;
 
 fromClause
@@ -430,8 +437,8 @@ fromClause
     ;
 
 prefixPath
-    : K_ROOT (DOT (nodeNames | nodeName))*
-    -> ^(TOK_PATH ^(TOK_ROOT nodeName*))
+    : K_ROOT (DOT node)*
+    -> ^(TOK_PATH ^(TOK_ROOT node*))
     ;
 
 whereClause

--- a/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlParser.g
+++ b/server/src/main/antlr3/org/apache/iotdb/db/sql/parse/TqlParser.g
@@ -409,7 +409,7 @@ functionCall
     ;
 
 suffixPath
-    : nodeName | nodeNames (DOT nodeName | nodeNames)*
+    : nodeNames (DOT nodeName | nodeNames)* | nodeName
     -> ^(TOK_PATH nodeName+)
     ;
 
@@ -430,7 +430,7 @@ fromClause
     ;
 
 prefixPath
-    : K_ROOT (DOT nodeName | nodeNames)*
+    : K_ROOT (DOT nodeNames | nodeName)*
     -> ^(TOK_PATH ^(TOK_ROOT nodeName*))
     ;
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -1081,17 +1081,20 @@ public class LogicalGenerator {
     List<List<String>> result = new ArrayList<>();
     List<Path> pathLists = new ArrayList<>();
     if (childCount == 1 && node.getChild(0).getType() == TOK_ROOT) {
+      ArrayList<String> rootList = new ArrayList<>();
+      rootList.add(SQLConstant.ROOT);
+      paths.add(rootList);
       AstNode childNode = node.getChild(0);
       childCount = childNode.getChildCount();
       for (int i = 0; i < childCount; i++) {
         AstNode grandChild = childNode.getChild(i);
         int grandChildCount = grandChild.getChildCount();
         if(grandChild.getType() == TOK_SUBPATH) {
+          ArrayList<String> path = new ArrayList<>();
           for(int j = 0; j < grandChildCount; j++) {
-            ArrayList<String> path = new ArrayList<>();
             path.add(grandChild.getChild(j).getText());
-            paths.add(path);
           }
+          paths.add(path);
         } else {
           ArrayList<String> path = new ArrayList<>();
           path.add(grandChild.getText());
@@ -1104,11 +1107,11 @@ public class LogicalGenerator {
         AstNode childNode = node.getChild(i);
         int count = childNode.getChildCount();
         if(childNode.getType() == TOK_SUBPATH) {
+          ArrayList<String> path = new ArrayList<>();
           for(int j = 0; j < count; j++) {
-            ArrayList<String> path = new ArrayList<>();
             path.add(childNode.getChild(j).getText());
-            paths.add(path);
           }
+          paths.add(path);
         } else {
           ArrayList<String> path = new ArrayList<>();
           path.add(childNode.getText());

--- a/server/src/test/java/org/apache/iotdb/db/qp/QueryProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/QueryProcessorTest.java
@@ -135,5 +135,8 @@ public class QueryProcessorTest {
     PhysicalPlan plan10 = processor.parseSQLToPhysicalPlan(fillStatement);
     assertEquals(OperatorType.FILL, plan10.getOperatorType());
 
+    String queryStatement1 = "select * from root.{vehicle,vehicle1}.device1";
+    PhysicalPlan plan11 = processor.parseSQLToPhysicalPlan(queryStatement1);
+    assertEquals(OperatorType.QUERY, plan11.getOperatorType());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/sql/TqlParserTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sql/TqlParserTest.java
@@ -920,11 +920,15 @@ public class TqlParserTest {
   public void query20() throws ParseException {
     ArrayList<String> ans = new ArrayList<>(
         Arrays.asList("TOK_QUERY", "TOK_SELECT",
-            "TOK_PATH", "s3",
-            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "dwf", "TOK_SUBPATH", "d1", "d2"));
+            "TOK_PATH", "s1",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT",
+            "TOK_SUBPATH", "a1", "a2",
+            "b",
+            "TOK_SUBPATH", "c1", "c2", "c3",
+            "TOK_SUBPATH", "d1", "d2", "d3"));
     ArrayList<String> rec = new ArrayList<>();
     AstNode astTree = ParseGenerator
-        .generateAST("select s3 from root.dwf.{d1,d2}");
+        .generateAST("select s1 from root.{a1,a2}.b.{c1,c2,c3}.{d1,d2,d3}");
     astTree = ParseUtils.findRootNonNullToken(astTree);
     recursivePrintSon(astTree, rec);
     int i = 0;

--- a/server/src/test/java/org/apache/iotdb/db/sql/TqlParserTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sql/TqlParserTest.java
@@ -918,12 +918,20 @@ public class TqlParserTest {
 
   @Test
   public void query20() throws ParseException {
+    ArrayList<String> ans = new ArrayList<>(
+        Arrays.asList("TOK_QUERY", "TOK_SELECT",
+            "TOK_PATH", "s3",
+            "TOK_FROM", "TOK_PATH", "TOK_ROOT", "dwf", "TOK_SUBPATH", "d1", "d2"));
     ArrayList<String> rec = new ArrayList<>();
     AstNode astTree = ParseGenerator
         .generateAST("select s3 from root.dwf.{d1,d2}");
     astTree = ParseUtils.findRootNonNullToken(astTree);
     recursivePrintSon(astTree, rec);
-
+    int i = 0;
+    while (i <= rec.size() - 1) {
+      assertEquals(ans.get(i), rec.get(i));
+      i++;
+    }
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/sql/TqlParserTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sql/TqlParserTest.java
@@ -917,6 +917,16 @@ public class TqlParserTest {
   }
 
   @Test
+  public void query20() throws ParseException {
+    ArrayList<String> rec = new ArrayList<>();
+    AstNode astTree = ParseGenerator
+        .generateAST("select s3 from root.dwf.{d1,d2}");
+    astTree = ParseUtils.findRootNonNullToken(astTree);
+    recursivePrintSon(astTree, rec);
+
+  }
+
+  @Test
   public void queryGroupByDevice() throws ParseException {
     // template for test case
     ArrayList<String> ans = new ArrayList<>(


### PR DESCRIPTION
https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-260
For example, you can use
```
  SELECT status FROM root.ln.wf01.{wt01,wt02}
```
<img width="674" alt="Screen Shot 2019-11-06 at 1 35 45 PM" src="https://user-images.githubusercontent.com/26118649/68271264-f72b6000-009a-11ea-94a4-2e3f8e8322a7.png">
