### PR TITLE
[IOTDB-319]get lock in FileReaderManager outside of the synchronized block

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/control/FileReaderManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/FileReaderManager.java
@@ -164,25 +164,29 @@ public class FileReaderManager implements IService {
    * Increase the reference count of the reader specified by filePath. Only when the reference count
    * of a reader equals zero, the reader can be closed and removed.
    */
-  synchronized void increaseFileReaderReference(TsFileResource tsFile, boolean isClosed) {
+  void increaseFileReaderReference(TsFileResource tsFile, boolean isClosed) {
     // TODO : this should be called in get()
-    if (!isClosed) {
-      unclosedReferenceMap.computeIfAbsent(tsFile, k -> new AtomicInteger()).getAndIncrement();
-    } else {
-      closedReferenceMap.computeIfAbsent(tsFile, k -> new AtomicInteger()).getAndIncrement();
-    }
     tsFile.getWriteQueryLock().readLock().lock();
+    synchronized (this) {
+      if (!isClosed) {
+        unclosedReferenceMap.computeIfAbsent(tsFile, k -> new AtomicInteger()).getAndIncrement();
+      } else {
+        closedReferenceMap.computeIfAbsent(tsFile, k -> new AtomicInteger()).getAndIncrement();
+      }
+    }
   }
 
   /**
    * Decrease the reference count of the reader specified by filePath. This method is latch-free.
    * Only when the reference count of a reader equals zero, the reader can be closed and removed.
    */
-  synchronized void decreaseFileReaderReference(TsFileResource tsFile, boolean isClosed) {
-    if (!isClosed && unclosedReferenceMap.containsKey(tsFile)) {
-      unclosedReferenceMap.get(tsFile).getAndDecrement();
-    } else if (closedReferenceMap.containsKey(tsFile)){
-      closedReferenceMap.get(tsFile).getAndDecrement();
+  void decreaseFileReaderReference(TsFileResource tsFile, boolean isClosed) {
+    synchronized (this) {
+      if (!isClosed && unclosedReferenceMap.containsKey(tsFile)) {
+        unclosedReferenceMap.get(tsFile).getAndDecrement();
+      } else if (closedReferenceMap.containsKey(tsFile)){
+        closedReferenceMap.get(tsFile).getAndDecrement();
+      }
     }
     tsFile.getWriteQueryLock().readLock().unlock();
   }


### PR DESCRIPTION
[deadlock.docx](https://github.com/apache/incubator-iotdb/files/3882286/deadlock.docx)
