### PR TITLE
[IOTDB-317] Fix "flush + wrong aggregation" causes failed query in v0.8.x

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -693,7 +693,6 @@ public class StorageGroupProcessor {
       } catch (InterruptedException e) {
         logger.error("CloseFileNodeCondition error occurs while waiting for closing the storage "
             + "group {}", storageGroupName, e);
-        Thread.currentThread().interrupt();
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -397,7 +397,6 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     } catch (QueryProcessException | MetadataException | OutOfMemoryError | SQLException e) {
       logger
           .error(String.format("Failed to fetch timeseries %s's metadata", req.getColumnPath()), e);
-      Thread.currentThread().interrupt();
       status = getStatus(TSStatusCode.METADATA_ERROR, e.getMessage());
       resp.setStatus(status);
       return resp;


### PR DESCRIPTION
This PR fixes the bug of **flush + wrong aggregation** causes failed query in v0.8.x as is described in [issue IOTDB-317](https://issues.apache.org/jira/browse/IOTDB-317).

**【The main cause of this bug】**
When a wrong aggregation sql is executed, in `IoTDBStatement.java`, **getColumnsType** function is called when creating a new `IoTDBQueryResultSet`:
```
IoTDBQueryResultSet resSet = new IoTDBQueryResultSet(this,
            execResp.getColumns(), client,
            operationHandle, sql, execResp.getOperationType(),
            getColumnsType(execResp.getColumns()), queryId.getAndIncrement());
``` 
**getColumnsType** function calls **fetchMetadata** function in `TSServiceImpl.java`, which catches an exception (**QueryProcessException** in 0.9.x, and **PathErrorException** in 0.8.x), and uses `Thread.currentThread().interrupt()` to interrupt current thread. (The similar interrupt is also happened when executing `flush`)

However, when executing a new query, a new **TSFileSequenceReader** is created, so a new **DefaultTsFileInput** is opened:
```
public DefaultTsFileInput(Path file) throws IOException {
    channel = FileChannel.open(file, StandardOpenOption.READ);
  }
```
This causes **ClosedByInterruptException**:
```
Checked exception received by a thread when another thread interrupts it
while it is blocked in an I/O operation upon a channel.
Before this exception is thrown the channel will have been closed and the interrupt
status of the previously-blocked thread will have been set.
```
which finally causes the issue.

**【Why this bug is solved in 0.9.x】**
In PR #294 , the return data type in **TSExecuteStatementResp** is changed and fetch metadata requests are avoided, so the exception will not be thrown and the thread will not be interrupted.
Since interrupting current thread is useless and not necessary,  it should be deleted not only in 0.8.x (which fixes the bug) but also in 0.9.x.