### PR TITLE
Add antlr error listener.

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/QueryProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/QueryProcessor.java
@@ -18,9 +18,10 @@
  */
 package org.apache.iotdb.db.qp;
 
+import java.time.ZoneId;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.LogicalOperatorException;
 import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
@@ -35,8 +36,6 @@ import org.apache.iotdb.db.qp.strategy.optimizer.ConcatPathOptimizer;
 import org.apache.iotdb.db.qp.strategy.optimizer.DnfFilterOptimizer;
 import org.apache.iotdb.db.qp.strategy.optimizer.MergeSingleFilterOptimizer;
 import org.apache.iotdb.db.qp.strategy.optimizer.RemoveNotOptimizer;
-
-import java.time.ZoneId;
 
 /**
  * provide a integration method for other user.
@@ -56,13 +55,13 @@ public class QueryProcessor {
   }
 
   public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr)
-      throws QueryProcessException, MetadataException {
+      throws QueryProcessException, ParseCancellationException{
     IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
     return parseSQLToPhysicalPlan(sqlStr, config.getZoneID());
   }
 
   public PhysicalPlan parseSQLToPhysicalPlan(String sqlStr, ZoneId zoneId)
-      throws QueryProcessException {
+      throws QueryProcessException, ParseCancellationException {
     Operator operator = parseDriver.parse(sqlStr, zoneId);
     operator = logicalOptimize(operator, executor);
     PhysicalGenerator physicalGenerator = new PhysicalGenerator(executor);

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGeneratorError.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGeneratorError.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.qp.strategy;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+
+public class LogicalGeneratorError extends BaseErrorListener {
+
+  public static final LogicalGeneratorError INSTANCE = new LogicalGeneratorError();
+
+  @Override
+  public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
+    throw new ParseCancellationException("line " + line + ":" + charPositionInLine + " " + msg);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/ParseDriver.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/ParseDriver.java
@@ -19,7 +19,6 @@
 package org.apache.iotdb.db.qp.strategy;
 
 import java.time.ZoneId;
-import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.service;
 
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.iotdb.db.auth.AuthException;
 import org.apache.iotdb.db.auth.AuthorityChecker;
 import org.apache.iotdb.db.auth.authorizer.IAuthorizer;
@@ -572,7 +573,11 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       } else {
         return executeUpdateStatement(physicalPlan);
       }
-    } catch (SQLParserException e) {
+    } catch (ParseCancellationException e) {
+      logger.debug(e.getMessage());
+      return getTSExecuteStatementResp(getStatus(TSStatusCode.SQL_PARSE_ERROR, e.getMessage()));
+    }
+      catch (SQLParserException e) {
       logger.error("check metadata error: ", e);
       return getTSExecuteStatementResp(getStatus(TSStatusCode.METADATA_ERROR,
           "Check metadata error: " + e.getMessage()));

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -574,11 +574,9 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         return executeUpdateStatement(physicalPlan);
       }
     } catch (ParseCancellationException e) {
-      logger.debug("sql syntax error: ", e);
-      return getTSExecuteStatementResp(getStatus(TSStatusCode.SQL_PARSE_ERROR,
-          "Sql syntax error: " + e.getMessage()));
-    }
-      catch (SQLParserException e) {
+      logger.debug(e.getMessage());
+      return getTSExecuteStatementResp(getStatus(TSStatusCode.SQL_PARSE_ERROR, e.getMessage()));
+    } catch (SQLParserException e) {
       logger.error("check metadata error: ", e);
       return getTSExecuteStatementResp(getStatus(TSStatusCode.METADATA_ERROR,
           "Check metadata error: " + e.getMessage()));

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -574,8 +574,9 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         return executeUpdateStatement(physicalPlan);
       }
     } catch (ParseCancellationException e) {
-      logger.debug(e.getMessage());
-      return getTSExecuteStatementResp(getStatus(TSStatusCode.SQL_PARSE_ERROR, e.getMessage()));
+      logger.debug("sql syntax error: ", e);
+      return getTSExecuteStatementResp(getStatus(TSStatusCode.SQL_PARSE_ERROR,
+          "Sql syntax error: " + e.getMessage()));
     }
       catch (SQLParserException e) {
       logger.error("check metadata error: ", e);

--- a/server/src/test/java/org/apache/iotdb/db/qp/QueryProcessorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/QueryProcessorTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iotdb.db.qp;
 
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.qp.executor.QueryProcessExecutor;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
@@ -135,6 +137,11 @@ public class QueryProcessorTest {
     String fillStatement = "select sensor1 from root.vehicle.device1 where time = 50 Fill(int32[linear, 5m, 5m], boolean[previous, 5m])";
     PhysicalPlan plan10 = processor.parseSQLToPhysicalPlan(fillStatement);
     assertEquals(OperatorType.FILL, plan10.getOperatorType());
+  }
 
+  @Test(expected = ParseCancellationException.class)
+  public void parseErrorSQLToPhysicalPlan() throws QueryProcessException {
+    String createTSStatement = "create timeseriess root.vehicle.d1.s1 with datatype=INT32,encoding=RLE";
+    processor.parseSQLToPhysicalPlan(createTSStatement);
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/QPUpdateTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/QPUpdateTest.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.qp.plan;
 import static org.apache.iotdb.db.utils.EnvironmentUtils.TEST_QUERY_CONTEXT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -91,14 +92,14 @@ public class QPUpdateTest {
     String sql = "UPDATE root.laptop SET d1.s1 = -33000, d2.s1 = 'string' WHERE time < 100";
     try {
       plan = processor.parseSQLToPhysicalPlan(sql);
-    } catch (QueryProcessException | MetadataException e) {
+    } catch (QueryProcessException e) {
       assertEquals("UPDATE clause doesn't support multi-update yet.", e.getMessage());
     }
     sql = "UPDATE root.laptop SET d1.s1 = -33000 WHERE time < 100";
     try {
       plan = processor.parseSQLToPhysicalPlan(sql);
-    } catch (QueryProcessException | MetadataException e) {
-      assertTrue(false);
+    } catch (QueryProcessException e) {
+      fail();
     }
     assertEquals("UpdatePlan:  paths:  root.laptop.d1.s1\n" + "  value:-33000\n" + "  filter: \n"
             + "    199\n",


### PR DESCRIPTION
Add an antlr4 error listener. Display syntax error information in a client.

```
IoTDB> insert into root.ln.wf02.wt02(timestamp,status) value(1,true)
insert into root.ln.wf02.wt02(timestamp,status) value(1,true)
Msg: line 1:48 mismatched input 'value' expecting VALUES
It costs 0.445s
```