### PR TITLE
[IOTDB-304] Fix bug of incomplete HDFS URI

### DIFF
--- a/docs/Documentation-CHN/UserGuide/3-Server/4-Config Manual.md
+++ b/docs/Documentation-CHN/UserGuide/3-Server/4-Config Manual.md
@@ -302,6 +302,24 @@
 |默认值|LOCAL |
 |改后生效方式|重启服务器生效|
 
+* core\_site\_path
+
+|Name| core\_site\_path |
+|:---:|:---|
+|描述| 在Tsfile和相关数据文件存储到HDFS的情况下用于配置core-site.xml的绝对路径|
+|类型| String |
+|默认值|/etc/hadoop/conf/core-site.xml |
+|改后生效方式|重启服务器生效|
+
+* hdfs\_site\_path
+
+|Name| hdfs\_site\_path |
+|:---:|:---|
+|描述| 在Tsfile和相关数据文件存储到HDFS的情况下用于配置hdfs-site.xml的绝对路径|
+|类型| String |
+|默认值|/etc/hadoop/conf/hdfs-site.xml |
+|改后生效方式|重启服务器生效|
+
 * hdfs\_ip
 
 |名字| hdfs\_ip |

--- a/docs/Documentation-CHN/UserGuide/8-System Design (Developer)/3-Writing Data on HDFS.md
+++ b/docs/Documentation-CHN/UserGuide/8-System Design (Developer)/3-Writing Data on HDFS.md
@@ -52,6 +52,24 @@
 |默认值|LOCAL |
 |改后生效方式|重启服务器生效|
 
+* core\_site\_path
+
+|Name| core\_site\_path |
+|:---:|:---|
+|描述| 在Tsfile和相关数据文件存储到HDFS的情况下用于配置core-site.xml的绝对路径|
+|类型| String |
+|默认值|/etc/hadoop/conf/core-site.xml |
+|改后生效方式|重启服务器生效|
+
+* hdfs\_site\_path
+
+|Name| hdfs\_site\_path |
+|:---:|:---|
+|描述| 在Tsfile和相关数据文件存储到HDFS的情况下用于配置hdfs-site.xml的绝对路径|
+|类型| String |
+|默认值|/etc/hadoop/conf/hdfs-site.xml |
+|改后生效方式|重启服务器生效|
+
 * hdfs\_ip
 
 |名字| hdfs\_ip |

--- a/docs/Documentation/UserGuide/3-Server/4-Config Manual.md
+++ b/docs/Documentation/UserGuide/3-Server/4-Config Manual.md
@@ -337,6 +337,24 @@ The detail of each variables are as follows:
 |Default|LOCAL |
 |Effective|After restart system|
 
+* core\_site\_path
+
+|Name| core\_site\_path |
+|:---:|:---|
+|Description| Absolute file path of core-site.xml if Tsfile and related data files are stored in HDFS.|
+|Type| String |
+|Default|/etc/hadoop/conf/core-site.xml |
+|Effective|After restart system|
+
+* hdfs\_site\_path
+
+|Name| hdfs\_site\_path |
+|:---:|:---|
+|Description| Absolute file path of hdfs-site.xml if Tsfile and related data files are stored in HDFS.|
+|Type| String |
+|Default|/etc/hadoop/conf/hdfs-site.xml |
+|Effective|After restart system|
+
 * hdfs\_ip
 
 |Name| hdfs\_ip |

--- a/docs/Documentation/UserGuide/8-System Design (Developer)/3-Writing Data on HDFS.md
+++ b/docs/Documentation/UserGuide/8-System Design (Developer)/3-Writing Data on HDFS.md
@@ -52,6 +52,24 @@ Edit user config in `iotdb-engine.properties`. Related configurations are:
 |Default|LOCAL |
 |Effective|After restart system|
 
