### PR TITLE
[IOTDB-363] Correct the doc link error for `Development-Contributing.…

### DIFF
--- a/docs/Development-Contributing.md
+++ b/docs/Development-Contributing.md
@@ -81,7 +81,7 @@ Changes to IoTDB source codes are made through Github pull request. Anyone can r
 
 ### Contributing by Documentation Changes
 
-To propose a change to release documentation (that is, docs that appear under <https://iotdb.apache.org/#/Documents>), edit the Markdown source files in IoTDB’s docs/ directory(`documentation-EN` branch). The process to propose a doc change is otherwise the same as the process for proposing code changes below.  
+To propose a change to release documentation (that is, docs that appear under <https://iotdb.apache.org/#/Documents/progress/chap1/sec1>), edit the Markdown source files in IoTDB’s docs/ directory(`documentation-EN` branch). The process to propose a doc change is otherwise the same as the process for proposing code changes below.  
 
 Whenever updating **User Guide** documents, remember to update `0-Content.md` at the same time. Here are two brief examples to show how to add new documents or how to modify existing documents:
 

--- a/docs/Development-Document.md
+++ b/docs/Development-Document.md
@@ -31,7 +31,7 @@ Documents of Apache IoTDB (incubating) are open source. If you have found any mi
 
 ### Documentation Changes
 
-To propose a change to release documentation (that is, docs that appear under <https://iotdb.apache.org/#/Documents>), edit the Markdown source files in IoTDB’s docs/ directory(`documentation-EN` branch). The process to propose a doc change is otherwise the same as the process for proposing code changes below.  
+To propose a change to release documentation (that is, docs that appear under <https://iotdb.apache.org/#/Documents/progress/chap1/sec1>), edit the Markdown source files in IoTDB’s docs/ directory(`documentation-EN` branch). The process to propose a doc change is otherwise the same as the process for proposing code changes below.  
 
 Whenever updating **User Guide** documents, remember to update `0-Content.md` at the same time. Here are two brief examples to show how to add new documents or how to modify existing documents:
 


### PR DESCRIPTION
Currently, the link https://iotdb.apache.org/#/Documents of docs in https://iotdb.apache.org/#/Development/Contributing

is incorrect, I think we should correct it as follows:

1) https://iotdb.apache.org/#/Documents -> https://iotdb.apache.org/#/Documents/progress/chap1/sec1

or

2) https://iotdb.apache.org/#/Documents -> https://iotdb.apache.org/#/Documents/0.9.0/chap1/sec1

I prefer to `https://iotdb.apache.org/#/Documents/progress/chap1/sec1`

What do you think?