### PR TITLE
[IOTDB-334] Move LIMIT&OFFSET to Server Side

### DIFF
--- a/docs/Documentation-CHN/UserGuide/5-Operation Manual/4-SQL Reference.md
+++ b/docs/Documentation-CHN/UserGuide/5-Operation Manual/4-SQL Reference.md
@@ -292,7 +292,7 @@ Note: Integer in <TimeUnit> needs to be greater than 0
 * Limit语句
 
 ```
-SELECT <SelectClause> FROM <FromClause> [WHERE <WhereClause>] [LIMIT <LIMITClause>] [SLIMIT <SLIMITClause>]
+SELECT <SelectClause> FROM <FromClause> [WHERE <WhereClause>] [<LIMITClause>] [<SLIMITClause>]
 SelectClause : [<Path> | Function]+
 Function : <AggregationFunction> LPAREN <Path> RPAREN
 FromClause : <Path>
@@ -303,19 +303,18 @@ TimeExpr : TIME PrecedenceEqualOperator (<TimeValue> | <RelativeTime>)
 RelativeTimeDurationUnit = Integer ('Y'|'MO'|'W'|'D'|'H'|'M'|'S'|'MS'|'US'|'NS')
 RelativeTime : (now() | <TimeValue>) [(+|-) RelativeTimeDurationUnit]+
 SensorExpr : (<Timeseries>|<Path>) PrecedenceEqualOperator <PointValue>
-LIMITClause : <N> [OFFSETClause]?
-N : NonNegativeInteger
+LIMITClause : LIMIT <N> [OFFSETClause]?
+N : Integer
 OFFSETClause : OFFSET <OFFSETValue>
-OFFSETValue : NonNegativeInteger
-SLIMITClause : <SN> [SOFFSETClause]?
-SN : NonNegativeInteger
+OFFSETValue : Integer
+SLIMITClause : SLIMIT <SN> [SOFFSETClause]?
+SN : Integer
 SOFFSETClause : SOFFSET <SOFFSETValue>
-SOFFSETValue : NonNegativeInteger
-NonNegativeInteger:= ('+')? Digit+
+SOFFSETValue : Integer
 Eg: IoTDB > SELECT status, temperature FROM root.ln.wf01.wt01 WHERE temperature < 24 and time > 2017-11-1 0:13:00 LIMIT 3 OFFSET 2
 Eg. IoTDB > SELECT COUNT (status), MAX_VALUE(temperature) FROM root.ln.wf01.wt01 WHERE time < 1509466500000 GROUP BY(5m, 1509465660000, [1509465720000, 1509466380000]) LIMIT 3
+Note: N, OFFSETValue, SN and SOFFSETValue must be greater than 0.
 Note: The order of <LIMITClause> and <SLIMITClause> does not affect the grammatical correctness.
-Note: <SLIMITClause> can only effect in Prefixpath and StarPath.
 Note: <FillClause> can not use <LIMITClause> but not <SLIMITClause>.
 ```
 

--- a/docs/Documentation/UserGuide/5-Operation Manual/4-SQL Reference.md
+++ b/docs/Documentation/UserGuide/5-Operation Manual/4-SQL Reference.md
@@ -298,7 +298,7 @@ Note: Integer in <TimeUnit> needs to be greater than 0
 * Limit Statement
 
 ```
-SELECT <SelectClause> FROM <FromClause> [WHERE <WhereClause>] [LIMIT <LIMITClause>] [SLIMIT <SLIMITClause>]
+SELECT <SelectClause> FROM <FromClause> [WHERE <WhereClause>] [<LIMITClause>] [<SLIMITClause>]
 SelectClause : [<Path> | Function]+
 Function : <AggregationFunction> LPAREN <Path> RPAREN
 FromClause : <Path>
@@ -309,17 +309,17 @@ TimeExpr : TIME PrecedenceEqualOperator (<TimeValue> | <RelativeTime>)
 RelativeTimeDurationUnit = Integer ('Y'|'MO'|'W'|'D'|'H'|'M'|'S'|'MS'|'US'|'NS')
 RelativeTime : (now() | <TimeValue>) [(+|-) RelativeTimeDurationUnit]+
 SensorExpr : (<Timeseries>|<Path>) PrecedenceEqualOperator <PointValue>
-LIMITClause : <N> [OFFSETClause]?
-N : PositiveInteger
+LIMITClause : LIMIT <N> [OFFSETClause]?
+N : Integer
 OFFSETClause : OFFSET <OFFSETValue>
-OFFSETValue : NonNegativeInteger
-SLIMITClause : <SN> [SOFFSETClause]?
-SN : PositiveInteger
+OFFSETValue : Integer
+SLIMITClause : SLIMIT <SN> [SOFFSETClause]?
+SN : Integer
 SOFFSETClause : SOFFSET <SOFFSETValue>
-SOFFSETValue : NonNegativeInteger
-NonNegativeInteger:= ('+')? Digit+
+SOFFSETValue : Integer
 Eg: IoTDB > SELECT status, temperature FROM root.ln.wf01.wt01 WHERE temperature < 24 and time > 2017-11-1 0:13:00 LIMIT 3 OFFSET 2
 Eg. IoTDB > SELECT COUNT (status), MAX_VALUE(temperature) FROM root.ln.wf01.wt01 WHERE time < 1509466500000 GROUP BY(5m, 1509465660000, [1509465720000, 1509466380000]) LIMIT 3
+Note: N, OFFSETValue, SN and SOFFSETValue must be greater than 0.
 Note: The order of <LIMITClause> and <SLIMITClause> does not affect the grammatical correctness.
 Note: <FillClause> can not use <LIMITClause> but not <SLIMITClause>.
 ```

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -32,7 +32,16 @@ import java.util.List;
 import org.apache.iotdb.rpc.IoTDBRPCException;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
