### PR TITLE
[IOTDB-364] Add IoTDBDataDirViewer Tool

### DIFF
--- a/docs/Documentation-CHN/UserGuide/8-System Design (Developer)/1-Hierarchy.md
+++ b/docs/Documentation-CHN/UserGuide/8-System Design (Developer)/1-Hierarchy.md
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
+    
         http://www.apache.org/licenses/LICENSE-2.0
-
+    
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -87,15 +87,15 @@ TsFile文件的内容可以划分为两个部分: 数据和元数据。数据和
 
 ##### ChunkHeader
 
-|成员|类型|
-|:---:|:---:|
-|传感器名称(measurementID)|String|
-|chunk大小(dataSize)|int|
-|chunk的数据类型(dataType)|short|
-|包含的page数量(numOfPages)|int|
-|压缩类型(compressionType)|short|
-|编码类型(encodingType)|short|
-|Max Tombstone Time(暂时没用)|long|
+|             成员             |  类型  |
+| :--------------------------: | :----: |
+|  传感器名称(measurementID)   | String |
+|     chunk大小(dataSize)      |  int   |
+|  chunk的数据类型(dataType)   | short  |
+|  包含的page数量(numOfPages)  |  int   |
+|  压缩类型(compressionType)   | short  |
+|    编码类型(encodingType)    | short  |
+| Max Tombstone Time(暂时没用) |  long  |
 
 ##### Page
 
@@ -103,26 +103,26 @@ TsFile文件的内容可以划分为两个部分: 数据和元数据。数据和
 
 PageHeader 结构
 
-|成员|类型|
-|:---:|:---:|
-|压缩前数据大小(uncompressedSize)|int|
-|SNAPPY压缩后数据大小(compressedSize)|int|
-|包含的values的数量(numOfValues)|int|
-|最大时间戳(maxTimestamp)|long|
-|最小时间戳(minTimestamp)|long|
-|该页最大值(max)|Type of the page|
-|该页最小值(min)|Type of the page|
-|该页第一个值(first)|Type of the page|
-|该页值的和(sum)|double|
-|该页最后一个值(last)|Type of the page|
+|                 成员                 |       类型       |
+| :----------------------------------: | :--------------: |
+|   压缩前数据大小(uncompressedSize)   |       int        |
+| SNAPPY压缩后数据大小(compressedSize) |       int        |
+|   包含的values的数量(numOfValues)    |       int        |
+|       最大时间戳(maxTimestamp)       |       long       |
+|       最小时间戳(minTimestamp)       |       long       |
+|           该页最大值(max)            | Type of the page |
+|           该页最小值(min)            | Type of the page |
+|         该页第一个值(first)          | Type of the page |
+|           该页值的和(sum)            |      double      |
+|         该页最后一个值(last)         | Type of the page |
 
 ##### ChunkGroupFooter
 
-|成员|类型|
-|:---:|:---:|
-|设备Id(deviceID)|String|
-|ChunkGroup大小(dataSize)|long|
-|包含的chunks的数量(numberOfChunks)|int|
+|                成员                |  类型  |
+| :--------------------------------: | :----: |
+|          设备Id(deviceID)          | String |
+|      ChunkGroup大小(dataSize)      |  long  |
+| 包含的chunks的数量(numberOfChunks) |  int   |
 
 #### 1.2.3  元数据
 
@@ -130,35 +130,35 @@ PageHeader 结构
 
 第一部分的元数据是 `TsDeviceMetaData` 
 
-|成员|类型|
-|:---:|:---:|
-|开始时间(startTime)|long|
-|结束时间(endTime)|long|
-|包含的ChunkGroup的数量|int|
-|所有的ChunkGroupMetaData(chunkGroupMetadataList)|list|
+|                       成员                       | 类型 |
+| :----------------------------------------------: | :--: |
+|               开始时间(startTime)                | long |
+|                结束时间(endTime)                 | long |
+|              包含的ChunkGroup的数量              | int  |
+| 所有的ChunkGroupMetaData(chunkGroupMetadataList) | list |
 
 ###### ChunkGroupMetaData
 
-|成员|类型|
-|:---:|:---:|
-|设备Id(deviceID)|String|
-|在文件中ChunkGroup开始的偏移量(startOffsetOfChunkGroup)|long|
-|在文件中ChunkGroup结束的偏移量(endOffsetOfChunkGroup)|long|
-|版本(version)|long|
-|包含的ChunkMetaData的数量|int|
-|所有的ChunkMetaData(chunkMetaDataList)|list|
+|                          成员                           |  类型  |
+| :-----------------------------------------------------: | :----: |
+|                    设备Id(deviceID)                     | String |
+| 在文件中ChunkGroup开始的偏移量(startOffsetOfChunkGroup) |  long  |
+|  在文件中ChunkGroup结束的偏移量(endOffsetOfChunkGroup)  |  long  |
+|                      版本(version)                      |  long  |
+|                包含的ChunkMetaData的数量                |  int   |
+|         所有的ChunkMetaData(chunkMetaDataList)          |  list  |
 
 ###### ChunkMetaData
 
-|成员|类型|
-|:---:|:---:|
-|传感器名称(measurementUid)|String|
-|文件中ChunkHeader开始的偏移量(offsetOfChunkHeader)|long|
-|数据的总数(numOfPoints)|long|
-|开始时间(startTime)|long|
-|结束时间(endTime)|long|
-|数据类型(tsDataType)|short|
-|chunk的统计信息|TsDigest|
+|                        成员                        |   类型   |
+| :------------------------------------------------: | :------: |
+|             传感器名称(measurementUid)             |  String  |
+| 文件中ChunkHeader开始的偏移量(offsetOfChunkHeader) |   long   |
+|              数据的总数(numOfPoints)               |   long   |
+|                开始时间(startTime)                 |   long   |
+|                 结束时间(endTime)                  |   long   |
+|                数据类型(tsDataType)                |  short   |
+|                  chunk的统计信息                   | TsDigest |
 
 ###### TsDigest
 
