### PR TITLE
[IOTDB-357]Fix NullPointerException in tsfile recover performer

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -120,7 +120,6 @@ public class IoTDB implements IoTDBMBean {
   private void initMManager(){
     MManager.getInstance().init();
     IoTDBConfigDynamicAdapter.getInstance().setInitialized(true);
-    logger.debug("After initializing, ");
     logger.debug(
         "After initializing, max memTable num is {}, tsFile threshold is {}, memtableSize is {}",
         IoTDBDescriptor.getInstance().getConfig().getMaxMemtableNumber(),

--- a/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
@@ -50,8 +50,7 @@ import org.slf4j.LoggerFactory;
  * TsFileRecoverPerformer recovers a SeqTsFile to correct status, redoes the WALs since last crash
  * and removes the redone logs.
  */
-public class
-TsFileRecoverPerformer {
+public class TsFileRecoverPerformer {
 
   private static final Logger logger = LoggerFactory.getLogger(TsFileRecoverPerformer.class);
 
@@ -208,8 +207,7 @@ TsFileRecoverPerformer {
         // flush logs
 
         MemTableFlushTask tableFlushTask = new MemTableFlushTask(recoverMemTable, schema,
-            restorableTsFileIOWriter,
-            logNodePrefix);
+            restorableTsFileIOWriter, tsFileResource.getFile().getParentFile().getName());
         tableFlushTask.syncFlushMemTable();
       }
       // close file


### PR DESCRIPTION
This pr is to fix the hidden bug in method `redoLogs()` of class `TsFileRecoverPerformer`.
The jira link: https://issues.apache.org/jira/browse/IOTDB-357