### PR TITLE
[IOTDB-336]declare that the release version of JDK is 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <maven.assembly.version>2.5.5</maven.assembly.version>
         <scala.version>2.11.12</scala.version>
         <hadoop2.version>2.7.3</hadoop2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
         <maven.assembly.version>2.5.5</maven.assembly.version>
         <scala.version>2.11.12</scala.version>
         <hadoop2.version>2.7.3</hadoop2.version>
@@ -764,6 +763,9 @@
                 <!-- This needs to be updated as soon as Java 20 is shipped -->
                 <jdk>[11,20)</jdk>
             </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
             <dependencies>
                 <!-- for jdk-11 -->
                 <dependency>


### PR DESCRIPTION
I tried to use JDK11 to compile a binary file, you can get it at https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.2/rc1.

However, if a user uses JDK8 to run it, an exception will occur:

java.lang.NoSuchMethodError: java.nio.ByteBuffer.clear()Ljava/nio/ByteBuffer;

 

It is because before JDK9, ByteBuffer.clear() returns  Buffer, while from JDK9 on, the method return ByteBuffer.

 

According to https://github.com/apache/curator/pull/312, add a parameter `–release 8` can solve the problem. 

In maven, we can add a property called 

```

<maven.compiler.release>8</maven.compiler.release>

```