@@ -177,6 +177,7 @@ Map<String, ByteBuffer> statistics = {
     "max_value" -> ByteBuffer of int value 99
 }
 ```
+
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/33376433/63765352-664a4280-c8fb-11e9-869e-859edf6d00bb.png">
 
 在 v0.9.0 版本中, 为了提高空间和时间的效率，存储的结构被修改为数组的形式。也就是 `ByteBuffer[] statistics`。用固定的位置代表某一个具体的统计信息, 在 StatisticType 中定义的顺序如下:
@@ -218,40 +219,41 @@ ByteBuffer[] statistics = [
 
 上节讲到的是 `TsDeviceMetadatas` 紧跟其后的数据是 `TsFileMetaData`。
 
-|成员|类型|
-|:---:|:---:|
-|包含的设备个数|int|
-|设备名称和设备元数据索引的键值对(deviceIndexMap)|String, TsDeviceMetadataIndex pair|
-|包含的传感器个数|int|
-|传感器名称和传感器元数据的键值对(measurementSchema)|String, MeasurementSchema pair|
-|水印标识|byte|
-|当标识为0x01时的水印信息(createdBy)|String|
-|包含的Chunk总数(totalChunkNum)|int|
-|失效的Chunk总数(invalidChunkNum)|int|
-|布隆过滤器序列化大小|int|
-|布隆过滤器所有数据|byte[Bloom filter size]|
-|布隆过滤器容量|int|
-|布隆过滤器容量包含的HashFunction数量|int|
+|                        成员                         |                类型                |
+| :-------------------------------------------------: | :--------------------------------: |
+|                   包含的设备个数                    |                int                 |
+|  设备名称和设备元数据索引的键值对(deviceIndexMap)   | String, TsDeviceMetadataIndex pair |
+|                  包含的传感器个数                   |                int                 |
+| 传感器名称和传感器元数据的键值对(measurementSchema) |   String, MeasurementSchema pair   |
+|                      水印标识                       |                byte                |
+|         当标识为0x01时的水印信息(createdBy)         |               String               |
+|           包含的Chunk总数(totalChunkNum)            |                int                 |
+|          失效的Chunk总数(invalidChunkNum)           |                int                 |
+|                布隆过滤器序列化大小                 |                int                 |
+|                 布隆过滤器所有数据                  |      byte[Bloom filter size]       |
+|                   布隆过滤器容量                    |                int                 |
+|        布隆过滤器容量包含的HashFunction数量         |                int                 |
 
 ###### TsDeviceMetadataIndex
 
-|成员|类型|
-|:---:|:---:|
-|设备名|String|
-|文件中TsDeviceMetaData的偏移量(offset)|long|
-|序列化后数据大小(len)|int|
-|存储的设备最小时间(startTime)|long|
-|存储的设备最大时间(endTime)|long|
+|                  成员                  |  类型  |
+| :------------------------------------: | :----: |
+|                 设备名                 | String |
+| 文件中TsDeviceMetaData的偏移量(offset) |  long  |
+|         序列化后数据大小(len)          |  int   |
+|     存储的设备最小时间(startTime)      |  long  |
+|      存储的设备最大时间(endTime)       |  long  |
 
 ###### MeasurementSchema
-|成员|类型|
-|:---:|:---:|
-|传感器名称(measurementId)|String|
-|数据类型(type)|short|
-|编码方式(encoding)|short|
-|压缩方式(compressor)|short|
-|附带参数的数量|int|
-|所有附带的参数(props)|String, String pair|
+
+|           成员            |        类型         |
+| :-----------------------: | :-----------------: |
+| 传感器名称(measurementId) |       String        |
+|      数据类型(type)       |        short        |
+|    编码方式(encoding)     |        short        |
+|   压缩方式(compressor)    |        short        |
+|      附带参数的数量       |         int         |
+|   所有附带的参数(props)   | String, String pair |
 
 如果附带的参数数量大于 0, 传感器的附带参数会以一个数组形式的 <String, String> 键值对存储。
 
@@ -263,35 +265,85 @@ ByteBuffer[] statistics = [
 
 
 #### 1.2.4 Magic String
+
 TsFile 是以6个字节的magic string (`TsFile`) 作为结束.
 
 
 恭喜您, 至此您已经完成了 TsFile 的探秘之旅，祝您玩儿的开心!
 
-### 1.3 工具集
+### 1.3 TsFile工具集
 
-#### 1.3.1 TsFileResource 打印工具
+#### 1.3.1 IoTDB Data Directory 快速概览工具
 
-该工具的启动脚本会在编译 server 之后生成至 `server\target\iotdb-server-0.10.0\tools` 目录中。
+该工具的启动脚本会在编译 server 之后生成至 `server\target\iotdb-server-0.10.0\tools\tsfileToolSet` 目录中。
+
+使用方式:
+
+For Windows:
+
+```
+.\print-iotdb-data-dir.bat <IoTDB数据文件夹路径，如果是多个文件夹用逗号分隔> (<输出结果的存储路径>) 
+```
+
+For Linux or MacOs:
+
+```
+./print-iotdb-data-dir.sh <IoTDB数据文件夹路径，如果是多个文件夹用逗号分隔> (<输出结果的存储路径>) 
+```
+
+在Windows系统中的示例:
+
+```
+D:\incubator-iotdb\server\target\iotdb-server-0.10.0-SNAPSHOT\tools\tsfileToolSet>.\print-iotdb-data-dir.bat D:\\data\data
+​````````````````````````
+Starting Printing the IoTDB Data Directory Overview
+​````````````````````````
+output save path:IoTDB_data_dir_overview.txt
+TsFile data dir num:1
+21:17:38.841 [main] WARN org.apache.iotdb.tsfile.common.conf.TSFileDescriptor - Failed to find config file iotdb-engine.properties at classpath, use default configuration
+|==============================================================
+|D:\\data\data
+|--sequence
+|  |--root.ln.wf01.wt01
+|  |  |--1575813520203-101-0.tsfile
+|  |  |--1575813520203-101-0.tsfile.resource
+|  |  |  |--device root.ln.wf01.wt01, start time 1 (1970-01-01T08:00:00.001+08:00[GMT+08:00]), end time 5 (1970-01-01T08:00:00.005+08:00[GMT+08:00])
+|  |  |--1575813520669-103-0.tsfile
+|  |  |--1575813520669-103-0.tsfile.resource
+|  |  |  |--device root.ln.wf01.wt01, start time 100 (1970-01-01T08:00:00.100+08:00[GMT+08:00]), end time 300 (1970-01-01T08:00:00.300+08:00[GMT+08:00])
+|  |  |--1575813521372-107-0.tsfile
+|  |  |--1575813521372-107-0.tsfile.resource
+|  |  |  |--device root.ln.wf01.wt01, start time 500 (1970-01-01T08:00:00.500+08:00[GMT+08:00]), end time 540 (1970-01-01T08:00:00.540+08:00[GMT+08:00])
+|--unsequence
+|  |--root.ln.wf01.wt01
+|  |  |--1575813521063-105-0.tsfile
+|  |  |--1575813521063-105-0.tsfile.resource
+|  |  |  |--device root.ln.wf01.wt01, start time 10 (1970-01-01T08:00:00.010+08:00[GMT+08:00]), end time 50 (1970-01-01T08:00:00.050+08:00[GMT+08:00])
+|==============================================================
+````````````````````````
+
+#### 1.3.2 TsFileResource 打印工具
+
+该工具的启动脚本会在编译 server 之后生成至 `server\target\iotdb-server-0.10.0\tools\tsfileToolSet` 目录中。
 
 使用方式:
 
 Windows:
 
 ```
-.\print-tsfile-sketch.bat <TsFileResource 文件夹路径>
+.\print-tsfile-sketch.bat <TsFileResource文件夹路径>
 ```
 
 Linux or MacOs:
 
 ```
-./print-tsfile-sketch.sh <TsFileResource 文件夹路径>
+./print-tsfile-sketch.sh <TsFileResource文件夹路径>
 ```
 
 在Windows系统中的示例:
 
 ```
-D:\incubator-iotdb\server\target\iotdb-server-0.10.0\tools>.\print-tsfile-resource-files.bat D:\data\data\sequence\root.vehicle
+D:\incubator-iotdb\server\target\iotdb-server-0.10.0\tools\tsfileToolSet>.\print-tsfile-resource-files.bat D:\data\data\sequence\root.vehicle
 ​````````````````````````
 Starting Printing the TsFileResources
 ​````````````````````````
@@ -299,18 +351,18 @@ Starting Printing the TsFileResources
 analyzing D:\data\data\sequence\root.vehicle\1572496142067-101-0.tsfile ...
 device root.vehicle.d0, start time 3000 (1970-01-01T08:00:03+08:00[GMT+08:00]), end time 100999 (1970-01-01T08:01:40.999+08:00[GMT+08:00])
 analyzing the resource file finished.
-```
+````````````````````````
 
-#### 1.3.2 TsFile 描述工具
+#### 1.3.3 TsFile 描述工具
 
-该工具的启动脚本会在编译 server 之后生成至 `server\target\iotdb-server-0.10.0\tools` 目录中。
+该工具的启动脚本会在编译 server 之后生成至 `server\target\iotdb-server-0.10.0\tools\tsfileToolSet` 目录中。
 
 使用方式:
 
 Windows:
 
 ```
-.\print-tsfile-sketch.bat <TsFile文件路径> (<输出文件的存储路径>) 
+.\print-tsfile-sketch.bat <TsFile文件路径> (<输出结果的存储路径>) 
 ```
 
 - 注意: 如果没有设置输出文件的存储路径, 将使用 "TsFile_sketch_view.txt" 做为默认值。
@@ -318,7 +370,7 @@ Windows:
 Linux or MacOs:
 
 ```
-./print-tsfile-sketch.sh <TsFile文件路径> (<输出文件的存储路径>) 
+./print-tsfile-sketch.sh <TsFile文件路径> (<输出结果的存储路径>) 
 ```
 
 - 注意: 如果没有设置输出文件的存储路径, 将使用 "TsFile_sketch_view.txt" 做为默认值。 
