### PR TITLE
[IOTDB-287] Allow anything in a JDBC URL.

### DIFF
--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
@@ -51,31 +51,17 @@ public class Utils {
       return params;
     }
     boolean isUrlLegal = false;
-    Pattern pattern = Pattern.compile("^"
-        + "(((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}" // Domain name
-        + "|"
-        + "localhost" // localhost
-        + "|"
-        + "(([0-9]{1,3}\\.){3})[0-9]{1,3})" // Ip
-        + ":"
-        + "[0-9]{1,5}" // Port
-        + "/?$");
+    Pattern pattern = Pattern.compile("([^:]+):([0-9]{1,5})/?");
     String subURL = url.substring(Config.IOTDB_URL_PREFIX.length());
     Matcher matcher = pattern.matcher(subURL);
     if(matcher.matches()) {
       isUrlLegal = true;
     }
-    String[] DomainAndPort;
-    if(subURL.contains("/")) {
-      DomainAndPort = subURL.substring(0, subURL.length()-1).split(":");
-    } else {
-      DomainAndPort = subURL.split(":");
-    }
-    params.setHost(DomainAndPort[0]);
-    params.setPort(Integer.parseInt(DomainAndPort[1]));
     if (!isUrlLegal) {
-      throw new IoTDBURLException("Error url format, url should be jdbc:iotdb://domain|ip:port/ or jdbc:iotdb://domain|ip:port");
+      throw new IoTDBURLException("Error url format, url should be jdbc:iotdb://anything:port/ or jdbc:iotdb://anything:port");
     }
+    params.setHost(matcher.group(1));
+    params.setPort(Integer.parseInt(matcher.group(2)));
 
     if (info.containsKey(Config.AUTH_USER)) {
       params.setUsername(info.getProperty(Config.AUTH_USER));

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
@@ -78,9 +78,15 @@ public class UtilsTest {
   }
 
   @Test(expected = IoTDBURLException.class)
-  public void testParseWrongUrl() throws IoTDBURLException {
+  public void testParseWrongUrl1() throws IoTDBURLException {
     Properties properties = new Properties();
     Utils.parseUrl("jdbc:iotdb//test6667", properties);
+  }
+
+  @Test(expected = IoTDBURLException.class)
+  public void testParseWrongUrl2() throws IoTDBURLException {
+    Properties properties = new Properties();
+    Utils.parseUrl("jdbc:iotdb//test:test:test:6667:6667", properties);
   }
 
   @Test(expected = IoTDBURLException.class)

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
@@ -70,60 +70,11 @@ public class UtilsTest {
     assertEquals(params.getUsername(), userName);
     assertEquals(params.getPassword(), userPwd);
 
-    //don't contain / in the end of url
-    params = Utils.parseUrl(String.format(Config.IOTDB_URL_PREFIX + "%s:%s", host1, port),
-            properties);
+    params = Utils.parseUrl(String.format(Config.IOTDB_URL_PREFIX + "%s:%s", host1, port), properties);
     assertEquals(params.getHost(), host1);
     assertEquals(params.getPort(), port);
-
-    //use a domain
-    String host2 = "google.com";
-    params = Utils.parseUrl(String.format(Config.IOTDB_URL_PREFIX + "%s:%s", host2, port),
-        properties);
-    assertEquals(params.getHost(), host2);
-    assertEquals(params.getPort(), port);
-
-    //use a different domain
-    String host3 = "www.google.com";
-    params = Utils.parseUrl(String.format(Config.IOTDB_URL_PREFIX + "%s:%s", host3, port),
-        properties);
-    assertEquals(params.getHost(), host3);
-    assertEquals(params.getPort(), port);
-
-    //use a ip
-    String host4 = "1.2.3.4";
-    params = Utils.parseUrl(String.format(Config.IOTDB_URL_PREFIX + "%s:%s", host4, port),
-        properties);
-    assertEquals(params.getHost(), host4);
-    assertEquals(params.getPort(), port);
-  }
-
-  @Test(expected = NumberFormatException.class)
-  public void testParseWrongDomain() throws IoTDBURLException {
-    String userName = "test";
-    String userPwd = "test";
-    String host = "www.::google.com";
-    int port = 6667;
-    Properties properties = new Properties();
-    properties.setProperty(Config.AUTH_USER, userName);
-    properties.setProperty(Config.AUTH_PASSWORD, userPwd);
-    IoTDBConnectionParams params = Utils
-        .parseUrl(String.format(Config.IOTDB_URL_PREFIX + "%s:%s/", host, port),
-            properties);
-  }
-
-  @Test(expected = IoTDBURLException.class)
-  public void testParseWrongIP() throws IoTDBURLException {
-    String userName = "test";
-    String userPwd = "test";
-    String host = "1.2.3.";
-    int port = 6667;
-    Properties properties = new Properties();
-    properties.setProperty(Config.AUTH_USER, userName);
-    properties.setProperty(Config.AUTH_PASSWORD, userPwd);
-    IoTDBConnectionParams params = Utils
-        .parseUrl(String.format(Config.IOTDB_URL_PREFIX + "%s:%s/", host, port),
-            properties);
+    assertEquals(params.getUsername(), userName);
+    assertEquals(params.getPassword(), userPwd);
   }
 
   @Test(expected = IoTDBURLException.class)

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
@@ -78,6 +78,12 @@ public class UtilsTest {
   }
 
   @Test(expected = IoTDBURLException.class)
+  public void testParseWrongUrl() throws IoTDBURLException {
+    Properties properties = new Properties();
+    Utils.parseUrl("jdbc:iotdb//test6667", properties);
+  }
+
+  @Test(expected = IoTDBURLException.class)
   public void testParseWrongPort() throws IoTDBURLException {
     String userName = "test";
     String userPwd = "test";


### PR DESCRIPTION
In this [pr](https://github.com/apache/incubator-iotdb/pull/514l), it restricts users to only use domain names and IP addresses. Obviously, this makes users can’t use a custom domain name like `master`. Now, you can use a JDBC URL like `jdbc:iotdb://anything:port/ or jdbc:iotdb://anything:port`.