+* core\_site\_path
+
+|Name| core\_site\_path |
+|:---:|:---|
+|Description| Absolute file path of core-site.xml if Tsfile and related data files are stored in HDFS.|
+|Type| String |
+|Default|/etc/hadoop/conf/core-site.xml |
+|Effective|After restart system|
+
+* hdfs\_site\_path
+
+|Name| hdfs\_site\_path |
+|:---:|:---|
+|Description| Absolute file path of hdfs-site.xml if Tsfile and related data files are stored in HDFS.|
+|Type| String |
+|Default|/etc/hadoop/conf/hdfs-site.xml |
+|Effective|After restart system|
+
 * hdfs\_ip
 
 |Name| hdfs\_ip |

--- a/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSConfUtil.java
+++ b/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSConfUtil.java
@@ -27,18 +27,21 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class HDFSConfUtil {
+class HDFSConfUtil {
 
   private static TSFileConfig tsFileConfig = TSFileDescriptor.getInstance().getConfig();
+  private static final Logger logger = LoggerFactory.getLogger(HDFSConfUtil.class);
 
-  public static Configuration setConf(Configuration conf) {
+  static Configuration setConf(Configuration conf) {
     try {
-      conf.addResource(new File("/etc/hdfs1/conf/core-site.xml").toURI().toURL());
-      conf.addResource(new File("/etc/hdfs1/conf/hdfs-site.xml").toURI().toURL());
-      conf.addResource(new File("/etc/yarn1/conf/yarn-site.xml").toURI().toURL());
+      conf.addResource(new File(tsFileConfig.getCoreSitePath()).toURI().toURL());
+      conf.addResource(new File(tsFileConfig.getHdfsSitePath()).toURI().toURL());
     } catch (MalformedURLException e) {
-      e.printStackTrace();
+      logger.error("Failed to add resource core-site.xml {} and hdfs-site.xml {}. ",
+          tsFileConfig.getCoreSitePath(), tsFileConfig.getHdfsSitePath(), e);
     }
 
     conf.set("fs.hdfs.impl", "org.apache.hadoop.hdfs.DistributedFileSystem");
@@ -70,21 +73,13 @@ public class HDFSConfUtil {
       conf.set("hadoop.security.authentication", "kerberos");
       conf.set("dfs.block.access.token.enable", "true");
 
-//      conf.set("dfs.namenode.kerberos.principal", "nn/_" + tsFileConfig.getKerberosPrincipal());
-//      conf.set("dfs.namenode.keytab.file", tsFileConfig.getKerberosKeytabFilePath());
-//      conf.set("dfs.secondary.namenode.kerberos.principal", tsFileConfig.getKerberosPrincipal());
-//      conf.set("dfs.secondary.namenode.keytab.file", tsFileConfig.getKerberosKeytabFilePath());
-//      conf.set("dfs.datanode.kerberos.principal", "dn/" + tsFileConfig.getKerberosPrincipal());
-//      conf.set("dfs.datanode.keytab.file", tsFileConfig.getKerberosKeytabFilePath());
-//      conf.set("dfs.namenode.kerberos.internal.spnego.principal",
-//          "HTTP/" + tsFileConfig.getKerberosKeytabFilePath());
-
       UserGroupInformation.setConfiguration(conf);
       try {
         UserGroupInformation.loginUserFromKeytab(tsFileConfig.getKerberosPrincipal(),
             tsFileConfig.getKerberosKeytabFilePath());
       } catch (IOException e) {
-        e.printStackTrace();
+        logger.error("Failed to login user from key tab. User: {}, path:{}. ",
+            tsFileConfig.getKerberosPrincipal(), tsFileConfig.getKerberosKeytabFilePath(), e);
       }
     }
 

--- a/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSFile.java
+++ b/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSFile.java
@@ -39,13 +39,12 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
-import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class HDFSFile extends File {
 
+  private static final long serialVersionUID = -8419827359081949547L;
   private Path hdfsPath;
   private FileSystem fs;
   private static final Logger logger = LoggerFactory.getLogger(HDFSFile.class);

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -131,6 +131,12 @@ timestamp_precision=ms
 # TSFile storage file system. Currently, Tsfile are supported to be stored in LOCAL file system or HDFS.
 tsfile_storage_fs=LOCAL
 
+# If using HDFS, the absolute file path of Hadoop core-site.xml should be configured
+core_site_path=/etc/hadoop/conf/core-site.xml
+
+# If using HDFS, the absolute file path of Hadoop hdfs-site.xml should be configured
+hdfs_site_path=/etc/hadoop/conf/hdfs-site.xml
+
 # If using HDFS, hadoop ip can be configured. If there are more than one hdfs_ip, Hadoop HA is used
 hdfs_ip=localhost
 

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -397,6 +397,16 @@ public class IoTDBConfig {
   private FSType tsFileStorageFs = FSType.LOCAL;
 
   /**
+   * Default core-site.xml file path is /etc/hadoop/conf/core-site.xml
+   */
+  private String coreSitePath = "/etc/hadoop/conf/core-site.xml";
+
+  /**
+   * Default hdfs-site.xml file path is /etc/hadoop/conf/hdfs-site.xml
+   */
+  private String hdfsSitePath = "/etc/hadoop/conf/hdfs-site.xml";
+
+  /**
    * Default HDFS ip is localhost
    */
   private String hdfsIp = "localhost";
@@ -425,7 +435,6 @@ public class IoTDBConfig {
    * Default DFS client failover proxy provider is "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    */
   private String dfsClientFailoverProxyProvider = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider";
-
 
   /**
    * whether use kerberos to authenticate hdfs
@@ -1156,6 +1165,22 @@ public class IoTDBConfig {
 
   public void setTsFileStorageFs(String tsFileStorageFs) {
     this.tsFileStorageFs = FSType.valueOf(tsFileStorageFs);
+  }
+
+  public String getCoreSitePath() {
+    return coreSitePath;
+  }
+
+  public void setCoreSitePath(String coreSitePath) {
+    this.coreSitePath = coreSitePath;
+  }
+
+  public String getHdfsSitePath() {
+    return hdfsSitePath;
+  }
+
+  public void setHdfsSitePath(String hdfsSitePath) {
+    this.hdfsSitePath = hdfsSitePath;
   }
 
   public String[] getHdfsIp() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -309,6 +309,10 @@ public class IoTDBDescriptor {
 
       conf.setTsFileStorageFs(properties.getProperty("tsfile_storage_fs",
           conf.getTsFileStorageFs().toString()));
+      conf.setCoreSitePath(
+          properties.getProperty("core_site_path", conf.getCoreSitePath()));
+      conf.setHdfsSitePath(
+          properties.getProperty("hdfs_site_path", conf.getHdfsSitePath()));
       conf.setHdfsIp(properties.getProperty("hdfs_ip").split(","));
       conf.setHdfsPort(properties.getProperty("hdfs_port", conf.getHdfsPort()));
       conf.setDfsNameServices(
@@ -333,6 +337,10 @@ public class IoTDBDescriptor {
       // At the same time, set TSFileConfig
       TSFileDescriptor.getInstance().getConfig()
           .setTSFileStorageFs(properties.getProperty("tsfile_storage_fs"));
+      TSFileDescriptor.getInstance().getConfig().setKerberosKeytabFilePath(
+          properties.getProperty("core_site_path", conf.getCoreSitePath()));
+      TSFileDescriptor.getInstance().getConfig().setKerberosPrincipal(
+          properties.getProperty("hdfs_site_path", conf.getHdfsSitePath()));
       TSFileDescriptor.getInstance().getConfig()
           .setHdfsIp(properties.getProperty("hdfs_ip").split(","));
       TSFileDescriptor.getInstance().getConfig().setHdfsPort(properties.getProperty("hdfs_port"));
@@ -346,11 +354,6 @@ public class IoTDBDescriptor {
           properties.getProperty("dfs_client_failover_proxy_provider"));
       TSFileDescriptor.getInstance().getConfig().setUseKerberos(Boolean.parseBoolean(
           properties.getProperty("hdfs_use_kerberos", String.valueOf(conf.isUseKerberos()))));
-      TSFileDescriptor.getInstance().getConfig().setKerberosKeytabFilePath(
-          properties.getProperty("kerberos_keytab_file_path", conf.getKerberosKeytabFilePath()));
-      TSFileDescriptor.getInstance().getConfig().setKerberosPrincipal(
-          properties.getProperty("kerberos_principal", conf.getKerberosPrincipal()));
-
 
       // set tsfile-format config
       TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(Integer

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -354,6 +354,10 @@ public class IoTDBDescriptor {
           properties.getProperty("dfs_client_failover_proxy_provider"));
       TSFileDescriptor.getInstance().getConfig().setUseKerberos(Boolean.parseBoolean(
           properties.getProperty("hdfs_use_kerberos", String.valueOf(conf.isUseKerberos()))));
+      TSFileDescriptor.getInstance().getConfig().setKerberosKeytabFilePath(
+          properties.getProperty("kerberos_keytab_file_path", conf.getKerberosKeytabFilePath()));
+      TSFileDescriptor.getInstance().getConfig().setKerberosPrincipal(
+          properties.getProperty("kerberos_principal", conf.getKerberosPrincipal()));
 
       // set tsfile-format config
       TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(Integer

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -24,7 +24,6 @@ import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFF
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -524,10 +523,9 @@ public class StorageGroupProcessor {
       baseDir = DirectoryManager.getInstance().getNextFolderForUnSequenceFile();
     }
     fsFactory.getFile(baseDir, storageGroupName).mkdirs();
-
-    String filePath = Paths.get(baseDir, storageGroupName,
+    String filePath = baseDir + File.separator + storageGroupName + File.separator +
         System.currentTimeMillis() + IoTDBConstant.TSFILE_NAME_SEPARATOR + versionController
-            .nextVersion()).toString() + IoTDBConstant.TSFILE_NAME_SEPARATOR + "0" + TSFILE_SUFFIX;
+        .nextVersion() + IoTDBConstant.TSFILE_NAME_SEPARATOR + "0" + TSFILE_SUFFIX;
 
     if (sequence) {
       return new TsFileProcessor(storageGroupName, fsFactory.getFile(filePath),

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
@@ -144,6 +144,14 @@ public class TSFileConfig {
    */
   private FSType TSFileStorageFs = FSType.LOCAL;
   /**
+   * Default core-site.xml file path is /etc/hadoop/conf/core-site.xml
+   */
+  private String coreSitePath = "/etc/hadoop/conf/core-site.xml";
+  /**
+   * Default hdfs-site.xml file path is /etc/hadoop/conf/hdfs-site.xml
+   */
+  private String hdfsSitePath = "/etc/hadoop/conf/hdfs-site.xml";
+  /**
    * Default hdfs ip is localhost
    */
   private String hdfsIp = "localhost";
@@ -371,6 +379,22 @@ public class TSFileConfig {
 
   public void setTSFileStorageFs(String TSFileStorageFs) {
     this.TSFileStorageFs = FSType.valueOf(TSFileStorageFs);
+  }
+
+  public String getCoreSitePath() {
+    return coreSitePath;
+  }
+
+  public void setCoreSitePath(String coreSitePath) {
+    this.coreSitePath = coreSitePath;
+  }
+
+  public String getHdfsSitePath() {
+    return hdfsSitePath;
+  }
+
+  public void setHdfsSitePath(String hdfsSitePath) {
+    this.hdfsSitePath = hdfsSitePath;
   }
 
   public String[] getHdfsIp() {


### PR DESCRIPTION
Fix bug of "Incomplete HDFS URI: no host".
Add two new configuration `core_site_path` and `hdfs_site_path` for users to config absolute file path of `core-site.xml` and `hdfs-site.xml` when Tsfile and related data files are stored in HDFS.