@@ -326,7 +378,7 @@ Linux or MacOs:
 在Windows系统中的示例:
 
 ```$xslt
-D:\incubator-iotdb\server\target\iotdb-server-0.10.0\tools>.\print-tsfile-sketch.bat D:\data\data\sequence\root.vehicle\1572496142067-101-0.tsfile
+D:\incubator-iotdb\server\target\iotdb-server-0.10.0\tools\tsfileToolSet>.\print-tsfile-sketch.bat D:\data\data\sequence\root.vehicle\1572496142067-101-0.tsfile
 ​````````````````````````
 Starting Printing the TsFile Sketch
 ​````````````````````````
@@ -400,15 +452,18 @@ file length: 187382
               187382|   END of TsFile
 
 ---------------------------------- TsFile Sketch End ----------------------------------
-```
+````````````````````````
 
-#### 1.3.3 TsFileSequenceRead
+#### 1.3.4 TsFileSequenceRead
+
 您可以使用示例中的类 `example/tsfile/org/apache/iotdb/tsfile/TsFileSequenceRead` 顺序打印 TsFile 中的内容.
 
 ### 1.4 TsFile 的总览图
 
 #### v0.8.0
+
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/33376433/65209576-2bd36000-dacb-11e9-9e43-49e0dd01274e.png">
 
 #### v0.9.0
+
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/33376433/69341240-26012300-0ca4-11ea-91a1-d516810cad44.png">

--- a/docs/Documentation/UserGuide/8-System Design (Developer)/1-Hierarchy.md
+++ b/docs/Documentation/UserGuide/8-System Design (Developer)/1-Hierarchy.md
@@ -90,15 +90,15 @@ A `Chunk` represents a *sensor*. There is a byte `0x01` as the marker, following
 
 ##### ChunkHeader
 
-|Member Description|Member Type|
-|:---:|:---:|
-|The name of this sensor(measurementID)|String|
-|Size of this chunk|int|
-|Data type of this chuck|short|
-|Number of pages|int|
-|Compression Type|short|
-|Encoding Type|short|
-|Max Tombstone Time(unused)|long|
+|           Member Description           | Member Type |
+| :------------------------------------: | :---------: |
+| The name of this sensor(measurementID) |   String    |
+|           Size of this chunk           |     int     |
+|        Data type of this chuck         |    short    |
+|            Number of pages             |     int     |
+|            Compression Type            |    short    |
+|             Encoding Type              |    short    |
+|       Max Tombstone Time(unused)       |    long     |
 
 ##### Page
 
@@ -106,26 +106,26 @@ A `Page` represents some data in a `Chunk`. It contains a `PageHeader` and the a
 
 PageHeader Structure
 
-|Member Description|Member Type|
-|:---:|:---:|
-|Data size before compressing|int|
-|Data size after compressing(if use SNAPPY)|int|
-|Number of values|int|
-|Maximum time stamp|long|
-|Minimum time stamp|long|
-|Maximum value of the page|Type of the page|
-|Minimum value of the page|Type of the page|
-|First value of the page|Type of the page|
-|Sum of the Page|double|
-|Last value of the page|Type of the page|
+|             Member Description             |   Member Type    |
+| :----------------------------------------: | :--------------: |
+|        Data size before compressing        |       int        |
+| Data size after compressing(if use SNAPPY) |       int        |
+|              Number of values              |       int        |
+|             Maximum time stamp             |       long       |
+|             Minimum time stamp             |       long       |
+|         Maximum value of the page          | Type of the page |
+|         Minimum value of the page          | Type of the page |
+|          First value of the page           | Type of the page |
+|              Sum of the Page               |      double      |
+|           Last value of the page           | Type of the page |
 
 ##### ChunkGroupFooter
 
-|Member Description|Member Type|
-|:---:|:---:|
-|DeviceId|String|
-|Data size of the ChunkGroup|long|
-|Number of chunks|int|
+|     Member Description      | Member Type |
+| :-------------------------: | :---------: |
+|          DeviceId           |   String    |
+| Data size of the ChunkGroup |    long     |
+|      Number of chunks       |     int     |
 
 #### 1.2.3  Metadata
 
@@ -133,35 +133,35 @@ PageHeader Structure
 
 The first part of metadata is `TsDeviceMetaData` 
 
-|Member Description|Member Type|
-|:---:|:---:|
-|Start time|long|
-|End time|long|
-|Number of chunk groups|int|
-|List of ChunkGroupMetaData|list|
+|     Member Description     | Member Type |
+| :------------------------: | :---------: |
+|         Start time         |    long     |
+|          End time          |    long     |
+|   Number of chunk groups   |     int     |
+| List of ChunkGroupMetaData |    list     |
 
 ###### ChunkGroupMetaData
 
-|Member Description|Member Type|
-|:---:|:---:|
-|DeviceId|String|
-|Start offset of the ChunkGroup|long|
-|End offset of the ChunkGroup|long|
-|Version|long|
-|Number of ChunkMetaData|int|
-|List of ChunkMetaData|list|
+|       Member Description       | Member Type |
+| :----------------------------: | :---------: |
+|            DeviceId            |   String    |
+| Start offset of the ChunkGroup |    long     |
+|  End offset of the ChunkGroup  |    long     |
+|            Version             |    long     |
+|    Number of ChunkMetaData     |     int     |
+|     List of ChunkMetaData      |    list     |
 
 ###### ChunkMetaData
 
-|Member Description|Member Type|
-|:---:|:---:|
-|MeasurementId|String|
-|Start offset of ChunkHeader|long|
-|Number of data points|long|
-|Start time|long|
-|End time|long|
-|Data type|short|
-|The statistics of this chunk|TsDigest|
+|      Member Description      | Member Type |
+| :--------------------------: | :---------: |
+|        MeasurementId         |   String    |
+| Start offset of ChunkHeader  |    long     |
+|    Number of data points     |    long     |
+|          Start time          |    long     |
+|           End time           |    long     |
+|          Data type           |    short    |
+| The statistics of this chunk |  TsDigest   |
 
 ###### TsDigest
 
