### PR TITLE
[IOTDB-388]disable sonar and coveralls for non-committers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -175,6 +175,7 @@ matrix:
 #        - mvn -B apache-rat:check
 #        - mvn -B clean package -pl server,grafana,client,example,:kafka-example,:rocketmq-example -am integration-test
     - os: linux
+      if: fork = false #only fork=true (i.e., the committer has permission to write the repo)
       name: sonar-analysis
       dist: xenial
       jdk: openjdk8
@@ -187,6 +188,7 @@ matrix:
       script:
         - mvn verify sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-iotdb -DskipTests
     - os: linux
+      if: fork = false #only fork=true (i.e., the committer has permission to write the repo)
       name: code-coverage
       dist: xenial
       jdk: openjdk8


### PR DESCRIPTION
As travis will upload results to sonar and coveralls but non-committers have no permission, the related PR CI will fail.

 

Therefore, we can disable the two CI stage for those who have no write permission of Apache IoTDB repo. That is, these users can just fork the repo and then submit pr.
 
If it does not work, we can constrain the type = pull_request. 

 