### PR TITLE
[IOTDB-341]Fix data type bug in grafana

### DIFF
--- a/grafana/src/main/java/org/apache/iotdb/web/grafana/dao/impl/BasicDaoImpl.java
+++ b/grafana/src/main/java/org/apache/iotdb/web/grafana/dao/impl/BasicDaoImpl.java
@@ -142,8 +142,9 @@ public class BasicDaoImpl implements BasicDao {
           tv.setValue(0);
         } else {
           try {
-            tv.setValue(resultSet.getFloat(columnName));
+            tv.setValue(Float.parseFloat(resultSet.getString(columnName)));
           } catch (Exception e) {
+            logger.error("Can not parse the value {}", resultSet.getString(columnName));
             tv.setValue(0);
           }
         }


### PR DESCRIPTION
When using grafana, it's unable to show the data correctly unless the type of data is Float. The data will always be 0.

The jira link: https://issues.apache.org/jira/browse/IOTDB-337