@@ -180,6 +180,7 @@ Map<String, ByteBuffer> statistics = {
     "max_value" -> ByteBuffer of int value 99
 }
 ```
+
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/33376433/63765352-664a4280-c8fb-11e9-869e-859edf6d00bb.png">
 
 In v0.9.0, the storage format is changed to an array for space and time efficiency. That is, `ByteBuffer[] statistics`. Each position of the array has a fixed association with a specific type of statistic, following the order defined in StatisticType:
@@ -218,39 +219,40 @@ ByteBuffer[] statistics = [
 
 `TsFileMetaData` follows after `TsDeviceMetadatas`.
 
-|Member Description|Member Type|
-|:---:|:---:|
-|Number of devices|int|
-|Pairs of device name and deviceMetadataIndex|String, TsDeviceMetadataIndex pair|
-|Number of measurements|int|
-|Pairs of measurement name and schema|String, MeasurementSchema pair|
-|Author byte|byte|
-|Author(if author byte is 0x01)|String|
-|totalChunkNum|int|
-|invalidChunkNum|int|
-|Bloom filter size|int|
-|Bloom filter bit vector|byte[Bloom filter size]|
-|Bloom filter capacity|int|
-|Bloom filter hash functions size|int|
+|              Member Description              |            Member Type             |
+| :------------------------------------------: | :--------------------------------: |
+|              Number of devices               |                int                 |
+| Pairs of device name and deviceMetadataIndex | String, TsDeviceMetadataIndex pair |
+|            Number of measurements            |                int                 |
+|     Pairs of measurement name and schema     |   String, MeasurementSchema pair   |
+|                 Author byte                  |                byte                |
+|        Author(if author byte is 0x01)        |               String               |
+|                totalChunkNum                 |                int                 |
+|               invalidChunkNum                |                int                 |
+|              Bloom filter size               |                int                 |
+|           Bloom filter bit vector            |      byte[Bloom filter size]       |
+|            Bloom filter capacity             |                int                 |
+|       Bloom filter hash functions size       |                int                 |
 
 ###### TsDeviceMetadataIndex
 
-|Member Description|Member Type|
-|:---:|:---:|
-|DeviceId|String|
-|Start offset of TsDeviceMetaData|long|
-|length|int|
-|Start time|long|
-|End time|long|
+|        Member Description        | Member Type |
+| :------------------------------: | :---------: |
+|             DeviceId             |   String    |
+| Start offset of TsDeviceMetaData |    long     |
+|              length              |     int     |
+|            Start time            |    long     |
+|             End time             |    long     |
 
 ###### MeasurementSchema
-|Member Description|Member Type|
-|:---:|:---:|
-|MeasurementId|String|
-|Data type|short|
-|Encoding|short|
-|Compressor|short|
-|Size of props|int|
+
+| Member Description | Member Type |
+| :----------------: | :---------: |
+|   MeasurementId    |   String    |
+|     Data type      |    short    |
+|      Encoding      |    short    |
+|     Compressor     |    short    |
+|   Size of props    |     int     |
 
 If size of props is greater than 0, there is an array of <String, String> pair as properties of this measurement.
 
@@ -262,35 +264,87 @@ After the TsFileMetaData, there is an int indicating the size of the TsFileMetaD
 
 
 #### 1.2.4 Magic String
+
 A TsFile ends with a 6-byte magic string (`TsFile`).
 
 
 Congratulations! You have finished the journey of discovering TsFile.
 
-### 1.3 Tool Set
+### 1.3 TsFile Tool Set
 
-#### 1.3.1 TsFileResource Print Tool
+#### 1.3.1 IoTDB Data Directory Overview Tool
 
-After building the server, the startup script of this tool will appear under the `server\target\iotdb-server-0.10.0\tools` directory.
+After building the server, the startup script of this tool will appear under the `server\target\iotdb-server-0.10.0\tools\tsfileToolSet` directory.
 
 Command:
 
 For Windows:
 
 ```
-.\print-tsfile-sketch.bat <path of your TsFileResource Directory>
+.\print-iotdb-data-dir.bat <path of your IoTDB data directory or directories separated by comma> (<path of the file for saving the output result>) 
 ```
 
 For Linux or MacOs:
 
 ```
-./print-tsfile-sketch.sh <path of your TsFileResource Directory>
+./print-iotdb-data-dir.sh <path of your IoTDB data directory or directories separated by comma> (<path of the file for saving the output result>) 
 ```
 
 An example on Windows:
 
 ```
-D:\incubator-iotdb\server\target\iotdb-server-0.10.0\tools>.\print-tsfile-resource-files.bat D:\data\data\sequence\root.vehicle
+D:\incubator-iotdb\server\target\iotdb-server-0.10.0-SNAPSHOT\tools\tsfileToolSet>.\print-iotdb-data-dir.bat D:\\data\data
+​````````````````````````
+Starting Printing the IoTDB Data Directory Overview
+​````````````````````````
+output save path:IoTDB_data_dir_overview.txt
+TsFile data dir num:1
+21:17:38.841 [main] WARN org.apache.iotdb.tsfile.common.conf.TSFileDescriptor - Failed to find config file iotdb-engine.properties at classpath, use default configuration
+|==============================================================
+|D:\\data\data
+|--sequence
+|  |--root.ln.wf01.wt01
+|  |  |--1575813520203-101-0.tsfile
+|  |  |--1575813520203-101-0.tsfile.resource
+|  |  |  |--device root.ln.wf01.wt01, start time 1 (1970-01-01T08:00:00.001+08:00[GMT+08:00]), end time 5 (1970-01-01T08:00:00.005+08:00[GMT+08:00])
+|  |  |--1575813520669-103-0.tsfile
+|  |  |--1575813520669-103-0.tsfile.resource
+|  |  |  |--device root.ln.wf01.wt01, start time 100 (1970-01-01T08:00:00.100+08:00[GMT+08:00]), end time 300 (1970-01-01T08:00:00.300+08:00[GMT+08:00])
+|  |  |--1575813521372-107-0.tsfile
+|  |  |--1575813521372-107-0.tsfile.resource
+|  |  |  |--device root.ln.wf01.wt01, start time 500 (1970-01-01T08:00:00.500+08:00[GMT+08:00]), end time 540 (1970-01-01T08:00:00.540+08:00[GMT+08:00])
+|--unsequence
+|  |--root.ln.wf01.wt01
+|  |  |--1575813521063-105-0.tsfile
+|  |  |--1575813521063-105-0.tsfile.resource
+|  |  |  |--device root.ln.wf01.wt01, start time 10 (1970-01-01T08:00:00.010+08:00[GMT+08:00]), end time 50 (1970-01-01T08:00:00.050+08:00[GMT+08:00])
+|==============================================================
+```
+
+
+
+#### 1.3.2 TsFileResource Print Tool
+
+After building the server, the startup script of this tool will appear under the `server\target\iotdb-server-0.10.0\tools\tsfileToolSet` directory.
+
+Command:
+
+For Windows:
+
+```
+.\print-tsfile-sketch.bat <path of your TsFileResource directory>
+```
+
+For Linux or MacOs:
+
+```
+./print-tsfile-sketch.sh <path of your TsFileResource directory>
+```
+
+An example on Windows:
+
+```
+D:\incubator-iotdb\server\target\iotdb-server-0.10.0\tools\tsfileToolSet>.\print-tsfile-resource-files.bat D:\data\data\sequence\root.vehicle
 ​````````````````````````
 Starting Printing the TsFileResources
 ​````````````````````````
@@ -298,11 +352,11 @@ Starting Printing the TsFileResources
 analyzing D:\data\data\sequence\root.vehicle\1572496142067-101-0.tsfile ...
 device root.vehicle.d0, start time 3000 (1970-01-01T08:00:03+08:00[GMT+08:00]), end time 100999 (1970-01-01T08:01:40.999+08:00[GMT+08:00])
 analyzing the resource file finished.
-```
+````````````````````````
 
-#### 1.3.2 TsFile Sketch Tool
+#### 1.3.3 TsFile Sketch Tool
 
-After building the server, the startup script of this tool will appear under the `server\target\iotdb-server-0.10.0\tools` directory.
+After building the server, the startup script of this tool will appear under the `server\target\iotdb-server-0.10.0\tools\tsfileToolSet` directory.
 
 Command:
 
@@ -325,7 +379,7 @@ For Linux or MacOs:
 An example on Windows:
 
 ```$xslt
-D:\incubator-iotdb\server\target\iotdb-server-0.10.0\tools>.\print-tsfile-sketch.bat D:\data\data\sequence\root.vehicle\1572496142067-101-0.tsfile
+D:\incubator-iotdb\server\target\iotdb-server-0.10.0\tools\tsfileToolSet>.\print-tsfile-sketch.bat D:\data\data\sequence\root.vehicle\1572496142067-101-0.tsfile
 ​````````````````````````
 Starting Printing the TsFile Sketch
 ​````````````````````````
@@ -399,15 +453,18 @@ file length: 187382
               187382|   END of TsFile
 
 ---------------------------------- TsFile Sketch End ----------------------------------