-import org.apache.iotdb.service.rpc.thrift.*;
+import org.apache.iotdb.service.rpc.thrift.TSCancelOperationReq;
+import org.apache.iotdb.service.rpc.thrift.TSCloseOperationReq;
+import org.apache.iotdb.service.rpc.thrift.TSExecuteBatchStatementReq;
+import org.apache.iotdb.service.rpc.thrift.TSExecuteBatchStatementResp;
+import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementReq;
+import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
+import org.apache.iotdb.service.rpc.thrift.TSIService;
+import org.apache.iotdb.service.rpc.thrift.TSOperationHandle;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+import org.apache.iotdb.service.rpc.thrift.TS_SessionHandle;
 import org.apache.thrift.TException;
 
 public class IoTDBStatement implements Statement {
@@ -96,7 +105,7 @@ public class IoTDBStatement implements Statement {
 
   // only for test
   IoTDBStatement(IoTDBConnection connection, TSIService.Iface client,
-                 TS_SessionHandle sessionHandle, ZoneId zoneId, long statementId) throws SQLException {
+      TS_SessionHandle sessionHandle, ZoneId zoneId, long statementId) throws SQLException {
     this.connection = connection;
     this.client = client;
     this.sessionHandle = sessionHandle;
@@ -277,9 +286,10 @@ public class IoTDBStatement implements Statement {
       return true;
     } else if (sqlToLowerCase.startsWith(COUNT_TIMESERIES_COMMAND_LOWERCASE)) {
       String[] cmdSplit = sqlToLowerCase.split("\\s+", 4);
-      if (cmdSplit.length != 3 && !(cmdSplit.length == 4 && cmdSplit[3].startsWith("group by level"))) {
+      if (cmdSplit.length != 3 && !(cmdSplit.length == 4 && cmdSplit[3]
+          .startsWith("group by level"))) {
         throw new SQLException(
-                "Error format of \'COUNT TIMESERIES <PATH>\' or \'COUNT TIMESERIES <PATH> GROUP BY LEVEL=<INTEGER>\'");
+            "Error format of \'COUNT TIMESERIES <PATH>\' or \'COUNT TIMESERIES <PATH> GROUP BY LEVEL=<INTEGER>\'");
       }
       if (cmdSplit.length == 3) {
         String path = cmdSplit[2];
@@ -291,7 +301,8 @@ public class IoTDBStatement implements Statement {
         String path = cmdSplit[2];
         int level = Integer.parseInt(cmdSplit[3].replaceAll(" ", "").substring(13));
         IoTDBDatabaseMetadata databaseMetadata = (IoTDBDatabaseMetadata) connection.getMetaData();
-        resultSet = databaseMetadata.getNodes(Constant.COUNT_NODE_TIMESERIES, path, null, null, level);
+        resultSet = databaseMetadata
+            .getNodes(Constant.COUNT_NODE_TIMESERIES, path, null, null, level);
         return true;
       }
     } else if (sqlToLowerCase.startsWith(COUNT_NODES_COMMAND_LOWERCASE)) {
@@ -305,7 +316,7 @@ public class IoTDBStatement implements Statement {
         resultSet = databaseMetaData.getNodes(Constant.COUNT_NODES, path, null, null, level);
         return true;
       }
-    } else if(sqlToLowerCase.equals(SHOW_VERSION_COMMAND_LOWERCASE)) {
+    } else if (sqlToLowerCase.equals(SHOW_VERSION_COMMAND_LOWERCASE)) {
       IoTDBDatabaseMetadata databaseMetadata = (IoTDBDatabaseMetadata) connection.getMetaData();
       resultSet = databaseMetadata.getColumns(Constant.CATALOG_VERSION, null, null, null);
       return true;
@@ -320,8 +331,9 @@ public class IoTDBStatement implements Statement {
       }
       if (execResp.getOperationHandle().hasResultSet) {
         this.resultSet = new IoTDBQueryResultSet(this,
-                execResp.getColumns(), execResp.getDataTypeList(),
-                execResp.ignoreTimeStamp, client, operationHandle, sql, operationHandle.getOperationId().getQueryId());
+            execResp.getColumns(), execResp.getDataTypeList(),
+            execResp.ignoreTimeStamp, client, operationHandle, sql,
+            operationHandle.getOperationId().getQueryId());
         return true;
       }
       return false;
@@ -354,7 +366,8 @@ public class IoTDBStatement implements Statement {
     TSExecuteBatchStatementReq execReq = new TSExecuteBatchStatementReq(sessionHandle,
         batchSQLList);
     TSExecuteBatchStatementResp execResp = client.executeBatchStatement(execReq);
-    if (execResp.getStatus().getStatusType().getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+    if (execResp.getStatus().getStatusType().getCode() == TSStatusCode.SUCCESS_STATUS
+        .getStatusCode()) {
       if (execResp.getResult() == null) {
         return new int[0];
       } else {
@@ -369,7 +382,8 @@ public class IoTDBStatement implements Statement {
     } else {
       BatchUpdateException exception;
       if (execResp.getResult() == null) {
-        exception = new BatchUpdateException(execResp.getStatus().getStatusType().getMessage(), new int[0]);
+        exception = new BatchUpdateException(execResp.getStatus().getStatusType().getMessage(),
+            new int[0]);
       } else {
         List<Integer> result = execResp.getResult();
         int len = result.size();
@@ -377,7 +391,8 @@ public class IoTDBStatement implements Statement {
         for (int i = 0; i < len; i++) {
           updateArray[i] = result.get(i);
         }
-        exception = new BatchUpdateException(execResp.getStatus().getStatusType().getMessage(), updateArray);
+        exception = new BatchUpdateException(execResp.getStatus().getStatusType().getMessage(),
+            updateArray);
       }
       throw exception;
     }
@@ -522,17 +537,13 @@ public class IoTDBStatement implements Statement {
 
   @Override
   public int getMaxRows() throws SQLException {
-    checkConnection("getMaxRows");
-    return maxRows;
+    throw new SQLException(METHOD_NOT_SUPPORTED_STRING);
   }
 
   @Override
   public void setMaxRows(int num) throws SQLException {
-    checkConnection("setMaxRows");
-    if (num < 0) {
-      throw new SQLException(String.format("maxRows %d must be >= 0!", num));
-    }
-    this.maxRows = num;
+    throw new SQLException(METHOD_NOT_SUPPORTED_STRING +
+        ". Please use the LIMIT clause in a query instead.");
   }
 
   @Override
@@ -641,18 +652,18 @@ public class IoTDBStatement implements Statement {
           this.stmtId = client.requestStatementId();
         } catch (TException e2) {
           throw new SQLException(
-                  "Cannot get id for statement after reconnecting. please check server status",
-                  e2);
+              "Cannot get id for statement after reconnecting. please check server status",
+              e2);
         }
       } else {
         throw new SQLException(
-                "Cannot get id for statement after reconnecting. please check server status", e);
+            "Cannot get id for statement after reconnecting. please check server status", e);
       }
     }
   }
 
 
-  private boolean reConnect(){
+  private boolean reConnect() {
     boolean flag = connection.reconnect();
     reInit();
     return flag;

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBQueryResultSetTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBQueryResultSetTest.java
@@ -18,14 +18,11 @@
  */
 package org.apache.iotdb.jdbc;
 
-import org.apache.iotdb.rpc.TSStatusCode;
-import org.apache.iotdb.service.rpc.thrift.*;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -38,9 +35,27 @@ import java.sql.Types;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.service.rpc.thrift.TSCloseOperationReq;
+import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementReq;
+import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
+import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataReq;
+import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataResp;
+import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
+import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
+import org.apache.iotdb.service.rpc.thrift.TSHandleIdentifier;
+import org.apache.iotdb.service.rpc.thrift.TSIService;
+import org.apache.iotdb.service.rpc.thrift.TSOperationHandle;
+import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
+import org.apache.iotdb.service.rpc.thrift.TSStatus;
+import org.apache.iotdb.service.rpc.thrift.TSStatusType;
+import org.apache.iotdb.service.rpc.thrift.TS_SessionHandle;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 /*
     This class is designed to test the function of TsfileQueryResultSet.
@@ -231,6 +246,9 @@ public class IoTDBQueryResultSetTest {
               + "1000,1000.11,55555,22222,1000.11,\n"; // Note the LIMIT&OFFSET clause takes effect
       Assert.assertEquals(standard, resultStr.toString());
     }
+
+    // The client issues 2 fetchResultReq in total. The last fetchResultReq get empty resultSet.
+    verify(fetchResultsResp, times(2)).getStatus();
   }
 
   // fake the first-time fetched result of 'testSql' from an IoTDB server
@@ -241,7 +259,6 @@ public class IoTDBQueryResultSetTest {
     tsDataTypeList.add(TSDataType.INT32); // root.vehicle.d0.s0
 
     Object[][] input = {
-        {1L, null, 1101L, null,},
         {2L, 2.22F, 40000L, null,},
         {3L, 3.33F, null, null,},
         {4L, 4.44F, null, null,},

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBStatementTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBStatementTest.java
@@ -251,19 +251,4 @@ public class IoTDBStatementTest {
     IoTDBStatement stmt = new IoTDBStatement(connection, client, sessHandle, zoneID);
     stmt.setFetchSize(-1);
   }
-
-  @SuppressWarnings("resource")
-  @Test
-  public void testSetMaxRows1() throws SQLException {
-    IoTDBStatement stmt = new IoTDBStatement(connection, client, sessHandle, zoneID);
-    stmt.setMaxRows(123);
-    assertEquals(123, stmt.getMaxRows());
-  }
-
-  @SuppressWarnings("resource")
-  @Test(expected = SQLException.class)
-  public void testSetMaxRows2() throws SQLException {
-    IoTDBStatement stmt = new IoTDBStatement(connection, client, sessHandle, zoneID);
-    stmt.setMaxRows(-1);
-  }
 }

--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -176,7 +176,7 @@ kerberos_principal=your principal
 write_read_free_memory_proportion=6:3:1
 
 # The amount of data read each time in batch (the number of data strips, that is, the number of different timestamps.)
-fetch_size=10000
+aggregate_fetch_size=100000
 
 # Size of log buffer in each log node(in byte).
 # If WAL is enabled and the size of a insert plan is smaller than this parameter, then the insert plan will be rejected by WAL

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -40,7 +40,7 @@ public class IoTDBConfig {
   private static final String MULTI_DIR_STRATEGY_PREFIX =
       "org.apache.iotdb.db.conf.directories.strategy.";
   private static final String DEFAULT_MULTI_DIR_STRATEGY = "MaxDiskUsableSpaceFirstStrategy";
-  
+
   /**
    * Port which the metrics service listens to.
    */
@@ -154,7 +154,7 @@ public class IoTDBConfig {
   /**
    * The amount of data that is read every time when IoTDB merges data.
    */
-  private int fetchSize = 10000;
+  private int aggregateFetchSize = 100000;
 
   /**
    * How many threads can concurrently flush. When <= 0, use CPU core number.
@@ -533,7 +533,7 @@ public class IoTDBConfig {
     }
   }
 
-  private String getHdfsDir(){
+  private String getHdfsDir() {
     String[] hdfsIps = TSFileDescriptor.getInstance().getConfig().getHdfsIp();
     String hdfsDir = "hdfs://";
     if (hdfsIps.length > 1) {
@@ -648,12 +648,12 @@ public class IoTDBConfig {
     this.multiDirStrategyClassName = multiDirStrategyClassName;
   }
 
-  public int getFetchSize() {
-    return fetchSize;
+  public int getAggregateFetchSize() {
+    return aggregateFetchSize;
   }
 
-  void setFetchSize(int fetchSize) {
-    this.fetchSize = fetchSize;
+  void setAggregateFetchSize(int aggregateFetchSize) {
+    this.aggregateFetchSize = aggregateFetchSize;
   }
 
   public int getMaxMemtableNumber() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -160,8 +160,8 @@ public class IoTDBDescriptor {
       conf.setMultiDirStrategyClassName(properties.getProperty("multi_dir_strategy",
           conf.getMultiDirStrategyClassName()));
 
-      conf.setFetchSize(Integer.parseInt(properties.getProperty("fetch_size",
-          Integer.toString(conf.getFetchSize()))));
+      conf.setAggregateFetchSize(Integer.parseInt(properties.getProperty("aggregate_fetch_size",
+          Integer.toString(conf.getAggregateFetchSize()))));
 
       long tsfileSizeThreshold = Long.parseLong(properties
           .getProperty("tsfile_size_threshold",

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/QueryOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/QueryOperator.java
@@ -38,9 +38,10 @@ public class QueryOperator extends SFWOperator {
   private Map<TSDataType, IFill> fillTypes;
   private boolean isFill = false;
 
-  private int seriesLimit;
-  private int seriesOffset;
-  private boolean hasSlimit = false; // false if sql does not contain SLIMIT clause
+  private int rowLimit = 0;
+  private int rowOffset = 0;
+  private int seriesLimit = 0;
+  private int seriesOffset = 0;
 
   private boolean isGroupByDevice = false;
 
@@ -73,13 +74,32 @@ public class QueryOperator extends SFWOperator {
     this.isGroupByTime = isGroupBy;
   }
 
+  public int getRowLimit() {
+    return rowLimit;
+  }
+
+  public void setRowLimit(int rowLimit) {
+    this.rowLimit = rowLimit;
+  }
+
+  public int getRowOffset() {
+    return rowOffset;
+  }
+
+  public void setRowOffset(int rowOffset) {
+    this.rowOffset = rowOffset;
+  }
+
+  public boolean hasLimit() {
+    return rowLimit > 0;
+  }
+
   public int getSeriesLimit() {
     return seriesLimit;
   }
 
   public void setSeriesLimit(int seriesLimit) {
     this.seriesLimit = seriesLimit;
-    this.hasSlimit = true;
   }
 
   public int getSeriesOffset() {
@@ -87,15 +107,11 @@ public class QueryOperator extends SFWOperator {
   }
 
   public void setSeriesOffset(int seriesOffset) {
-    /*
-     * Since soffset cannot be set alone without slimit, `hasSlimit` only need to be set true in the
-     * `setSeriesLimit` function.
-     */
     this.seriesOffset = seriesOffset;
   }
 
   public boolean hasSlimit() {
-    return hasSlimit;
+    return seriesLimit > 0;
   }
 
   public long getUnit() {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
@@ -35,6 +35,9 @@ public class QueryPlan extends PhysicalPlan {
   private List<TSDataType> dataTypes = null;
   private IExpression expression = null;
 
+  private int rowLimit = 0;
+  private int rowOffset = 0;
+
   private boolean isGroupByDevice = false; // for group by device sql
   private List<String> measurementColumnList; // for group by device sql
   private Map<String, Set<String>> measurementColumnsGroupByDevice; // for group by device sql
@@ -83,6 +86,26 @@ public class QueryPlan extends PhysicalPlan {
 
   public void setDataTypes(List<TSDataType> dataTypes) {
     this.dataTypes = dataTypes;
+  }
+
+  public int getRowLimit() {
+    return rowLimit;
+  }
+
+  public void setRowLimit(int rowLimit) {
+    this.rowLimit = rowLimit;
+  }
+
+  public int getRowOffset() {
+    return rowOffset;
+  }
+
+  public void setRowOffset(int rowOffset) {
+    this.rowOffset = rowOffset;
+  }
+
+  public boolean hasLimit() {
+    return rowLimit > 0;
   }
 
   public boolean isGroupByDevice() {

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -201,7 +201,8 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterAddLabel(ctx);
     PropertyOperator propertyOperator = new PropertyOperator(SQLConstant.TOK_PROPERTY_ADD_LABEL,
         PropertyOperator.PropertyType.ADD_PROPERTY_LABEL);
-    propertyOperator.setPropertyPath(new Path(new String[]{ctx.ID(1).getText(), ctx.ID(0).getText()}));
+    propertyOperator
+        .setPropertyPath(new Path(new String[]{ctx.ID(1).getText(), ctx.ID(0).getText()}));
     initializedOperator = propertyOperator;
     operatorType = SQLConstant.TOK_PROPERTY_ADD_LABEL;
   }
@@ -211,7 +212,8 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterDeleteLabel(ctx);
     PropertyOperator propertyOperator = new PropertyOperator(SQLConstant.TOK_PROPERTY_DELETE_LABEL,
         PropertyOperator.PropertyType.DELETE_PROPERTY_LABEL);
-    propertyOperator.setPropertyPath(new Path(new String[]{ctx.ID(1).getText(), ctx.ID(0).getText()}));
+    propertyOperator
+        .setPropertyPath(new Path(new String[]{ctx.ID(1).getText(), ctx.ID(0).getText()}));
     initializedOperator = propertyOperator;
     operatorType = SQLConstant.TOK_PROPERTY_DELETE_LABEL;
   }
@@ -367,7 +369,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   @Override
   public void enterLoadStatement(LoadStatementContext ctx) {
     super.enterLoadStatement(ctx);
-    if (ctx.prefixPath().nodeName().size() < 3 ) {
+    if (ctx.prefixPath().nodeName().size() < 3) {
       throw new SQLParserException("data load command: child count < 3\n");
     }
 
@@ -375,7 +377,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     StringContainer sc = new StringContainer(TsFileConstant.PATH_SEPARATOR);
     List<NodeNameContext> nodeNames = ctx.prefixPath().nodeName();
     sc.addTail(ctx.prefixPath().ROOT().getText());
-    for(NodeNameContext nodeName : nodeNames) {
+    for (NodeNameContext nodeName : nodeNames) {
       sc.addTail(nodeName.getText());
     }
     initializedOperator = new LoadDataOperator(SQLConstant.TOK_DATALOAD,
@@ -389,7 +391,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterGrantWatermarkEmbedding(ctx);
     List<RootOrIdContext> rootOrIdList = ctx.rootOrId();
     List<String> users = new ArrayList<>();
-    for(RootOrIdContext rootOrId : rootOrIdList) {
+    for (RootOrIdContext rootOrId : rootOrIdList) {
       users.add(rootOrId.getText());
     }
     initializedOperator = new DataAuthOperator(SQLConstant.TOK_GRANT_WATERMARK_EMBEDDING, users);
@@ -400,7 +402,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterRevokeWatermarkEmbedding(ctx);
     List<RootOrIdContext> rootOrIdList = ctx.rootOrId();
     List<String> users = new ArrayList<>();
-    for(RootOrIdContext rootOrId : rootOrIdList) {
+    for (RootOrIdContext rootOrId : rootOrIdList) {
       users.add(rootOrId.getText());
     }
     initializedOperator = new DataAuthOperator(SQLConstant.TOK_REVOKE_WATERMARK_EMBEDDING, users);
@@ -509,7 +511,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterShowTTLStatement(ctx);
     List<String> storageGroups = new ArrayList<>();
     List<PrefixPathContext> prefixPathList = ctx.prefixPath();
-    for(PrefixPathContext prefixPath : prefixPathList) {
+    for (PrefixPathContext prefixPath : prefixPathList) {
       storageGroups.add(parsePrefixPath(prefixPath).getFullPath());
     }
     initializedOperator = new ShowTTLOperator(storageGroups);
@@ -523,18 +525,18 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   }
 
   private String[] parsePrivilege(PrivilegesContext ctx) {
-    List<TerminalNode> privilegeList  = ctx.STRING_LITERAL();
+    List<TerminalNode> privilegeList = ctx.STRING_LITERAL();
     List<String> privileges = new ArrayList<>();
-    for(TerminalNode privilege : privilegeList) {
+    for (TerminalNode privilege : privilegeList) {
       privileges.add(removeStringQuote(privilege.getText()));
     }
     return privileges.toArray(new String[0]);
   }
 
   private String removeStringQuote(String src) {
-    if(src.charAt(0) == '\'' && src.charAt(src.length() - 1) == '\'') {
+    if (src.charAt(0) == '\'' && src.charAt(src.length() - 1) == '\'') {
       return src.substring(1, src.length() - 1);
-    } else if(src.charAt(0) == '\"' && src.charAt(src.length() - 1) == '\"') {
+    } else if (src.charAt(0) == '\"' && src.charAt(src.length() - 1) == '\"') {
       return src.substring(1, src.length() - 1);
     } else {
       throw new SQLParserException("error format for string with quote:" + src);
@@ -546,7 +548,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterDeleteTimeseries(ctx);
     List<Path> deletePaths = new ArrayList<>();
     List<PrefixPathContext> prefixPaths = ctx.prefixPath();
-    for(PrefixPathContext prefixPath : prefixPaths) {
+    for (PrefixPathContext prefixPath : prefixPaths) {
       deletePaths.add(parsePrefixPath(prefixPath));
     }
     DeleteTimeSeriesOperator deleteTimeSeriesOperator = new DeleteTimeSeriesOperator(
@@ -572,7 +574,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterDeleteStorageGroup(ctx);
     List<Path> deletePaths = new ArrayList<>();
     List<PrefixPathContext> prefixPaths = ctx.prefixPath();
-    for(PrefixPathContext prefixPath : prefixPaths) {
+    for (PrefixPathContext prefixPath : prefixPaths) {
       deletePaths.add(parsePrefixPath(prefixPath));
     }
     DeleteStorageGroupOperator deleteStorageGroupOperator = new DeleteStorageGroupOperator(
@@ -589,7 +591,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     deleteDataOp = new DeleteDataOperator(SQLConstant.TOK_DELETE);
     selectOp = new SelectOperator(SQLConstant.TOK_SELECT);
     List<PrefixPathContext> prefixPaths = ctx.prefixPath();
-    for(PrefixPathContext prefixPath : prefixPaths) {
+    for (PrefixPathContext prefixPath : prefixPaths) {
       Path path = parsePrefixPath(prefixPath);
       selectOp.addSelectPath(path);
     }
@@ -610,24 +612,24 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     long startTime;
     long endTime;
     List<TimeIntervalContext> timeIntervals = ctx.timeInterval();
-    for(TimeIntervalContext timeInterval : timeIntervals) {
-      if(timeInterval.timeValue(0).INT() != null) {
+    for (TimeIntervalContext timeInterval : timeIntervals) {
+      if (timeInterval.timeValue(0).INT() != null) {
         startTime = Long.parseLong(timeInterval.timeValue(0).INT().getText());
       } else {
         startTime = parseTimeFormat(timeInterval.timeValue(0).dateFormat().getText());
       }
-      if(timeInterval.timeValue(1).INT() != null) {
+      if (timeInterval.timeValue(1).INT() != null) {
         endTime = Long.parseLong(timeInterval.timeValue(1).INT().getText());
       } else {
         endTime = parseTimeFormat(timeInterval.timeValue(1).dateFormat().getText());
       }
-      intervals.add(new Pair<>(startTime,endTime));
+      intervals.add(new Pair<>(startTime, endTime));
     }
     queryOp.setIntervals(intervals);
 
     //
-    if(ctx.timeValue() != null) {
-      if(ctx.timeValue().INT() != null) {
+    if (ctx.timeValue() != null) {
+      if (ctx.timeValue().INT() != null) {
         queryOp.setOrigin(Long.parseLong(ctx.timeValue().INT().getText()));
       } else {
         queryOp.setOrigin(parseTimeFormat(ctx.timeValue().dateFormat().getText()));
@@ -646,7 +648,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     }
     List<TypeClauseContext> list = ctx.typeClause();
     Map<TSDataType, IFill> fillTypes = new EnumMap<>(TSDataType.class);
-    for(TypeClauseContext typeClause : list) {
+    for (TypeClauseContext typeClause : list) {
       parseTypeClause(typeClause, fillTypes);
     }
     queryOp.setFill(true);
@@ -655,13 +657,13 @@ public class LogicalGenerator extends SqlBaseBaseListener {
 
   private void parseTypeClause(TypeClauseContext ctx, Map<TSDataType, IFill> fillTypes) {
     TSDataType dataType = parseType(ctx.dataType().getText());
-    if(ctx.linearClause() != null && dataType == TSDataType.TEXT) {
+    if (ctx.linearClause() != null && dataType == TSDataType.TEXT) {
       throw new SQLParserException(String.format("type %s cannot use %s fill function"
           , dataType, ctx.linearClause().LINEAR().getText()));
     }
 
-    if(ctx.linearClause() != null) {
-      if(ctx.linearClause().DURATION(0) != null) {
+    if (ctx.linearClause() != null) {
+      if (ctx.linearClause().DURATION(0) != null) {
         long beforeRange = parseDuration(ctx.linearClause().DURATION(0).getText());
         long afterRange = parseDuration(ctx.linearClause().DURATION(1).getText());
         fillTypes.put(dataType, new LinearFill(beforeRange, afterRange));
@@ -669,7 +671,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
         fillTypes.put(dataType, new LinearFill(-1, -1));
       }
     } else {
-      if(ctx.previousClause().DURATION() != null) {
+      if (ctx.previousClause().DURATION() != null) {
         long preRange = parseDuration(ctx.previousClause().DURATION().getText());
         fillTypes.put(dataType, new PreviousFill(preRange));
       } else {
@@ -710,31 +712,65 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   @Override
   public void enterLimitClause(LimitClauseContext ctx) {
     super.enterLimitClause(ctx);
-    int limit = Integer.parseInt(ctx.INT().getText());
-    if(limit <= 0) {
-      throw new SQLParserException("LIMIT <N>: N must be a positive integer and can not be zero.");
+    int limit;
+    try {
+      limit = Integer.parseInt(ctx.INT().getText());
+    } catch (NumberFormatException e) {
+      throw new SQLParserException("Out of range. LIMIT <N>: N should be Int32.");
     }
-  }
-
-  @Override
-  public void enterSlimitClause(SlimitClauseContext ctx) {
-    super.enterSlimitClause(ctx);
-    int slimit = Integer.parseInt(ctx.INT().getText());
-    if(slimit <= 0) {
-      throw new SQLParserException("SLIMIT <SN>: SN must be a positive integer and can not be zero.");
+    if (limit <= 0) {
+      throw new SQLParserException("LIMIT <N>: N should be greater than 0.");
     }
-    queryOp.setSeriesLimit(slimit);
+    queryOp.setRowLimit(limit);
   }
 
   @Override
   public void enterOffsetClause(OffsetClauseContext ctx) {
     super.enterOffsetClause(ctx);
+    int offset;
+    try {
+      offset = Integer.parseInt(ctx.INT().getText());
+    } catch (NumberFormatException e) {
+      throw new SQLParserException(
+          "Out of range. OFFSET <OFFSETValue>: OFFSETValue should be Int32.");
+    }
+    if (offset <= 0) {
+      throw new SQLParserException("OFFSET <OFFSETValue>: OFFSETValue should be greater than 0.");
+    }
+    queryOp.setRowOffset(offset);
+  }
+
+  @Override
+  public void enterSlimitClause(SlimitClauseContext ctx) {
+    super.enterSlimitClause(ctx);
+    int slimit;
+    try {
+      slimit = Integer.parseInt(ctx.INT().getText());
+    } catch (NumberFormatException e) {
+      throw new SQLParserException(
+          "Out of range. SLIMIT <SN>: SN should be Int32.");
+    }
+    if (slimit <= 0) {
+      throw new SQLParserException("SLIMIT <SN>: SN should be greater than 0.");
+    }
+    queryOp.setSeriesLimit(slimit);
   }
 
   @Override
   public void enterSoffsetClause(SoffsetClauseContext ctx) {
     super.enterSoffsetClause(ctx);
-    queryOp.setSeriesOffset(Integer.parseInt(ctx.INT().getText()));
+    int soffset;
+    try {
+      soffset = Integer.parseInt(ctx.INT().getText());
+    } catch (NumberFormatException e) {
+      throw new SQLParserException(
+          "Out of range. SOFFSET <SOFFSETValue>: SOFFSETValue should be Int32.");
+    }
+    if (soffset <= 0) {
+      throw new SQLParserException(
+          "SOFFSET <SOFFSETValue>: SOFFSETValue should be greater than 0.");
+    }
+    queryOp.setSeriesOffset(soffset);
   }
 
   @Override
@@ -742,10 +778,10 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterInsertColumnSpec(ctx);
     List<NodeNameWithoutStarContext> nodeNamesWithoutStar = ctx.nodeNameWithoutStar();
     List<String> measurementList = new ArrayList<>();
-    for(NodeNameWithoutStarContext nodeNameWithoutStar: nodeNamesWithoutStar) {
+    for (NodeNameWithoutStarContext nodeNameWithoutStar : nodeNamesWithoutStar) {
       String measurement = nodeNameWithoutStar.getText();
-      if(measurement.contains("\"") || measurement.contains("\'")){
-        measurement = measurement.substring(1, measurement.length()-1);
+      if (measurement.contains("\"") || measurement.contains("\'")) {
+        measurement = measurement.substring(1, measurement.length() - 1);
       }
       measurementList.add(measurement);
     }
@@ -756,7 +792,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterInsertValuesSpec(InsertValuesSpecContext ctx) {
     super.enterInsertValuesSpec(ctx);
     long timestamp;
-    if(ctx.dateFormat() != null) {
+    if (ctx.dateFormat() != null) {
       timestamp = parseTimeFormat(ctx.dateFormat().getText());
     } else {
       timestamp = Long.parseLong(ctx.INT().getText());
@@ -764,23 +800,24 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     insertOp.setTime(timestamp);
     List<String> valueList = new ArrayList<>();
     List<ConstantContext> values = ctx.constant();
-    for(ConstantContext value : values) {
+    for (ConstantContext value : values) {
       valueList.add(value.getText());
     }
     insertOp.setValueList(valueList.toArray(new String[0]));
-    initializedOperator  = insertOp;
+    initializedOperator = insertOp;
   }
 
   private Path parseTimeseriesPath(TimeseriesPathContext ctx) {
     List<NodeNameWithoutStarContext> nodeNamesWithoutStar = ctx.nodeNameWithoutStar();
     List<String> path = new ArrayList<>();
-    if(ctx.ROOT() != null) {
+    if (ctx.ROOT() != null) {
       path.add(ctx.ROOT().getText());
     }
-    for(NodeNameWithoutStarContext nodeNameWithoutStar: nodeNamesWithoutStar) {
+    for (NodeNameWithoutStarContext nodeNameWithoutStar : nodeNamesWithoutStar) {
       path.add(nodeNameWithoutStar.getText());
     }
-    return new Path(new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
+    return new Path(
+        new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
   }
 
   @Override
@@ -793,15 +830,16 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     String compressor;
     List<PropertyContext> properties = ctx.property();
     Map<String, String> props = new HashMap<>(properties.size(), 1);
-    if(ctx.propertyValue() != null) {
+    if (ctx.propertyValue() != null) {
       compressor = ctx.propertyValue().getText().toUpperCase();
     } else {
       compressor = TSFileDescriptor.getInstance().getConfig().getCompressor().toUpperCase();
     }
     checkMetadataArgs(dataType, encoding, compressor);
-    if(ctx.property(0) != null) {
+    if (ctx.property(0) != null) {
       for (PropertyContext property : properties) {
-        props.put(property.ID().getText().toLowerCase(), property.propertyValue().getText().toLowerCase());
+        props.put(property.ID().getText().toLowerCase(),
+            property.propertyValue().getText().toLowerCase());
       }
     }
     createTimeSeriesOperator.setCompressor(CompressionType.valueOf(compressor));
@@ -843,7 +881,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterFromClause(ctx);
     FromOperator fromOp = new FromOperator(SQLConstant.TOK_FROM);
     List<PrefixPathContext> prefixFromPaths = ctx.prefixPath();
-    for(PrefixPathContext prefixFromPath : prefixFromPaths) {
+    for (PrefixPathContext prefixFromPath : prefixFromPaths) {
       Path path = parsePrefixPath(prefixFromPath);
       fromOp.addPrefixTablePath(path);
     }
@@ -855,7 +893,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterFunctionElement(ctx);
     selectOp = new SelectOperator(SQLConstant.TOK_SELECT);
     List<FunctionCallContext> functionCallContextList = ctx.functionCall();
-    for(FunctionCallContext functionCallContext : functionCallContextList) {
+    for (FunctionCallContext functionCallContext : functionCallContextList) {
       Path path = parseSuffixPath(functionCallContext.suffixPath());
       selectOp.addClusterPath(path, functionCallContext.ID().getText());
     }
@@ -867,7 +905,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterSelectElement(ctx);
     selectOp = new SelectOperator(SQLConstant.TOK_SELECT);
     List<SuffixPathContext> suffixPaths = ctx.suffixPath();
-    for(SuffixPathContext suffixPath : suffixPaths) {
+    for (SuffixPathContext suffixPath : suffixPaths) {
       Path path = parseSuffixPath(suffixPath);
       selectOp.addSelectPath(path);
     }
@@ -887,10 +925,11 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     List<NodeNameContext> nodeNames = ctx.nodeName();
     List<String> path = new ArrayList<>();
     path.add(ctx.ROOT().getText());
-    for(NodeNameContext nodeName : nodeNames) {
+    for (NodeNameContext nodeName : nodeNames) {
       path.add(nodeName.getText());
     }
-    return new Path(new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
+    return new Path(
+        new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
   }
 
   /**
@@ -920,7 +959,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
         tmp = 0;
       }
     }
-    if(total <= 0) {
+    if (total <= 0) {
       throw new SQLParserException("Interval must more than 0.");
     }
     return total;
@@ -932,7 +971,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     FilterOperator whereOp = new FilterOperator(SQLConstant.TOK_WHERE);
     whereOp.addChildOperator(parseOrExpression(ctx.orExpression()));
     switch (operatorType) {
-      case SQLConstant.TOK_DELETE :
+      case SQLConstant.TOK_DELETE:
         deleteDataOp.setFilterOperator(whereOp.getChildren().get(0));
         long deleteTime = parseDeleteTimeFilter(deleteDataOp);
         deleteDataOp.setTime(deleteTime);
@@ -950,13 +989,13 @@ public class LogicalGenerator extends SqlBaseBaseListener {
 
 
   private FilterOperator parseOrExpression(OrExpressionContext ctx) {
-    if(ctx.andExpression().size() == 1) {
+    if (ctx.andExpression().size() == 1) {
       isOrWhereClause = false;
       return parseAndExpression(ctx.andExpression(0));
     }
     isOrWhereClause = true;
     FilterOperator binaryOp = new FilterOperator(SQLConstant.KW_OR);
-    if(ctx.andExpression().size() > 2) {
+    if (ctx.andExpression().size() > 2) {
       binaryOp.addChildOperator(parseAndExpression(ctx.andExpression(0)));
       binaryOp.addChildOperator(parseAndExpression(ctx.andExpression(1)));
       for (int i = 2; i < ctx.andExpression().size(); i++) {
@@ -966,8 +1005,9 @@ public class LogicalGenerator extends SqlBaseBaseListener {
         binaryOp = op;
       }
     } else {
-      for(AndExpressionContext andExpressionContext : ctx.andExpression())
+      for (AndExpressionContext andExpressionContext : ctx.andExpression()) {
         binaryOp.addChildOperator(parseAndExpression(andExpressionContext));
+      }
     }
     return binaryOp;
   }
@@ -1015,12 +1055,14 @@ public class LogicalGenerator extends SqlBaseBaseListener {
         path = parseSuffixPath(ctx.suffixPath());
       }
       if (ctx.constant().dateExpression() != null) {
-        if(!path.equals(SQLConstant.RESERVED_TIME)) {
+        if (!path.equals(SQLConstant.RESERVED_TIME)) {
           throw new SQLParserException(path.toString(), "Date can only be used to time");
         }
-        basic = new BasicFunctionOperator(ctx.comparisonOperator().type.getType(), path, Long.toString(parseDateExpression(ctx.constant().dateExpression())));
+        basic = new BasicFunctionOperator(ctx.comparisonOperator().type.getType(), path,
+            Long.toString(parseDateExpression(ctx.constant().dateExpression())));
       } else {
-        basic = new BasicFunctionOperator(ctx.comparisonOperator().type.getType(), path, ctx.constant().getText());
+        basic = new BasicFunctionOperator(ctx.comparisonOperator().type.getType(), path,
+            ctx.constant().getText());
       }
       if (!isNotWhereClause && !isAndWhereClause && !isOrWhereClause) {
         return basic;
@@ -1032,10 +1074,11 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   private Path parseSuffixPath(SuffixPathContext ctx) {
     List<NodeNameContext> nodeNames = ctx.nodeName();
     List<String> path = new ArrayList<>();
-    for(NodeNameContext nodeName : nodeNames) {
+    for (NodeNameContext nodeName : nodeNames) {
       path.add(nodeName.getText());
     }
-    return new Path(new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
+    return new Path(
+        new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
   }
 
 
@@ -1050,14 +1093,14 @@ public class LogicalGenerator extends SqlBaseBaseListener {
    * eg. now() + 1d - 2h
    * </p>
    */
-  private Long parseDateExpression(DateExpressionContext ctx){
+  private Long parseDateExpression(DateExpressionContext ctx) {
     long time;
     time = parseTimeFormat(ctx.getChild(0).getText());
-    for(int i = 1; i < ctx.getChildCount(); i = i+2) {
-      if(ctx.getChild(i).getText().equals("+")) {
-        time+= parseDuration(ctx.getChild(i+1).getText());
+    for (int i = 1; i < ctx.getChildCount(); i = i + 2) {
+      if (ctx.getChild(i).getText().equals("+")) {
+        time += parseDuration(ctx.getChild(i + 1).getText());
       } else {
-        time-= parseDuration(ctx.getChild(i+1).getText());
+        time -= parseDuration(ctx.getChild(i + 1).getText());
       }
     }
     return time;
@@ -1088,7 +1131,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
    *
    * @param operator delete logical plan
    */
-  private long parseDeleteTimeFilter(DeleteDataOperator operator)  {
+  private long parseDeleteTimeFilter(DeleteDataOperator operator) {
     FilterOperator filterOperator = operator.getFilterOperator();
     if (filterOperator.getTokenIntType() != SQLConstant.LESSTHAN
         && filterOperator.getTokenIntType() != SQLConstant.LESSTHANOREQUALTO) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -158,7 +158,7 @@ public class PhysicalGenerator {
       case LOAD_CONFIGURATION:
         return new LoadConfigurationPlan();
       case SHOW:
-        switch (operator.getTokenIntType()){
+        switch (operator.getTokenIntType()) {
           case SQLConstant.TOK_DYNAMIC_PARAMETER:
             return new ShowPlan(ShowContentType.DYNAMIC_PARAMETER);
           case SQLConstant.TOK_FLUSH_TASK_INFO:
@@ -201,12 +201,8 @@ public class PhysicalGenerator {
       queryPlan = new QueryPlan();
     }
 
-    if (!queryOperator.isGroupByDevice()) {
-      List<Path> paths = queryOperator.getSelectedPaths();
-      queryPlan.setPaths(paths);
-
-    } else {
-      // below is the core realization of GROUP_BY_DEVICE sql
+    if (queryOperator.isGroupByDevice()) {
+      // below is the core realization of GROUP_BY_DEVICE sql logic
       List<Path> prefixPaths = queryOperator.getFromOperator().getPrefixPaths();
       List<Path> suffixPaths = queryOperator.getSelectOperator().getSuffixPaths();
       List<String> originAggregations = queryOperator.getSelectOperator().getAggregations();
@@ -312,6 +308,9 @@ public class PhysicalGenerator {
       queryPlan.setMeasurementColumnsGroupByDevice(measurementColumnsGroupByDevice);
       queryPlan.setDataTypeConsistencyChecker(dataTypeConsistencyChecker);
       queryPlan.setPaths(new ArrayList<>(allSelectPaths));
+    } else {
+      List<Path> paths = queryOperator.getSelectedPaths();
+      queryPlan.setPaths(paths);
     }
 
     queryPlan.checkPaths(executor);
@@ -323,6 +322,9 @@ public class PhysicalGenerator {
       IExpression expression = filterOperator.transformToExpression(executor);
       queryPlan.setExpression(expression);
     }
+
+    queryPlan.setRowLimit(queryOperator.getRowLimit());
+    queryPlan.setRowOffset(queryOperator.getRowOffset());
 
     return queryPlan;
   }

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/DeviceIterateDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/DeviceIterateDataSet.java
@@ -112,7 +112,7 @@ public class DeviceIterateDataSet extends QueryDataSet {
     this.currentColumnMapRelation = new int[deduplicatedMeasurementColumns.size()];
   }
 
-  public boolean hasNext() throws IOException {
+  protected boolean hasNextWithoutConstraint() throws IOException {
     if (curDataSetInitialized && currentDataSet.hasNext()) {
       return true;
     } else {
@@ -191,7 +191,7 @@ public class DeviceIterateDataSet extends QueryDataSet {
     return false;
   }
 
-  public RowRecord next() throws IOException {
+  protected RowRecord nextWithoutConstraint() throws IOException {
     RowRecord originRowRecord = currentDataSet.next();
 
     RowRecord rowRecord = new RowRecord(originRowRecord.getTimestamp());

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/EngineDataSetWithValueFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/EngineDataSetWithValueFilter.java
@@ -51,7 +51,7 @@ public class EngineDataSetWithValueFilter extends QueryDataSet {
   }
 
   @Override
-  public boolean hasNext() throws IOException {
+  protected boolean hasNextWithoutConstraint() throws IOException {
     if (hasCachedRowRecord) {
       return true;
     }
@@ -59,7 +59,7 @@ public class EngineDataSetWithValueFilter extends QueryDataSet {
   }
 
   @Override
-  public RowRecord next() throws IOException {
+  protected RowRecord nextWithoutConstraint() throws IOException {
     if (!hasCachedRowRecord && !cacheRowRecord()) {
       return null;
     }

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/EngineDataSetWithoutValueFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/EngineDataSetWithoutValueFilter.java
@@ -19,6 +19,9 @@
 
 package org.apache.iotdb.db.query.dataset;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.TreeSet;
 import org.apache.iotdb.db.query.reader.IPointReader;
 import org.apache.iotdb.db.utils.TimeValuePair;
 import org.apache.iotdb.db.utils.TsPrimitiveType;
@@ -28,10 +31,6 @@ import org.apache.iotdb.tsfile.read.common.Field;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.common.RowRecord;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.TreeSet;
 
 /**
  * TODO implement this class as TsFile DataSetWithoutTimeGenerator.
@@ -53,7 +52,7 @@ public class EngineDataSetWithoutValueFilter extends QueryDataSet {
    * @throws IOException IOException
    */
   public EngineDataSetWithoutValueFilter(List<Path> paths, List<TSDataType> dataTypes,
-                                         List<IPointReader> readers)
+      List<IPointReader> readers)
       throws IOException {
     super(paths, dataTypes);
     this.seriesReaderWithoutValueFilterList = readers;
@@ -75,12 +74,12 @@ public class EngineDataSetWithoutValueFilter extends QueryDataSet {
   }
 
   @Override
-  public boolean hasNext() {
+  protected boolean hasNextWithoutConstraint() {
     return !timeHeap.isEmpty();
   }
 
   @Override
-  public RowRecord next() throws IOException {
+  protected RowRecord nextWithoutConstraint() throws IOException {
     long minTime = timeHeapGet();
 
     RowRecord record = new RowRecord(minTime);

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/ListDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/ListDataSet.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.query.dataset;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -38,12 +37,12 @@ public class ListDataSet extends QueryDataSet {
   }
 
   @Override
-  public boolean hasNext() throws IOException {
+  protected boolean hasNextWithoutConstraint() {
     return index < records.size();
   }
 
   @Override
-  public RowRecord next() {
+  protected RowRecord nextWithoutConstraint() {
     return records.get(index++);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByEngineDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByEngineDataSet.java
@@ -81,7 +81,7 @@ public abstract class GroupByEngineDataSet extends QueryDataSet {
   }
 
   @Override
-  public boolean hasNext() {
+  protected boolean hasNextWithoutConstraint() {
     // has cached
     if (hasCachedTimeInterval) {
       return true;

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithValueFilterDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithValueFilterDataSet.java
@@ -61,7 +61,7 @@ public class GroupByWithValueFilterDataSet extends GroupByEngineDataSet {
       List<Pair<Long, Long>> mergedIntervals) {
     super(jobId, paths, unit, origin, mergedIntervals);
     this.allDataReaderList = new ArrayList<>();
-    this.timeStampFetchSize = 10 * IoTDBDescriptor.getInstance().getConfig().getFetchSize();
+    this.timeStampFetchSize = IoTDBDescriptor.getInstance().getConfig().getAggregateFetchSize();
   }
 
   /**
@@ -80,7 +80,7 @@ public class GroupByWithValueFilterDataSet extends GroupByEngineDataSet {
   }
 
   @Override
-  public RowRecord next() throws IOException {
+  protected RowRecord nextWithoutConstraint() throws IOException {
     if (!hasCachedTimeInterval) {
       throw new IOException("need to call hasNext() before calling next()"
           + " in GroupByWithoutValueFilterDataSet.");

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithoutValueFilterDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/groupby/GroupByWithoutValueFilterDataSet.java
@@ -102,7 +102,7 @@ public class GroupByWithoutValueFilterDataSet extends GroupByEngineDataSet {
   }
 
   @Override
-  public RowRecord next() throws IOException {
+  protected RowRecord nextWithoutConstraint() throws IOException {
     if (!hasCachedTimeInterval) {
       throw new IOException("need to call hasNext() before calling next() "
           + "in GroupByWithoutValueFilterDataSet.");

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/AggregateEngineExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/AggregateEngineExecutor.java
@@ -72,7 +72,7 @@ public class AggregateEngineExecutor {
     this.selectedSeries = selectedSeries;
     this.aggres = aggres;
     this.expression = expression;
-    this.aggregateFetchSize = 10 * IoTDBDescriptor.getInstance().getConfig().getFetchSize();
+    this.aggregateFetchSize = IoTDBDescriptor.getInstance().getConfig().getAggregateFetchSize();
   }
 
   /**

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBQueryDemoIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBQueryDemoIT.java
@@ -18,6 +18,15 @@
  */
 package org.apache.iotdb.db.integration;
 
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
 import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
@@ -25,10 +34,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.sql.*;
-
-import static org.junit.Assert.fail;
 
 public class IoTDBQueryDemoIT {
 
@@ -194,5 +199,100 @@ public class IoTDBQueryDemoIT {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void LimitTest() throws ClassNotFoundException {
+    String[] retArray = new String[]{
+        "1509465780000,false,20.18,v1,false,false,20.18,",
+        "1509465840000,false,21.13,v1,false,false,21.13,",
+        "1509465900000,false,22.72,v1,false,false,22.72,",
+        "1509465960000,false,20.71,v1,false,false,20.71,",
+        "1509466020000,false,21.45,v1,false,false,21.45,",
+    };
+
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      // test 1: fetchSize < limitNumber
+      statement.setFetchSize(4);
+      Assert.assertEquals(4, statement.getFetchSize());
+      boolean hasResultSet = statement.execute("select * from root where time>10 limit 5 offset 3");
+      Assert.assertTrue(hasResultSet);
+      try (ResultSet resultSet = statement.getResultSet()) {
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        StringBuilder header = new StringBuilder();
+        for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+          header.append(resultSetMetaData.getColumnName(i)).append(",");
+        }
+        System.out.println(header.toString());
+        Assert.assertEquals(
+            "Time,root.ln.wf01.wt01.status,root.ln.wf01.wt01.temperature,"
+                + "root.ln.wf02.wt02.hardware,root.ln.wf02.wt02.status,root.sgcc.wf03.wt01.status,"
+                + "root.sgcc.wf03.wt01.temperature,", header.toString());
+        Assert.assertEquals(Types.TIMESTAMP, resultSetMetaData.getColumnType(1));
+        Assert.assertEquals(Types.BOOLEAN, resultSetMetaData.getColumnType(2));
+        Assert.assertEquals(Types.FLOAT, resultSetMetaData.getColumnType(3));
+        Assert.assertEquals(Types.VARCHAR, resultSetMetaData.getColumnType(4));
+        Assert.assertEquals(Types.BOOLEAN, resultSetMetaData.getColumnType(5));
+        Assert.assertEquals(Types.BOOLEAN, resultSetMetaData.getColumnType(6));
+        Assert.assertEquals(Types.FLOAT, resultSetMetaData.getColumnType(7));
+
+        int cnt = 0;
+        while (resultSet.next()) {
+          StringBuilder builder = new StringBuilder();
+          for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+            builder.append(resultSet.getString(i)).append(",");
+          }
+          System.out.println(builder.toString());
+          Assert.assertEquals(retArray[cnt], builder.toString());
+          cnt++;
+        }
+        Assert.assertEquals(5, cnt);
+      }
+
+      // test 1: fetchSize > limitNumber
+      statement.setFetchSize(10000);
+      Assert.assertEquals(10000, statement.getFetchSize());
+      hasResultSet = statement.execute("select * from root where time>10 limit 5 offset 3");
+      Assert.assertTrue(hasResultSet);
+      try (ResultSet resultSet = statement.getResultSet()) {
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        StringBuilder header = new StringBuilder();
+        for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+          header.append(resultSetMetaData.getColumnName(i)).append(",");
+        }
+        System.out.println(header.toString());
+        Assert.assertEquals(
+            "Time,root.ln.wf01.wt01.status,root.ln.wf01.wt01.temperature,"
+                + "root.ln.wf02.wt02.hardware,root.ln.wf02.wt02.status,root.sgcc.wf03.wt01.status,"
+                + "root.sgcc.wf03.wt01.temperature,", header.toString());
+        Assert.assertEquals(Types.TIMESTAMP, resultSetMetaData.getColumnType(1));
+        Assert.assertEquals(Types.BOOLEAN, resultSetMetaData.getColumnType(2));
+        Assert.assertEquals(Types.FLOAT, resultSetMetaData.getColumnType(3));
+        Assert.assertEquals(Types.VARCHAR, resultSetMetaData.getColumnType(4));
+        Assert.assertEquals(Types.BOOLEAN, resultSetMetaData.getColumnType(5));
+        Assert.assertEquals(Types.BOOLEAN, resultSetMetaData.getColumnType(6));
+        Assert.assertEquals(Types.FLOAT, resultSetMetaData.getColumnType(7));
+
+        int cnt = 0;
+        while (resultSet.next()) {
+          StringBuilder builder = new StringBuilder();
+          for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+            builder.append(resultSet.getString(i)).append(",");
+          }
+          System.out.println(builder.toString());
+          Assert.assertEquals(retArray[cnt], builder.toString());
+          cnt++;
+        }
+        Assert.assertEquals(5, cnt);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
 
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/LogicalPlanSmallTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/LogicalPlanSmallTest.java
@@ -47,41 +47,124 @@ public class LogicalPlanSmallTest {
   }
 
   @Test
-  public void testSlimit1() {
-    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() slimit 10";
-    RootOperator operator = (RootOperator) parseDriver.parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+  public void testLimit() {
+    String sqlStr = "select * from root.vehicle.d1 limit 10";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
-    Assert.assertEquals(10, ((QueryOperator) operator).getSeriesLimit());
-  }
-
-  @Test(expected = NumberFormatException.class)
-  public void testSlimit2() {
-    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() slimit 1111111111111111111111";
-    RootOperator operator = (RootOperator) parseDriver.parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
-    // expected to throw LogicalOperatorException: SLIMIT <SN>: SN should be Int32.
-  }
-
-  @Test(expected = SQLParserException.class)
-  public void testSlimit3() {
-    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() slimit 0";
-    RootOperator operator = (RootOperator) parseDriver.parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
-    // expected to throw LogicalOperatorException: SLIMIT <SN>: SN must be a positive integer and can not be zero.
+    Assert.assertEquals(10, ((QueryOperator) operator).getRowLimit());
+    Assert.assertEquals(0, ((QueryOperator) operator).getRowOffset());
+    Assert.assertEquals(0, ((QueryOperator) operator).getSeriesLimit());
+    Assert.assertEquals(0, ((QueryOperator) operator).getSeriesOffset());
   }
 
   @Test
-  public void testSoffset() {
-    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() slimit 10 soffset 1";
-    RootOperator operator = (RootOperator) parseDriver.parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+  public void testOffset() {
+    String sqlStr = "select * from root.vehicle.d1 limit 10 offset 20";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
+    Assert.assertEquals(10, ((QueryOperator) operator).getRowLimit());
+    Assert.assertEquals(20, ((QueryOperator) operator).getRowOffset());
+    Assert.assertEquals(0, ((QueryOperator) operator).getSeriesLimit());
+    Assert.assertEquals(0, ((QueryOperator) operator).getSeriesOffset());
+  }
+
+  @Test
+  public void testSlimit() {
+    String sqlStr = "select * from root.vehicle.d1 limit 10 slimit 1";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    Assert.assertEquals(QueryOperator.class, operator.getClass());
+    Assert.assertEquals(10, ((QueryOperator) operator).getRowLimit());
+    Assert.assertEquals(0, ((QueryOperator) operator).getRowOffset());
+    Assert.assertEquals(1, ((QueryOperator) operator).getSeriesLimit());
+    Assert.assertEquals(0, ((QueryOperator) operator).getSeriesOffset());
+  }
+
+  @Test
+  public void testSOffset() {
+    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() limit 50 slimit 10 soffset 100";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    Assert.assertEquals(QueryOperator.class, operator.getClass());
+    Assert.assertEquals(50, ((QueryOperator) operator).getRowLimit());
+    Assert.assertEquals(0, ((QueryOperator) operator).getRowOffset());
     Assert.assertEquals(10, ((QueryOperator) operator).getSeriesLimit());
-    Assert.assertEquals(1, ((QueryOperator) operator).getSeriesOffset());
+    Assert.assertEquals(100, ((QueryOperator) operator).getSeriesOffset());
+  }
+
+  @Test(expected = SQLParserException.class)
+  public void testLimitOutOfRange() {
+    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() limit 1111111111111111111111";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    // expected to throw SQLParserException: Out of range. LIMIT <N>: N should be Int32.
+  }
+
+  @Test(expected = SQLParserException.class)
+  public void testLimitNotPositive() {
+    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() limit 0";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    // expected to throw SQLParserException: LIMIT <N>: N should be greater than 0.
+  }
+
+  @Test(expected = SQLParserException.class)
+  public void testOffsetOutOfRange() {
+    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() "
+        + "limit 1 offset 1111111111111111111111";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    // expected to throw SQLParserException: Out of range. OFFSET <OFFSETValue>: OFFSETValue should be Int32.
+  }
+
+  @Test(expected = SQLParserException.class)
+  public void testOffsetNotPositive() {
+    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() limit 1 offset 0";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    // expected to throw SQLParserException: OFFSET <OFFSETValue>: OFFSETValue should be greater than 0.
+  }
+
+  @Test(expected = SQLParserException.class)
+  public void testSlimitOutOfRange() {
+    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() slimit 1111111111111111111111";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    // expected to throw SQLParserException: Out of range. SLIMIT <SN>: SN should be Int32.
+  }
+
+  @Test(expected = SQLParserException.class)
+  public void testSlimitNotPositive() {
+    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() slimit 0";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    // expected to throw SQLParserException: SLIMIT <SN>: SN should be greater than 0.
+  }
+
+  @Test(expected = SQLParserException.class)
+  public void testSoffsetOutOfRange() {
+    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() "
+        + "slimit 1 soffset 1111111111111111111111";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    // expected to throw SQLParserException: Out of range. SOFFSET <SOFFSETValue>: SOFFSETValue should be Int32.
+  }
+
+  @Test(expected = SQLParserException.class)
+  public void testSoffsetNotPositive() {
+    String sqlStr = "select * from root.vehicle.d1 where s1 < 20 and time <= now() slimit 1 soffset 0";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    // expected to throw SQLParserException: SOFFSET <SOFFSETValue>: SOFFSETValue should be greater than 0.
   }
 
   @Test(expected = LogicalOptimizeException.class)
-  public void testSlimitLogicalOptimize()
-      throws QueryProcessException {
-    String sqlStr = "select s1 from root.vehicle.d1 where s1 < 20 and time <= now() slimit 10 soffset 1";
-    RootOperator operator = (RootOperator) parseDriver.parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+  public void testSoffsetExceedColumnNum() throws QueryProcessException {
+    String sqlStr = "select s1 from root.vehicle.d1 where s1 < 20 and time <= now() slimit 2 soffset 1";
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
 
     MemIntQpExecutor executor = new MemIntQpExecutor();
     Path path1 = new Path(
@@ -102,28 +185,14 @@ public class LogicalPlanSmallTest {
     executor.insert(new InsertPlan(path4.getDevice(), 10, path4.getMeasurement(), "10"));
     ConcatPathOptimizer concatPathOptimizer = new ConcatPathOptimizer(executor);
     operator = (SFWOperator) concatPathOptimizer.transform(operator);
-    // expected to throw LogicalOptimizeException: Wrong use of SLIMIT: SLIMIT is not allowed to be used with
-    // complete paths.
-  }
-
-  @Test(expected = NumberFormatException.class)
-  public void testLimit1() {
-    String sqlStr = "select s1 from root.vehicle.d1 where s1 < 20 and time <= now() limit 111111111111111111111111";
-    RootOperator operator = (RootOperator) parseDriver.parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
-    // expected to throw LogicalOperatorException: LIMIT <N>: N should be Int32.
-  }
-
-  @Test(expected = SQLParserException.class)
-  public void testLimit2() {
-    String sqlStr = "select s1 from root.vehicle.d1 where s1 < 20 and time <= now() limit 0";
-    RootOperator operator = (RootOperator) parseDriver.parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
-    // expected to throw LogicalOperatorException: LIMIT <N>: N must be a positive integer and can not be zero.
+    // expected to throw LogicalOptimizeException: SOFFSET <SOFFSETValue>: SOFFSETValue exceeds the range.
   }
 
   @Test
   public void testDeleteStorageGroup() {
     String sqlStr = "delete storage group root.vehicle.d1";
-    RootOperator operator = (RootOperator) parseDriver.parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    RootOperator operator = (RootOperator) parseDriver
+        .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
     Assert.assertEquals(DeleteStorageGroupOperator.class, operator.getClass());
     Path path = new Path("root.vehicle.d1");
     Assert.assertEquals(path, ((DeleteStorageGroupOperator) operator).getDeletePathList().get(0));

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
@@ -311,7 +311,18 @@ public class PhysicalPlanTest {
     IExpression expect = new GlobalTimeExpression(
         FilterFactory.or(TimeFilter.gt(1571090340000L), TimeFilter.lt(10L)));
     assertEquals(expect.toString(), queryFilter.toString());
+  }
 
+  @Test
+  public void testLimitOffset()
+      throws QueryProcessException, MetadataException {
+    String sqlStr = "SELECT s1 FROM root.vehicle.d1,root.vehicle.d2 WHERE time < 10 "
+        + "limit 100 offset 10 slimit 1 soffset 1";
+    QueryPlan plan = (QueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
+    assertEquals(100, plan.getRowLimit());
+    assertEquals(10, plan.getRowOffset());
+    // NOTE that the parameters of the SLIMIT clause is not stored in the physicalPlan,
+    // because the SLIMIT clause takes effect before the physicalPlan is finally generated.
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/query/executor/GroupByEngineDataSetTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/executor/GroupByEngineDataSetTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.query.executor;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.db.query.dataset.groupby.GroupByEngineDataSet;
@@ -29,19 +30,20 @@ import org.junit.Test;
 public class GroupByEngineDataSetTest {
 
   @Test
-  public void test1() {
+  public void test1() throws IOException {
     long jobId = 1000L;
     long unit = 20;
     long startTimePoint = 810;
     List<Pair<Long, Long>> pairList = new ArrayList<>();
-    pairList.add(new Pair<>(805L,811L));
-    pairList.add(new Pair<>(825L,849L));
+    pairList.add(new Pair<>(805L, 811L));
+    pairList.add(new Pair<>(825L, 849L));
 
     long[] startTimeArray = {805, 810, 830};
     long[] endTimeArray = {810, 830, 850};
-    GroupByEngineDataSet groupByEngine = new GroupByWithValueFilterDataSet(jobId, null, unit, startTimePoint, pairList);
+    GroupByEngineDataSet groupByEngine = new GroupByWithValueFilterDataSet(jobId, null, unit,
+        startTimePoint, pairList);
     int cnt = 0;
-    while (groupByEngine.hasNext()){
+    while (groupByEngine.hasNext()) {
       Pair pair = groupByEngine.nextTimePartition();
       Assert.assertTrue(cnt < startTimeArray.length);
       Assert.assertEquals(startTimeArray[cnt], pair.left);
@@ -52,21 +54,22 @@ public class GroupByEngineDataSetTest {
   }
 
   @Test
-  public void test2() {
+  public void test2() throws IOException {
     long jobId = 1000L;
     long unit = 20;
     long startTimePoint = 850;
     List<Pair<Long, Long>> pairList = new ArrayList<>();
-    pairList.add(new Pair<>(805L,835L));
-    pairList.add(new Pair<>(850L,855L));
-    pairList.add(new Pair<>(858L,860L));
-    pairList.add(new Pair<>(1200L,1220L));
+    pairList.add(new Pair<>(805L, 835L));
+    pairList.add(new Pair<>(850L, 855L));
+    pairList.add(new Pair<>(858L, 860L));
+    pairList.add(new Pair<>(1200L, 1220L));
 
     long[] startTimeArray = {805, 810, 830, 850, 1200, 1210};
     long[] endTimeArray = {810, 830, 850, 870, 1210, 1230};
-    GroupByEngineDataSet groupByEngine = new GroupByWithValueFilterDataSet(jobId, null, unit, startTimePoint, pairList);
+    GroupByEngineDataSet groupByEngine = new GroupByWithValueFilterDataSet(jobId, null, unit,
+        startTimePoint, pairList);
     int cnt = 0;
-    while (groupByEngine.hasNext()){
+    while (groupByEngine.hasNext()) {
       Pair pair = groupByEngine.nextTimePartition();
       Assert.assertTrue(cnt < startTimeArray.length);
       Assert.assertEquals(startTimeArray[cnt], pair.left);
@@ -77,21 +80,22 @@ public class GroupByEngineDataSetTest {
   }
 
   @Test
-  public void test3() {
+  public void test3() throws IOException {
     long jobId = 1000L;
     long unit = 20;
     long startTimePoint = 100;
     List<Pair<Long, Long>> pairList = new ArrayList<>();
-    pairList.add(new Pair<>(805L,835L));
-    pairList.add(new Pair<>(850L,855L));
-    pairList.add(new Pair<>(858L,860L));
-    pairList.add(new Pair<>(1200L,1220L));
+    pairList.add(new Pair<>(805L, 835L));
+    pairList.add(new Pair<>(850L, 855L));
+    pairList.add(new Pair<>(858L, 860L));
+    pairList.add(new Pair<>(1200L, 1220L));
 
     long[] startTimeArray = {805, 820, 850, 860, 1200, 1220};
     long[] endTimeArray = {820, 840, 860, 880, 1220, 1240};
-    GroupByEngineDataSet groupByEngine = new GroupByWithValueFilterDataSet(jobId, null, unit, startTimePoint, pairList);
+    GroupByEngineDataSet groupByEngine = new GroupByWithValueFilterDataSet(jobId, null, unit,
+        startTimePoint, pairList);
     int cnt = 0;
-    while (groupByEngine.hasNext()){
+    while (groupByEngine.hasNext()) {
       Pair pair = groupByEngine.nextTimePartition();
       Assert.assertTrue(cnt < startTimeArray.length);
       Assert.assertEquals(startTimeArray[cnt], pair.left);
@@ -102,21 +106,22 @@ public class GroupByEngineDataSetTest {
   }
 
   @Test
-  public void test4() {
+  public void test4() throws IOException {
     long jobId = 1000L;
     long unit = 200;
     long startTimePoint = 100;
     List<Pair<Long, Long>> pairList = new ArrayList<>();
-    pairList.add(new Pair<>(805L,835L));
-    pairList.add(new Pair<>(850L,855L));
-    pairList.add(new Pair<>(858L,860L));
-    pairList.add(new Pair<>(1200L,1220L));
+    pairList.add(new Pair<>(805L, 835L));
+    pairList.add(new Pair<>(850L, 855L));
+    pairList.add(new Pair<>(858L, 860L));
+    pairList.add(new Pair<>(1200L, 1220L));
 
     long[] startTimeArray = {805, 1200};
     long[] endTimeArray = {900, 1300};
-    GroupByEngineDataSet groupByEngine = new GroupByWithValueFilterDataSet(jobId, null, unit, startTimePoint, pairList);
+    GroupByEngineDataSet groupByEngine = new GroupByWithValueFilterDataSet(jobId, null, unit,
+        startTimePoint, pairList);
     int cnt = 0;
-    while (groupByEngine.hasNext()){
+    while (groupByEngine.hasNext()) {
       Pair pair = groupByEngine.nextTimePartition();
       Assert.assertTrue(cnt < startTimeArray.length);
       Assert.assertEquals(startTimeArray[cnt], pair.left);
@@ -126,22 +131,23 @@ public class GroupByEngineDataSetTest {
     Assert.assertEquals(startTimeArray.length, cnt);
   }
 
-//(80ms, 30,[50,100], [585,590], [615, 650])
+  //(80ms, 30,[50,100], [585,590], [615, 650])
   @Test
-  public void test5() {
+  public void test5() throws IOException {
     long jobId = 1000L;
     long unit = 80;
     long startTimePoint = 30;
     List<Pair<Long, Long>> pairList = new ArrayList<>();
-    pairList.add(new Pair<>(50L,100L));
-    pairList.add(new Pair<>(585L,590L));
-    pairList.add(new Pair<>(615L,650L));
+    pairList.add(new Pair<>(50L, 100L));
+    pairList.add(new Pair<>(585L, 590L));
+    pairList.add(new Pair<>(615L, 650L));
 
     long[] startTimeArray = {50, 585, 590};
     long[] endTimeArray = {110, 590, 670};
-    GroupByEngineDataSet groupByEngine = new GroupByWithValueFilterDataSet(jobId, null, unit, startTimePoint, pairList);
+    GroupByEngineDataSet groupByEngine = new GroupByWithValueFilterDataSet(jobId, null, unit,
+        startTimePoint, pairList);
     int cnt = 0;
-    while (groupByEngine.hasNext()){
+    while (groupByEngine.hasNext()) {
       Pair pair = groupByEngine.nextTimePartition();
       Assert.assertTrue(cnt < startTimeArray.length);
       Assert.assertEquals(startTimeArray[cnt], pair.left);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/DataSetWithTimeGenerator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/DataSetWithTimeGenerator.java
@@ -20,7 +20,6 @@ package org.apache.iotdb.tsfile.read.query.dataset;
 
 import java.io.IOException;
 import java.util.List;
-
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.common.RowRecord;
@@ -56,12 +55,12 @@ public class DataSetWithTimeGenerator extends QueryDataSet {
   }
 
   @Override
-  public boolean hasNext() throws IOException {
+  protected boolean hasNextWithoutConstraint() throws IOException {
     return timeGenerator.hasNext();
   }
 
   @Override
-  public RowRecord next() throws IOException {
+  protected RowRecord nextWithoutConstraint() throws IOException {
     long timestamp = timeGenerator.next();
     RowRecord rowRecord = new RowRecord(timestamp);
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/DataSetWithoutTimeGenerator.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/query/dataset/DataSetWithoutTimeGenerator.java
@@ -91,12 +91,12 @@ public class DataSetWithoutTimeGenerator extends QueryDataSet {
   }
 
   @Override
-  public boolean hasNext() {
+  protected boolean hasNextWithoutConstraint() {
     return timeHeap.size() > 0;
   }
 
   @Override
-  public RowRecord next() throws IOException {
+  protected RowRecord nextWithoutConstraint() throws IOException {
     long minTime = timeHeapGet();
 
     RowRecord record = new RowRecord(minTime);


### PR DESCRIPTION
Moving LIMIT&OFFSET to the server side has two benefits :-)
1. reduces the size of the result data transferred between the server and the client. In the old code, the server returns the result data starting at the first row to the client, and leaves the boring work of iterating to the OFFSET row to the client.
2. makes the code of jdbc easier to understand.


To achieve the benefits, changes in this pr include:
- The server side:
  - sql->logicalPlan->physicalPlan
    - Antlr4 doesn't need changing
    - parse LIMIT&OFFSET parameters and save them in logicalPlan (Note that SLIMIT&SOFFSET parameters are also saved in logicalOperator. SLIMIT&SOFFSET take effect in the optimization of logicalPlan or in the generation of physicalPlan from logicalPlan.)
    - pass LIMIT&OFFSET parameters from logicalPlan to physicalPlan
  - physicalPlan->QueryDataSet
    - pass LIMIT&OFFSET parameters from physicalPlan to QueryDataSet
  - QueryDataSet->fetch data
    - modify QueryDataSet's `hasNext` and `next` methods to make LIMIT&OFFSET take effect
- The client side:
  - remove the old LIMIT&OFFSET logic in the IoTDBQueryResultSet's `hasNext` and `next` methods
  - remove the  support of IoTDBStatement's `setMaxRows` and `getMaxRows` methods for the clarity and ease of maintenance of code.