### PR TITLE
[IOTDB-313] Add RandomOnDiskUsableSpaceStrategy

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -109,6 +109,7 @@ timestamp_precision=ms
 # 1. SequenceStrategy: the system will choose the directory in sequence.
 # 2. MaxDiskUsableSpaceFirstStrategy: the system will choose the directory whose disk has the maximum space.
 # 3. MinFolderOccupiedSpaceFirstStrategy: the system will choose the directory whose folder has the minimum occupied space.
+# 4. RandomOnDiskUsableSpaceStrategy: the system will randomly choose the directory based on usable space of disks. The more usable space, the greater the chance of being chosen;
 # Set SequenceStrategy,MaxDiskUsableSpaceFirstStrategy and MinFolderOccupiedSpaceFirstStrategy to apply the corresponding strategy.
 # If this property is unset, system will use MaxDiskUsableSpaceFirstStrategy as default strategy.
 # For this property, fully-qualified class name (include package name) and simple class name are both acceptable.

--- a/server/src/main/java/org/apache/iotdb/db/conf/directories/strategy/RandomOnDiskUsableSpaceStrategy.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/directories/strategy/RandomOnDiskUsableSpaceStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.conf.directories.strategy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.apache.iotdb.db.exception.DiskSpaceInsufficientException;
+import org.apache.iotdb.db.utils.CommonUtils;
+
+public class RandomOnDiskUsableSpaceStrategy extends DirectoryStrategy {
+
+  private Random random = new Random(System.currentTimeMillis());
+
+  @Override
+  public int nextFolderIndex() throws DiskSpaceInsufficientException {
+    List<Long> spaceList = getFolderUsableSpaceList();
+    long spaceSum = spaceList.stream().mapToLong(Long::longValue).sum();
+
+    if (spaceSum <= 0) {
+      throw new DiskSpaceInsufficientException(folders);
+    }
+
+    long randomV = Math.abs(random.nextLong()) % spaceSum;
+    int index = 0;
+    /* In fact, index will never equals spaceList.size(),
+    for that randomV is less than sum of spaceList. */
+    while (index < spaceList.size() && randomV >= spaceList.get(index)) {
+      randomV -= spaceList.get(index);
+      index++;
+    }
+
+    return index;
+  }
+
+  /**
+   * get space list of all folders.
+   */
+  public List<Long> getFolderUsableSpaceList() {
+    List<Long> spaceList = new ArrayList<>();
+    for (int i = 0; i < folders.size(); i++) {
+      String folder = folders.get(i);
+      spaceList.add(CommonUtils.getUsableSpace(folder));
+    }
+    return spaceList;
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/conf/directories/strategy/DirectoryStrategyTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/conf/directories/strategy/DirectoryStrategyTest.java
@@ -19,6 +19,8 @@
 package org.apache.iotdb.db.conf.directories.strategy;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -46,7 +48,7 @@ public class DirectoryStrategyTest {
   Set<Integer> fullDirIndexSet;
 
   @Before
-  public void setUp() throws DiskSpaceInsufficientException, IOException {
+  public void setUp() throws IOException {
     dataDirList = new ArrayList<>();
     for (int i = 0; i < 5; i++) {
       dataDirList.add("data" + i);
@@ -145,6 +147,25 @@ public class DirectoryStrategyTest {
       }
     }
     return index;
+  }
+
+  @Test
+  public void testRandomOnDiskUsableSpaceStrategy()
+      throws DiskSpaceInsufficientException {
+    RandomOnDiskUsableSpaceStrategy randomOnDiskUsableSpaceStrategy = new RandomOnDiskUsableSpaceStrategy();
+    randomOnDiskUsableSpaceStrategy.setFolders(dataDirList);
+
+    for (int i = 0; i < dataDirList.size(); i++) {
+      assertFalse(fullDirIndexSet.contains(randomOnDiskUsableSpaceStrategy.nextFolderIndex()));
+    }
+
+    int newFullIndex = randomOnDiskUsableSpaceStrategy.nextFolderIndex();
+    PowerMockito.when(CommonUtils.getUsableSpace(dataDirList.get(newFullIndex))).thenReturn(0L);
+    for (int i = 0; i < dataDirList.size(); i++) {
+      int index = randomOnDiskUsableSpaceStrategy.nextFolderIndex();
+      assertFalse(fullDirIndexSet.contains(index));
+      assertTrue(newFullIndex != index);
+    }
   }
 
   @Test


### PR DESCRIPTION
When usable space of one certain directory is much more than the others (when adding a new disk), all new files will be written to this directory, which is not optimal. Therefore, RandomOnDiskUsableSpaceStrategy is added here, which will randomly choose directory based on usable space. The more usable space the directory contains, the greater the chance of being chosen.