### PR TITLE
[IOTDB-322] upgrade to thrift 0.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,7 +139,7 @@ matrix:
 
     - os: linux
       name: linux-openjdk11
-      dist: trusty
+      dist: xenial
       sudo: required
       before_install:
         - wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz -O jdk11.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,10 +158,10 @@ matrix:
       name: linux-openjdk8
       dist: xenial
       jdk: openjdk8
-    - os: linux
-      name: linux-oraclejdk8
-      dist: xenial
-      jdk: oraclejdk8
+#    - os: linux
+#      name: linux-oraclejdk8
+#      dist: xenial
+#      jdk: oraclejdk8
 #    - os: linux
 #      name: linux-oraclejdk11
 #      dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,11 +156,11 @@ matrix:
         - kill %1
     - os: linux
       name: linux-openjdk8
-      dist: trusty
+      dist: xenial
       jdk: openjdk8
     - os: linux
       name: linux-oraclejdk8
-      dist: trusty
+      dist: xenial
       jdk: oraclejdk8
 #    - os: linux
 #      name: linux-oraclejdk11
@@ -189,5 +189,6 @@ script:
   - java -version
   - ./mvnw.sh -B -ntp apache-rat:check
   - ./mvnw.sh -B -ntp clean integration-test
+
 
 after_success:

--- a/pom.xml
+++ b/pom.xml
@@ -814,7 +814,7 @@
                 </os>
             </activation>
             <properties>
-                <thrift.download-url>https://raw.githubusercontent.com/jt2594838/mvn-thrift-compiler/master/thrift_0.12.0_0.13.0_linux.exe</thrift.download-url>
+                <thrift.download-url>https://github.com/jt2594838/mvn-thrift-compiler/raw/master/thrift_0.12.0_0.13.0_linux.exe</thrift.download-url>
                 <thrift.executable>thrift_0.12.0_0.13.0_linux.exe</thrift.executable>
                 <thrift.skip-making-executable>false</thrift.skip-making-executable>
                 <thrift.exec-cmd.executable>chmod</thrift.exec-cmd.executable>
@@ -829,9 +829,7 @@
                 </os>
             </activation>
             <properties>
-                <thrift.download-url>
-                    https://raw.githubusercontent.com/jt2594838/mvn-thrift-compiler/master/thrift_0.12.0_0.13.0_mac.exe
-                    </thrift.download-url>
+                <thrift.download-url>https://github.com/jt2594838/mvn-thrift-compiler/raw/master/thrift_0.12.0_0.13.0_mac.exe</thrift.download-url>
                 <thrift.executable>thrift_0.12.0_0.13.0_mac.exe</thrift.executable>
                 <thrift.skip-making-executable>false</thrift.skip-making-executable>
                 <thrift.exec-cmd.executable>chmod</thrift.exec-cmd.executable>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <spark.version>2.4.3</spark.version>
         <common.io.version>2.5</common.io.version>
         <commons.collections4>4.0</commons.collections4>
-        <thrift.version>0.9.3</thrift.version>
+        <thrift.version>0.12.0</thrift.version>
         <airline.version>0.8</airline.version>
         <jackson.version>2.10.0</jackson.version>
         <antlr3.version>3.5.2</antlr3.version>
@@ -814,8 +814,8 @@
                 </os>
             </activation>
             <properties>
-                <thrift.download-url>https://github.com/ccascone/mvn-thrift-compiler/raw/1.0_${thrift.version}/exe/thrift-linux-x86_64.exe</thrift.download-url>
-                <thrift.executable>thrift-${thrift.version}-unix-x86_64</thrift.executable>
+                <thrift.download-url>https://raw.githubusercontent.com/jt2594838/mvn-thrift-compiler/master/thrift_0.12.0_0.13.0_linux.exe</thrift.download-url>
+                <thrift.executable>thrift_0.12.0_0.13.0_linux.exe</thrift.executable>
                 <thrift.skip-making-executable>false</thrift.skip-making-executable>
                 <thrift.exec-cmd.executable>chmod</thrift.exec-cmd.executable>
                 <thrift.exec-cmd.args>+x ${project.build.directory}/tools/${thrift.executable}</thrift.exec-cmd.args>
@@ -829,8 +829,10 @@
                 </os>
             </activation>
             <properties>
-                <thrift.download-url>https://github.com/ccascone/mvn-thrift-compiler/raw/1.0_${thrift.version}/exe/thrift-osx-x86_64.exe</thrift.download-url>
-                <thrift.executable>thrift-${thrift.version}-osx-x86_64</thrift.executable>
+                <thrift.download-url>
+                    https://raw.githubusercontent.com/jt2594838/mvn-thrift-compiler/master/thrift_0.12.0_0.13.0_mac.exe
+                    </thrift.download-url>
+                <thrift.executable>thrift_0.12.0_0.13.0_mac.exe</thrift.executable>
                 <thrift.skip-making-executable>false</thrift.skip-making-executable>
                 <thrift.exec-cmd.executable>chmod</thrift.exec-cmd.executable>
                 <thrift.exec-cmd.args>+x ${project.build.directory}/tools/${thrift.executable}</thrift.exec-cmd.args>


### PR DESCRIPTION
Thrift 0.9 has a bug (https://issues.apache.org/jira/browse/IOTDB-322) and has been resolved from 0.10.

Tianjiang compiled the binaries files of Thrift 0.12-0.13  and by using Chris's setting, we can  let the pom automatically compile .thrift files.

Linux (Ubuntu) is upgraded from 14.04 to 16.04

OracleJDK8 is disabled on Linux while OpenJDK 8 and 11 work well.