### PR TITLE
Move the vulnera-checks section into the apache-release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,86 +518,6 @@
         </pluginManagement>
         <plugins>
             <!--
-              Strange things usually happen if you run with a too low Java version.
-              This plugin not only checks the minimum java version of 1.8, but also
-              checks all dependencies (and transitive dependencies) for reported CVEs.
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
-                <!--$NO-MVN-MAN-VER$-->
-                <executions>
-                    <!-- Ensure we're not mixing dependency versions -->
-                    <execution>
-                        <id>enforce-version-convergence</id>
-                        <configuration>
-                            <rules>
-                                <dependencyConvergence/>
-                            </rules>
-                        </configuration>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                    </execution>
-                    <!--
-                        Fails the build if classes are included from multiple
-                        artifacts and these are not identical.
-                    -->
-                    <!--execution>
-                        <id>enforce-ban-duplicate-classes</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <banDuplicateClasses>
-                                    <scopes>
-                                        <scope>compile</scope>
-                                        <scope>provided</scope>
-                                    </scopes>
-                                    <findAllDuplicates>true</findAllDuplicates>
-                                    <ignoreWhenIdentical>true</ignoreWhenIdentical>
-                                </banDuplicateClasses>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
-                    </execution-->
-                    <!-- Make sure no dependencies are used for which known vulnerabilities exist. -->
-                    <execution>
-                        <id>vulnerability-checks</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Just generate warnings for now -->
-                            <fail>false</fail>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>1.8.0</version>
-                                </requireJavaVersion>
-                                <!-- Disabled for now as it breaks the ability to build single modules -->
-                                <!--reactorModuleConvergence/-->
-                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.sonatype.ossindex.maven</groupId>
-                        <artifactId>ossindex-maven-enforcer-rules</artifactId>
-                        <version>1.0.0</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>extra-enforcer-rules</artifactId>
-                        <version>1.2</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <!--
               Even if Maven transitively pulls in dependencies, relying on these can
               quite often cause hard to find problems. So it's a good practice to make
               sure everything directly required is also directly added as a dependency.
@@ -1034,6 +954,86 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                    <!--
+                      Strange things usually happen if you run with a too low Java version.
+                      This plugin not only checks the minimum java version of 1.8, but also
+                      checks all dependencies (and transitive dependencies) for reported CVEs.
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.0.0-M2</version>
+                        <!--$NO-MVN-MAN-VER$-->
+                        <executions>
+                            <!-- Ensure we're not mixing dependency versions -->
+                            <execution>
+                                <id>enforce-version-convergence</id>
+                                <configuration>
+                                    <rules>
+                                        <dependencyConvergence/>
+                                    </rules>
+                                </configuration>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                            </execution>
+                            <!--
+                                Fails the build if classes are included from multiple
+                                artifacts and these are not identical.
+                            -->
+                            <!--execution>
+                                <id>enforce-ban-duplicate-classes</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <banDuplicateClasses>
+                                            <scopes>
+                                                <scope>compile</scope>
+                                                <scope>provided</scope>
+                                            </scopes>
+                                            <findAllDuplicates>true</findAllDuplicates>
+                                            <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                                        </banDuplicateClasses>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution-->
+                            <!-- Make sure no dependencies are used for which known vulnerabilities exist. -->
+                            <execution>
+                                <id>vulnerability-checks</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Just generate warnings for now -->
+                                    <fail>false</fail>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>1.8.0</version>
+                                        </requireJavaVersion>
+                                        <!-- Disabled for now as it breaks the ability to build single modules -->
+                                        <!--reactorModuleConvergence/-->
+                                        <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.sonatype.ossindex.maven</groupId>
+                                <artifactId>ossindex-maven-enforcer-rules</artifactId>
+                                <version>1.0.0</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>extra-enforcer-rules</artifactId>
+                                <version>1.2</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
In the local development, the `package` was often used, but I found it interesting that each `package` required about 20m. Later, I found that **oss** inspection wasted a lot of time. When I deleted it, the packaging time was reduced to 2m.
Therefore, I submit this pr in the hope of saving time for people with the same problem as me