### PR TITLE
[fix] fix upgrade when use compress

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/tool/upgrade/TsfileUpgradeToolV0_8_0.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/tool/upgrade/TsfileUpgradeToolV0_8_0.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
+import org.apache.iotdb.tsfile.compress.IUnCompressor.SnappyUnCompressor;
+import org.apache.iotdb.tsfile.exception.compress.CompressionTypeNotSupportedException;
 import org.apache.iotdb.tsfile.exception.write.PageException;
 import org.apache.iotdb.tsfile.file.MetaMarker;
 import org.apache.iotdb.tsfile.file.footer.ChunkGroupFooter;
@@ -41,6 +43,7 @@ import org.apache.iotdb.tsfile.file.metadata.TsDeviceMetadataIndex;
 import org.apache.iotdb.tsfile.file.metadata.TsDigest;
 import org.apache.iotdb.tsfile.file.metadata.TsDigest.StatisticType;
 import org.apache.iotdb.tsfile.file.metadata.TsFileMetaData;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
@@ -150,7 +153,6 @@ public class TsfileUpgradeToolV0_8_0 implements AutoCloseable {
   }
 
   /**
-   *
    * @param movePosition whether move the position of the file reader after reading the magic header
    * to the end of the magic head string.
    */
@@ -437,6 +439,7 @@ public class TsfileUpgradeToolV0_8_0 implements AutoCloseable {
             for (int i = 0; i < chunkHeaders.size(); i++) {
               TSDataType tsDataType = chunkHeaders.get(i).getDataType();
               TSEncoding encodingType = chunkHeaders.get(i).getEncodingType();
+              CompressionType compressionType = chunkHeaders.get(i).getCompressionType();
               ChunkHeader chunkHeader = chunkHeaders.get(i);
               List<PageHeader> pageHeaderList = pageHeadersList.get(i);
               List<ByteBuffer> pageList = pagesList.get(i);
@@ -446,7 +449,7 @@ public class TsfileUpgradeToolV0_8_0 implements AutoCloseable {
                     schema.getMeasurementSchema(chunkHeader.getMeasurementID()));
                 for (int j = 0; j < pageHeaderList.size(); j++) {
                   if (encodingType.equals(TSEncoding.PLAIN)) {
-                    pageList.set(j, rewrite(pageList.get(j), tsDataType));
+                    pageList.set(j, rewrite(pageList.get(j), tsDataType, compressionType));
                   }
                   chunkBuffer
                       .writePageHeaderAndDataIntoBuff(pageList.get(j), pageHeaderList.get(j));
@@ -485,7 +488,18 @@ public class TsfileUpgradeToolV0_8_0 implements AutoCloseable {
     }
   }
 
-  static ByteBuffer rewrite(ByteBuffer page, TSDataType tsDataType) {
+  static ByteBuffer rewrite(ByteBuffer page, TSDataType tsDataType,
+      CompressionType compressionType) {
+    switch (compressionType) {
+      case UNCOMPRESSED:
+        break;
+      case SNAPPY:
+        SnappyUnCompressor snappyUnCompressor = new SnappyUnCompressor();
+        page = ByteBuffer.wrap(snappyUnCompressor.uncompress(page.array()));
+        break;
+      default:
+        throw new CompressionTypeNotSupportedException(compressionType.toString());
+    }
     ByteBuffer modifiedPage = ByteBuffer.allocate(page.capacity());
 
     int timeBufferLength = ReadWriteForEncodingUtils.readUnsignedVarInt(page);


### PR DESCRIPTION
I have tested a bug in upgrading when using snappy compress. 