-```
+````````````````````````
 
-#### 1.3.3 TsFileSequenceRead
+#### 1.3.4 TsFileSequenceRead
+
 You can also use `example/tsfile/org/apache/iotdb/tsfile/TsFileSequenceRead` to sequentially print a TsFile's content.
 
 ### 1.4 A TsFile Visualization Example
 
 #### v0.8.0
+
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/33376433/65209576-2bd36000-dacb-11e9-9e43-49e0dd01274e.png">
 
 #### v0.9.0
+
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://user-images.githubusercontent.com/33376433/69341240-26012300-0ca4-11ea-91a1-d516810cad44.png">

--- a/server/src/assembly/resources/tools/tsfileToolSet/print-iotdb-data-dir.bat
+++ b/server/src/assembly/resources/tools/tsfileToolSet/print-iotdb-data-dir.bat
@@ -20,16 +20,16 @@
 
 @echo off
 echo ````````````````````````
-echo Starting Printing the TsFile Sketch
+echo Starting Printing the IoTDB Data Directory Overview
 echo ````````````````````````
 
 if "%OS%" == "Windows_NT" setlocal
 
-pushd %~dp0..
+pushd %~dp0..\..
 if NOT DEFINED IOTDB_HOME set IOTDB_HOME=%CD%
 popd
 
-if NOT DEFINED MAIN_CLASS set MAIN_CLASS=org.apache.iotdb.db.tools.TsFileSketchTool
+if NOT DEFINED MAIN_CLASS set MAIN_CLASS=org.apache.iotdb.db.tools.IoTDBDataDirViewer
 if NOT DEFINED JAVA_HOME goto :err
 
 @REM -----------------------------------------------------------------------------

--- a/server/src/assembly/resources/tools/tsfileToolSet/print-iotdb-data-dir.sh
+++ b/server/src/assembly/resources/tools/tsfileToolSet/print-iotdb-data-dir.sh
@@ -19,11 +19,11 @@
 #
 
 echo ---------------------
-echo Starting Printing the TsFile Sketch
+echo Starting Printing the IoTDB Data Directory Overview
 echo ---------------------
 
 if [ -z "${IOTDB_HOME}" ]; then
-  export IOTDB_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+  export IOTDB_HOME="$(cd "`dirname "$0"`"/../..; pwd)"
 fi
 
 if [ -n "$JAVA_HOME" ]; then
@@ -42,7 +42,7 @@ for f in ${IOTDB_HOME}/lib/*.jar; do
   CLASSPATH=${CLASSPATH}":"$f
 done
 
-MAIN_CLASS=org.apache.iotdb.db.tools.TsFileSketchTool
+MAIN_CLASS=org.apache.iotdb.db.tools.IoTDBDataDirViewer
 
 "$JAVA" -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
 exit $?

--- a/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-resource-files.bat
+++ b/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-resource-files.bat
@@ -24,7 +24,7 @@ echo ````````````````````````
 
 if "%OS%" == "Windows_NT" setlocal
 
-pushd %~dp0..
+pushd %~dp0..\..
 if NOT DEFINED IOTDB_HOME set IOTDB_HOME=%CD%
 popd
 

--- a/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-resource-files.sh
+++ b/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-resource-files.sh
@@ -24,7 +24,7 @@ echo Starting Printing the TsFileResources
 echo ---------------------
 
 if [ -z "${IOTDB_HOME}" ]; then
-  export IOTDB_HOME="`dirname "$0"`/.."
+  export IOTDB_HOME="`dirname "$0"`/../.."
 fi
 
 IOTDB_CONF=${IOTDB_HOME}/conf

--- a/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-sketch.bat
+++ b/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-sketch.bat
@@ -1,0 +1,64 @@
+@REM
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM
+
+
+@echo off
+echo ````````````````````````
+echo Starting Printing the TsFile Sketch
+echo ````````````````````````
+
+if "%OS%" == "Windows_NT" setlocal
+
+pushd %~dp0..\..
+if NOT DEFINED IOTDB_HOME set IOTDB_HOME=%CD%
+popd
+
+if NOT DEFINED MAIN_CLASS set MAIN_CLASS=org.apache.iotdb.db.tools.TsFileSketchTool
+if NOT DEFINED JAVA_HOME goto :err
+
+@REM -----------------------------------------------------------------------------
+@REM ***** CLASSPATH library setting *****
+@REM Ensure that any user defined CLASSPATH variables are not used on startup
+set CLASSPATH="%IOTDB_HOME%\lib"
+
+@REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
+for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
+goto okClasspath
+
+:append
+set CLASSPATH=%CLASSPATH%;%1
+goto :eof
+
+@REM -----------------------------------------------------------------------------
+:okClasspath
+
+"%JAVA_HOME%\bin\java" -cp "%CLASSPATH%" %MAIN_CLASS% %*
+
+goto finally
+
+
+:err
+echo JAVA_HOME environment variable must be set!
+pause
+
+
+@REM -----------------------------------------------------------------------------
+:finally
+
+ENDLOCAL

--- a/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-sketch.sh
+++ b/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-sketch.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+echo ---------------------
+echo Starting Printing the TsFile Sketch
+echo ---------------------
+
+if [ -z "${IOTDB_HOME}" ]; then
+  export IOTDB_HOME="$(cd "`dirname "$0"`"/../..; pwd)"
+fi
+
+if [ -n "$JAVA_HOME" ]; then
+    for java in "$JAVA_HOME"/bin/amd64/java "$JAVA_HOME"/bin/java; do
+        if [ -x "$java" ]; then
+            JAVA="$java"
+            break
+        fi
+    done
+else
+    JAVA=java
+fi
+
+CLASSPATH=""
+for f in ${IOTDB_HOME}/lib/*.jar; do
+  CLASSPATH=${CLASSPATH}":"$f
+done
+
+MAIN_CLASS=org.apache.iotdb.db.tools.TsFileSketchTool
+
+"$JAVA" -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
+exit $?

--- a/server/src/main/java/org/apache/iotdb/db/tools/IoTDBDataDirViewer.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/IoTDBDataDirViewer.java
@@ -1,0 +1,119 @@
+package org.apache.iotdb.db.tools;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
+import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
+import org.apache.iotdb.db.qp.constant.DatetimeUtils;
+import org.apache.iotdb.tsfile.fileSystem.FSFactoryProducer;
+
+public class IoTDBDataDirViewer {
+
+  public static void main(String[] args) throws IOException {
+    String[] data_dir;
+    String outFile = "IoTDB_data_dir_overview.txt";
+    if (args.length == 0) {
+      String path = "data/data";
+      data_dir = path.split(","); //multiple data dirs separated by comma
+    } else if (args.length == 1) {
+      data_dir = args[0].split(",");
+    } else if (args.length == 2) {
+      data_dir = args[0].split(",");
+      outFile = args[1];
+    } else {
+      throw new IOException("Invalid parameters. Please check the user guide.");
+    }
+    System.out.println("output save path:" + outFile);
+    System.out.println("data dir num:" + data_dir.length);
+    try (PrintWriter pw = new PrintWriter(new FileWriter(outFile))) {
+      for (String dir : data_dir) {
+        File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
+        File[] seqAndUnseqDirs = dirFile.listFiles();
+        if (seqAndUnseqDirs == null || seqAndUnseqDirs.length != 2) {
+          throw new IOException(
+              "Irregular data dir structure.There should be a sequence and unsequence directory "
+                  + "under the data directory " + dirFile.getName());
+        }
+        List<File> fileList = Arrays.asList(seqAndUnseqDirs);
+        fileList.sort(((o1, o2) -> o1.getName().compareTo(o2.getName())));
+        if (!seqAndUnseqDirs[0].getName().equals("sequence") || !seqAndUnseqDirs[1].getName()
+            .equals("unsequence")) {
+          throw new IOException(
+              "Irregular data dir structure.There should be a sequence and unsequence directory "
+                  + "under the data directory " + dirFile.getName());
+        }
+
+        printlnBoth(pw, "|==============================================================");
+        printlnBoth(pw, "|" + dir);
+        printlnBoth(pw, "|--sequence");
+        printFilesInSeqOrUnseqDir(seqAndUnseqDirs[0], pw);
+        printlnBoth(pw, "|--unsequence");
+        printFilesInSeqOrUnseqDir(seqAndUnseqDirs[1], pw);
+      }
+      printlnBoth(pw, "|==============================================================");
+    }
+  }
+
+  private static void printFilesInSeqOrUnseqDir(File seqOrUnseqDir, PrintWriter pw)
+      throws IOException {
+    File[] storageGroupDirs = seqOrUnseqDir.listFiles();
+    if (storageGroupDirs == null) {
+      throw new IOException(
+          "Irregular data dir structure.There should be storage group directories under "
+              + "the sequence/unsequence directory " + seqOrUnseqDir.getName());
+    }
+    List<File> fileList = Arrays.asList(storageGroupDirs);
+    fileList.sort(((o1, o2) -> o1.getName().compareTo(o2.getName())));
+    for (File storageGroup : storageGroupDirs) {
+      printlnBoth(pw, "|  |--" + storageGroup.getName());
+      printFilesInStorageGroupDir(storageGroup, pw);
+    }
+  }
+
+  private static void printFilesInStorageGroupDir(File storageGroup, PrintWriter pw)
+      throws IOException {
+    File[] files = storageGroup.listFiles();
+    if (files == null) {
+      throw new IOException(
+          "Irregular data dir structure.There should be tsfiles under "
+              + "the storage group directory " + storageGroup.getName());
+    }
+    List<File> fileList = Arrays.asList(files);
+    fileList.sort(((o1, o2) -> o1.getName().compareTo(o2.getName())));
+    for (File file : files) {
+      printlnBoth(pw, "|  |  |--" + file.getName());
+
+      // To print the content if it is a tsfile.resource
+      if (file.getName().endsWith(".tsfile.resource")) {
+        printResource(file.getAbsolutePath(), pw);
+      }
+    }
+  }
+
+  private static void printResource(String filename, PrintWriter pw) throws IOException {
+    filename = filename.substring(0, filename.length() - 9);
+    TsFileResource resource = new TsFileResource(SystemFileFactory.INSTANCE.getFile(filename));
+    resource.deSerialize();
+    // sort device strings
+    SortedSet<String> keys = new TreeSet<>(resource.getStartTimeMap().keySet());
+    for (String device : keys) {
+      printlnBoth(pw,
+          String.format("|  |  |  |--device %s, start time %d (%s), end time %d (%s)", device,
+              resource.getStartTimeMap().get(device), DatetimeUtils
+                  .convertMillsecondToZonedDateTime(resource.getStartTimeMap().get(device)),
+              resource.getEndTimeMap().get(device), DatetimeUtils
+                  .convertMillsecondToZonedDateTime(resource.getEndTimeMap().get(device))));
+    }
+  }
+
+  private static void printlnBoth(PrintWriter pw, String str) {
+    System.out.println(str);
+    pw.println(str);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
+++ b/server/src/main/java/org/apache/iotdb/db/tools/TsFileSketchTool.java
@@ -23,6 +23,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
@@ -50,161 +51,163 @@ public class TsFileSketchTool {
     }
     System.out.println("TsFile path:" + filename);
     System.out.println("Sketch save path:" + outFile);
-    PrintWriter pw = new PrintWriter(new FileWriter(outFile));
-    long length = FSFactoryProducer.getFSFactory().getFile(filename).length();
-    printlnBoth(pw,
-        "-------------------------------- TsFile Sketch --------------------------------");
-    printlnBoth(pw, "file path: " + filename);
-    printlnBoth(pw, "file length: " + length);
+    try (PrintWriter pw = new PrintWriter(new FileWriter(outFile))) {
+      long length = FSFactoryProducer.getFSFactory().getFile(filename).length();
+      printlnBoth(pw,
+          "-------------------------------- TsFile Sketch --------------------------------");
+      printlnBoth(pw, "file path: " + filename);
+      printlnBoth(pw, "file length: " + length);
 
-    // get metadata information
-    TsFileSequenceReader reader = new TsFileSequenceReader(filename);
-    TsFileMetaData tsFileMetaData = reader.readFileMetadata();
-    List<TsDeviceMetadataIndex> tsDeviceMetadataIndexSortedList = tsFileMetaData.getDeviceMap()
-        .values()
-        .stream()
-        .sorted((x, y) -> (int) (x.getOffset() - y.getOffset())).collect(Collectors.toList());
-    List<ChunkGroupMetaData> chunkGroupMetaDataTmpList = new ArrayList<>();
-    List<TsDeviceMetadata> tsDeviceMetadataSortedList = new ArrayList<>();
-    for (TsDeviceMetadataIndex index : tsDeviceMetadataIndexSortedList) {
-      TsDeviceMetadata deviceMetadata = reader.readTsDeviceMetaData(index);
-      tsDeviceMetadataSortedList.add(deviceMetadata);
-      chunkGroupMetaDataTmpList.addAll(deviceMetadata.getChunkGroupMetaDataList());
-    }
-    List<ChunkGroupMetaData> chunkGroupMetaDataSortedList = chunkGroupMetaDataTmpList.stream()
-        .sorted((x, y) -> (int) (x.getStartOffsetOfChunkGroup() - y.getStartOffsetOfChunkGroup()))
-        .collect(Collectors.toList());
-
-    // begin print
-    StringBuilder str1 = new StringBuilder();
-    for (int i = 0; i < 21; i++) {
-      str1.append("|");
-    }
-
-    printlnBoth(pw, "");
-    printlnBoth(pw, String.format("%20s", "POSITION") + "|\tCONTENT");
-    printlnBoth(pw, String.format("%20s", "--------") + " \t-------");
-    printlnBoth(pw, String.format("%20d", 0) + "|\t[magic head] " + reader.readHeadMagic());
-    printlnBoth(pw,
-        String.format("%20d", TSFileConfig.MAGIC_STRING.getBytes().length) + "|\t[version number] "
-            + reader.readVersionNumber());
-    // chunkGroup begins
-    for (ChunkGroupMetaData chunkGroupMetaData : chunkGroupMetaDataSortedList) {
-      printlnBoth(pw, str1.toString() + "\t[Chunk Group] of "
-          + chunkGroupMetaData.getDeviceID() + " begins at pos " + chunkGroupMetaData
-          .getStartOffsetOfChunkGroup() + ", ends at pos " + chunkGroupMetaData
-          .getEndOffsetOfChunkGroup() + ", version:" + chunkGroupMetaData.getVersion()
-          + ", num of Chunks:" + chunkGroupMetaData.getChunkMetaDataList().size());
-      // chunk begins
-      long chunkEndPos = 0;
-      for (ChunkMetaData chunkMetaData : chunkGroupMetaData.getChunkMetaDataList()) {
-        printlnBoth(pw,
-            String.format("%20d", chunkMetaData.getOffsetOfChunkHeader()) + "|\t[Chunk] of "
-                + chunkMetaData.getMeasurementUid() + ", numOfPoints:" + chunkMetaData
-                .getNumOfPoints() + ", time range:[" + chunkMetaData.getStartTime() + ","
-                + chunkMetaData.getEndTime() + "], tsDataType:" + chunkMetaData.getDataType()
-                + ", \n" + String.format("%20s", "") + " \t" + chunkMetaData.getStatistics());
-        printlnBoth(pw, String.format("%20s", "") + "|\t\t[marker] 1");
-        printlnBoth(pw, String.format("%20s", "") + "|\t\t[ChunkHeader]");
-        Chunk chunk = reader.readMemChunk(chunkMetaData);
-        printlnBoth(pw,
-            String.format("%20s", "") + "|\t\t" + chunk.getHeader().getNumOfPages() + " pages");
-        chunkEndPos =
-            chunkMetaData.getOffsetOfChunkHeader() + chunk.getHeader().getSerializedSize() + chunk
-                .getHeader().getDataSize();
+      // get metadata information
+      TsFileSequenceReader reader = new TsFileSequenceReader(filename);
+      TsFileMetaData tsFileMetaData = reader.readFileMetadata();
+      List<TsDeviceMetadataIndex> tsDeviceMetadataIndexSortedList = tsFileMetaData.getDeviceMap()
+          .values()
+          .stream()
+          .sorted((x, y) -> (int) (x.getOffset() - y.getOffset())).collect(Collectors.toList());
+      List<ChunkGroupMetaData> chunkGroupMetaDataTmpList = new ArrayList<>();
+      List<TsDeviceMetadata> tsDeviceMetadataSortedList = new ArrayList<>();
+      for (TsDeviceMetadataIndex index : tsDeviceMetadataIndexSortedList) {
+        TsDeviceMetadata deviceMetadata = reader.readTsDeviceMetaData(index);
+        tsDeviceMetadataSortedList.add(deviceMetadata);
+        chunkGroupMetaDataTmpList.addAll(deviceMetadata.getChunkGroupMetaDataList());
       }
-      // chunkGroupFooter begins
-      printlnBoth(pw, String.format("%20s", chunkEndPos) + "|\t[Chunk Group Footer]");
-      ChunkGroupFooter chunkGroupFooter = reader.readChunkGroupFooter(chunkEndPos, false);
-      printlnBoth(pw, String.format("%20s", "") + "|\t\t[marker] 0");
+      List<ChunkGroupMetaData> chunkGroupMetaDataSortedList = chunkGroupMetaDataTmpList.stream()
+          .sorted(Comparator.comparingLong(ChunkGroupMetaData::getStartOffsetOfChunkGroup))
+          .collect(Collectors.toList());
+
+      // begin print
+      StringBuilder str1 = new StringBuilder();
+      for (int i = 0; i < 21; i++) {
+        str1.append("|");
+      }
+
+      printlnBoth(pw, "");
+      printlnBoth(pw, String.format("%20s", "POSITION") + "|\tCONTENT");
+      printlnBoth(pw, String.format("%20s", "--------") + " \t-------");
+      printlnBoth(pw, String.format("%20d", 0) + "|\t[magic head] " + reader.readHeadMagic());
       printlnBoth(pw,
-          String.format("%20s", "") + "|\t\t[deviceID] " + chunkGroupFooter.getDeviceID());
+          String.format("%20d", TSFileConfig.MAGIC_STRING.getBytes().length)
+              + "|\t[version number] "
+              + reader.readVersionNumber());
+      // chunkGroup begins
+      for (ChunkGroupMetaData chunkGroupMetaData : chunkGroupMetaDataSortedList) {
+        printlnBoth(pw, str1.toString() + "\t[Chunk Group] of "
+            + chunkGroupMetaData.getDeviceID() + " begins at pos " + chunkGroupMetaData
+            .getStartOffsetOfChunkGroup() + ", ends at pos " + chunkGroupMetaData
+            .getEndOffsetOfChunkGroup() + ", version:" + chunkGroupMetaData.getVersion()
+            + ", num of Chunks:" + chunkGroupMetaData.getChunkMetaDataList().size());
+        // chunk begins
+        long chunkEndPos = 0;
+        for (ChunkMetaData chunkMetaData : chunkGroupMetaData.getChunkMetaDataList()) {
+          printlnBoth(pw,
+              String.format("%20d", chunkMetaData.getOffsetOfChunkHeader()) + "|\t[Chunk] of "
+                  + chunkMetaData.getMeasurementUid() + ", numOfPoints:" + chunkMetaData
+                  .getNumOfPoints() + ", time range:[" + chunkMetaData.getStartTime() + ","
+                  + chunkMetaData.getEndTime() + "], tsDataType:" + chunkMetaData.getDataType()
+                  + ", \n" + String.format("%20s", "") + " \t" + chunkMetaData.getStatistics());
+          printlnBoth(pw, String.format("%20s", "") + "|\t\t[marker] 1");
+          printlnBoth(pw, String.format("%20s", "") + "|\t\t[ChunkHeader]");
+          Chunk chunk = reader.readMemChunk(chunkMetaData);
+          printlnBoth(pw,
+              String.format("%20s", "") + "|\t\t" + chunk.getHeader().getNumOfPages() + " pages");
+          chunkEndPos =
+              chunkMetaData.getOffsetOfChunkHeader() + chunk.getHeader().getSerializedSize() + chunk
+                  .getHeader().getDataSize();
+        }
+        // chunkGroupFooter begins
+        printlnBoth(pw, String.format("%20s", chunkEndPos) + "|\t[Chunk Group Footer]");
+        ChunkGroupFooter chunkGroupFooter = reader.readChunkGroupFooter(chunkEndPos, false);
+        printlnBoth(pw, String.format("%20s", "") + "|\t\t[marker] 0");
+        printlnBoth(pw,
+            String.format("%20s", "") + "|\t\t[deviceID] " + chunkGroupFooter.getDeviceID());
+        printlnBoth(pw,
+            String.format("%20s", "") + "|\t\t[dataSize] " + chunkGroupFooter.getDataSize());
+        printlnBoth(pw, String.format("%20s", "") + "|\t\t[num of chunks] " + chunkGroupFooter
+            .getNumberOfChunks());
+        printlnBoth(pw, str1.toString() + "\t[Chunk Group] of "
+            + chunkGroupMetaData.getDeviceID() + " ends");
+      }
+
+      // metadata begins
+      printlnBoth(pw, String.format("%20s", tsDeviceMetadataIndexSortedList.get(0).getOffset() - 1)
+          + "|\t[marker] 2");
+      for (
+          int i = 0; i < tsDeviceMetadataSortedList.size(); i++) {
+        TsDeviceMetadata tsDeviceMetadata = tsDeviceMetadataSortedList.get(i);
+        TsDeviceMetadataIndex tsDeviceMetadataIndex = tsDeviceMetadataIndexSortedList.get(i);
+        printlnBoth(pw,
+            String.format("%20s", tsDeviceMetadataIndex.getOffset())
+                + "|\t[TsDeviceMetadata] of " + tsDeviceMetadata.getChunkGroupMetaDataList().get(0)
+                .getDeviceID() + ", startTime:" + tsDeviceMetadataIndex.getStartTime()
+                + ", endTime:"
+                + tsDeviceMetadataIndex.getEndTime());
+        printlnBoth(pw,
+            String.format("%20s", "") + "|\t\t[startTime] " + tsDeviceMetadata.getStartTime());
+        printlnBoth(pw,
+            String.format("%20s", "") + "|\t\t[endTime] " + tsDeviceMetadata.getEndTime());
+        printlnBoth(pw,
+            String.format("%20s", "") + "|\t\t[num of ChunkGroupMetaData] " + tsDeviceMetadata
+                .getChunkGroupMetaDataList().size());
+        printlnBoth(pw, String.format("%20s", "") +
+            "|\t\t" + tsDeviceMetadata.getChunkGroupMetaDataList().size() + " ChunkGroupMetaData");
+      }
+
+      printlnBoth(pw, String.format("%20s", reader.getFileMetadataPos()) + "|\t[TsFileMetaData]");
       printlnBoth(pw,
-          String.format("%20s", "") + "|\t\t[dataSize] " + chunkGroupFooter.getDataSize());
-      printlnBoth(pw, String.format("%20s", "") + "|\t\t[num of chunks] " + chunkGroupFooter
-          .getNumberOfChunks());
-      printlnBoth(pw, str1.toString() + "\t[Chunk Group] of "
-          + chunkGroupMetaData.getDeviceID() + " ends");
+          String.format("%20s", "") + "|\t\t[num of devices] " + tsFileMetaData
+              .getDeviceMap().size());
+      printlnBoth(pw,
+          String.format("%20s", "") + "|\t\t" + tsFileMetaData.getDeviceMap().size()
+              + " key&TsDeviceMetadataIndex");
+      printlnBoth(pw, String.format("%20s", "") + "|\t\t[num of measurements] " + tsFileMetaData
+          .getMeasurementSchema().size());
+      printlnBoth(pw,
+          String.format("%20s", "") + "|\t\t" + tsFileMetaData.getMeasurementSchema().size()
+              + " key&measurementSchema");
+      boolean createByIsNotNull = (tsFileMetaData.getCreatedBy() != null);
+      printlnBoth(pw,
+          String.format("%20s", "") + "|\t\t[createBy isNotNull] " + createByIsNotNull);
+      if (createByIsNotNull) {
+        printlnBoth(pw,
+            String.format("%20s", "") + "|\t\t[createBy] " + tsFileMetaData.getCreatedBy());
+      }
+      printlnBoth(pw,
+          String.format("%20s", "") + "|\t\t[totalChunkNum] " + tsFileMetaData.getTotalChunkNum());
+      printlnBoth(pw,
+          String.format("%20s", "") + "|\t\t[invalidChunkNum] " + tsFileMetaData
+              .getInvalidChunkNum());
+
+      // bloom filter
+      BloomFilter bloomFilter = tsFileMetaData.getBloomFilter();
+      printlnBoth(pw,
+          String.format("%20s", "") + "|\t\t[bloom filter bit vector byte array length] "
+              + bloomFilter.serialize().length);
+      printlnBoth(pw,
+          String.format("%20s", "") + "|\t\t[bloom filter bit vector byte array] ");
+      printlnBoth(pw,
+          String.format("%20s", "") + "|\t\t[bloom filter number of bits] "
+              + bloomFilter.getSize());
+      printlnBoth(pw,
+          String.format("%20s", "") + "|\t\t[bloom filter number of hash functions] "
+              + bloomFilter.getHashFunctionSize());
+
+      printlnBoth(pw,
+          String.format("%20s", (reader.getFileMetadataPos() + reader.getFileMetadataSize()))
+              + "|\t[TsFileMetaDataSize] " + reader.getFileMetadataSize());
+
+      printlnBoth(pw,
+          String.format("%20s", reader.getFileMetadataPos() + reader.getFileMetadataSize() + 4)
+              + "|\t[magic tail] " + reader.readTailMagic());
+
+      printlnBoth(pw,
+          String.format("%20s", length) + "|\tEND of TsFile");
+
+      printlnBoth(pw, "");
+
+      printlnBoth(pw,
+          "---------------------------------- TsFile Sketch End ----------------------------------");
     }
-
-    // metadata begins
-    printlnBoth(pw, String.format("%20s", tsDeviceMetadataIndexSortedList.get(0).getOffset() - 1)
-        + "|\t[marker] 2");
-    for (
-        int i = 0; i < tsDeviceMetadataSortedList.size(); i++) {
-      TsDeviceMetadata tsDeviceMetadata = tsDeviceMetadataSortedList.get(i);
-      TsDeviceMetadataIndex tsDeviceMetadataIndex = tsDeviceMetadataIndexSortedList.get(i);
-      printlnBoth(pw,
-          String.format("%20s", tsDeviceMetadataIndex.getOffset())
-              + "|\t[TsDeviceMetadata] of " + tsDeviceMetadata.getChunkGroupMetaDataList().get(0)
-              .getDeviceID() + ", startTime:" + tsDeviceMetadataIndex.getStartTime() + ", endTime:"
-              + tsDeviceMetadataIndex.getEndTime());
-      printlnBoth(pw,
-          String.format("%20s", "") + "|\t\t[startTime] " + tsDeviceMetadata.getStartTime());
-      printlnBoth(pw,
-          String.format("%20s", "") + "|\t\t[endTime] " + tsDeviceMetadata.getEndTime());
-      printlnBoth(pw,
-          String.format("%20s", "") + "|\t\t[num of ChunkGroupMetaData] " + tsDeviceMetadata
-              .getChunkGroupMetaDataList().size());
-      printlnBoth(pw, String.format("%20s", "") +
-          "|\t\t" + tsDeviceMetadata.getChunkGroupMetaDataList().size() + " ChunkGroupMetaData");
-    }
-
-    printlnBoth(pw, String.format("%20s", reader.getFileMetadataPos()) + "|\t[TsFileMetaData]");
-    printlnBoth(pw,
-        String.format("%20s", "") + "|\t\t[num of devices] " + tsFileMetaData
-            .getDeviceMap().size());
-    printlnBoth(pw,
-        String.format("%20s", "") + "|\t\t" + tsFileMetaData.getDeviceMap().size()
-            + " key&TsDeviceMetadataIndex");
-    printlnBoth(pw, String.format("%20s", "") + "|\t\t[num of measurements] " + tsFileMetaData
-        .getMeasurementSchema().size());
-    printlnBoth(pw,
-        String.format("%20s", "") + "|\t\t" + tsFileMetaData.getMeasurementSchema().size()
-            + " key&measurementSchema");
-    boolean createByIsNotNull = (tsFileMetaData.getCreatedBy() != null);
-    printlnBoth(pw,
-        String.format("%20s", "") + "|\t\t[createBy isNotNull] " + createByIsNotNull);
-    if (createByIsNotNull) {
-      printlnBoth(pw,
-          String.format("%20s", "") + "|\t\t[createBy] " + tsFileMetaData.getCreatedBy());
-    }
-    printlnBoth(pw,
-        String.format("%20s", "") + "|\t\t[totalChunkNum] " + tsFileMetaData.getTotalChunkNum());
-    printlnBoth(pw,
-        String.format("%20s", "") + "|\t\t[invalidChunkNum] " + tsFileMetaData
-            .getInvalidChunkNum());
-
-    // bloom filter
-    BloomFilter bloomFilter = tsFileMetaData.getBloomFilter();
-    printlnBoth(pw,
-        String.format("%20s", "") + "|\t\t[bloom filter bit vector byte array length] "
-            + bloomFilter.serialize().length);
-    printlnBoth(pw,
-        String.format("%20s", "") + "|\t\t[bloom filter bit vector byte array] ");
-    printlnBoth(pw,
-        String.format("%20s", "") + "|\t\t[bloom filter number of bits] "
-            + bloomFilter.getSize());
-    printlnBoth(pw,
-        String.format("%20s", "") + "|\t\t[bloom filter number of hash functions] "
-            + bloomFilter.getHashFunctionSize());
-
-    printlnBoth(pw,
-        String.format("%20s", (reader.getFileMetadataPos() + reader.getFileMetadataSize()))
-            + "|\t[TsFileMetaDataSize] " + reader.getFileMetadataSize());
-
-    printlnBoth(pw,
-        String.format("%20s", reader.getFileMetadataPos() + reader.getFileMetadataSize() + 4)
-            + "|\t[magic tail] " + reader.readTailMagic());
-
-    printlnBoth(pw,
-        String.format("%20s", length) + "|\tEND of TsFile");
-
-    printlnBoth(pw, "");
-
-    printlnBoth(pw,
-        "---------------------------------- TsFile Sketch End ----------------------------------");
-    pw.close();
   }
 
   private static void printlnBoth(PrintWriter pw, String str) {


### PR DESCRIPTION
An example:
```
|==============================================================
|D:\\data\data
|--sequence
|  |--root.ln.wf01.wt01
|  |  |--1575813520203-101-0.tsfile
|  |  |--1575813520203-101-0.tsfile.resource
|  |  |  |--device root.ln.wf01.wt01, start time 1 (1970-01-01T08:00:00.001+08:00[GMT+08:00]), end time 5 (1970-01-01T08:00:00.005+08:00[GMT+08:00])
|  |  |--1575813520669-103-0.tsfile
|  |  |--1575813520669-103-0.tsfile.resource
|  |  |  |--device root.ln.wf01.wt01, start time 100 (1970-01-01T08:00:00.100+08:00[GMT+08:00]), end time 300 (1970-01-01T08:00:00.300+08:00[GMT+08:00])
|  |  |--1575813521372-107-0.tsfile
|  |  |--1575813521372-107-0.tsfile.resource
|  |  |  |--device root.ln.wf01.wt01, start time 500 (1970-01-01T08:00:00.500+08:00[GMT+08:00]), end time 540 (1970-01-01T08:00:00.540+08:00[GMT+08:00])
|--unsequence
|  |--root.ln.wf01.wt01
|  |  |--1575813521063-105-0.tsfile
|  |  |--1575813521063-105-0.tsfile.resource
|  |  |  |--device root.ln.wf01.wt01, start time 10 (1970-01-01T08:00:00.010+08:00[GMT+08:00]), end time 50 (1970-01-01T08:00:00.050+08:00[GMT+08:00])
|==============================================================
```