### PR TITLE
Do not create used file maps for non-data queries

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/control/QueryResourceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/control/QueryResourceManager.java
@@ -64,9 +64,11 @@ public class QueryResourceManager {
    * Register a new query. When a query request is created firstly, this method must
    * be invoked.
    */
-  public long assignQueryId() {
+  public long assignQueryId(boolean isDataQuery) {
     long queryId = queryIdAtom.incrementAndGet();
-    filePathsManager.addQueryId(queryId);
+    if (isDataQuery) {
+      filePathsManager.addQueryId(queryId);
+    }
     return queryId;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -639,7 +639,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       } // else default ignoreTimeStamp is false
       resp.setOperationType(plan.getOperatorType().toString());
       // generate the queryId for the operation
-      long queryId = generateQueryId();
+      long queryId = generateQueryId(true);
       // put it into the corresponding Set
       statementId2QueryId.computeIfAbsent(statementId, k -> new HashSet<>()).add(queryId);
 
@@ -905,7 +905,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
 
     status = executePlan(plan);
     TSExecuteStatementResp resp = getTSExecuteStatementResp(status);
-    long queryId = generateQueryId();
+    long queryId = generateQueryId(false);
     resp.setQueryId(queryId);
     return resp;
   }
@@ -1039,7 +1039,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       plan = (InsertPlan) queryId2Plan.get(req.getQueryId());
       queryId = req.getQueryId();
     } else {
-      queryId = generateQueryId();
+      queryId = generateQueryId(false);
       plan = new InsertPlan();
       queryId2Plan.put(queryId, plan);
     }
@@ -1313,8 +1313,8 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         : getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR);
   }
 
-  private long generateQueryId() {
-    return QueryResourceManager.getInstance().assignQueryId();
+  private long generateQueryId(boolean isDataQuery) {
+    return QueryResourceManager.getInstance().assignQueryId(isDataQuery);
   }
 }
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
@@ -175,7 +175,7 @@ public class IoTDBSequenceDataQueryIT {
     queryExpression.addSelectedPath(new Path(Constant.d1s1));
     queryExpression.setExpression(null);
 
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
     QueryDataSet queryDataSet = engineExecutor.query(queryExpression, TEST_QUERY_CONTEXT);
 
@@ -200,7 +200,7 @@ public class IoTDBSequenceDataQueryIT {
 
     GlobalTimeExpression globalTimeExpression = new GlobalTimeExpression(TimeFilter.gtEq(800L));
     queryExpression.setExpression(globalTimeExpression);
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
     QueryDataSet queryDataSet = engineExecutor.query(queryExpression, TEST_QUERY_CONTEXT);
 
@@ -236,7 +236,7 @@ public class IoTDBSequenceDataQueryIT {
         ValueFilter.gtEq(14));
     queryExpression.setExpression(singleSeriesExpression);
 
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
     QueryDataSet queryDataSet = engineExecutor.query(queryExpression, TEST_QUERY_CONTEXT);
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
@@ -246,7 +246,7 @@ public class IoTDBSeriesReaderIT {
     queryExpression.addSelectedPath(new Path(Constant.d1s1));
     queryExpression.setExpression(null);
 
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
     QueryDataSet queryDataSet = engineExecutor.query(queryExpression, TEST_QUERY_CONTEXT);
 
@@ -274,7 +274,7 @@ public class IoTDBSeriesReaderIT {
         ValueFilter.gtEq(20));
     queryExpression.setExpression(singleSeriesExpression);
 
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
     QueryDataSet queryDataSet = engineExecutor.query(queryExpression, TEST_QUERY_CONTEXT);
 
@@ -302,7 +302,7 @@ public class IoTDBSeriesReaderIT {
     SingleSeriesExpression expression = new SingleSeriesExpression(path, TimeFilter.gt(22987L));
     queryExpression.setExpression(expression);
 
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
     QueryDataSet queryDataSet = engineExecutor.query(queryExpression, TEST_QUERY_CONTEXT);
 
@@ -331,7 +331,7 @@ public class IoTDBSeriesReaderIT {
         ValueFilter.lt(111));
     queryExpression.setExpression(singleSeriesExpression);
 
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
     QueryDataSet queryDataSet = engineExecutor.query(queryExpression, TEST_QUERY_CONTEXT);
 

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -164,7 +164,7 @@ public class EnvironmentUtils {
     MultiFileLogNodeManager.getInstance().start();
     FlushManager.getInstance().start();
     MergeManager.getINSTANCE().start();
-    TEST_QUERY_JOB_ID  = QueryResourceManager.getInstance().assignQueryId();
+    TEST_QUERY_JOB_ID  = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
   }
 

--- a/session/src/test/java/org/apache/iotdb/session/utils/EnvironmentUtils.java
+++ b/session/src/test/java/org/apache/iotdb/session/utils/EnvironmentUtils.java
@@ -58,7 +58,7 @@ public class EnvironmentUtils {
   private static IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static DirectoryManager directoryManager = DirectoryManager.getInstance();
 
-  private static long TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+  private static long TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
   private static QueryContext TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
   private static long oldTsFileThreshold = config.getTsFileSizeThreshold();
@@ -160,7 +160,7 @@ public class EnvironmentUtils {
     StorageEngine.getInstance().reset();
     MultiFileLogNodeManager.getInstance().start();
     FlushManager.getInstance().start();
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
   }
 

--- a/spark-iotdb-connector/src/test/scala/org/apache/iotdb/spark/db/EnvironmentUtils.java
+++ b/spark-iotdb-connector/src/test/scala/org/apache/iotdb/spark/db/EnvironmentUtils.java
@@ -93,7 +93,7 @@ public class EnvironmentUtils {
   private static IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static DirectoryManager directoryManager = DirectoryManager.getInstance();
 
-  public static long TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+  public static long TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
   public static QueryContext TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
   private static long oldTsFileThreshold = config.getTsFileSizeThreshold();
@@ -195,7 +195,7 @@ public class EnvironmentUtils {
     StorageEngine.getInstance().reset();
     MultiFileLogNodeManager.getInstance().start();
     FlushManager.getInstance().start();
-    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId();
+    TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
   }
 


### PR DESCRIPTION
When generating a queryId, two maps recording the files used by this query are created, which are not necessary for non-data queries, so we remove the map creation for non-data queries by separating data query and non-data query.