### PR TITLE
[IOTDB-159] Fix NullPointerException in SeqTsFileRecoverTest and UnseqTsFileRecoverTest

### DIFF
--- a/server/src/test/java/org/apache/iotdb/db/writelog/recover/SeqTsFileRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/recover/SeqTsFileRecoverTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.conf.adapter.ActiveTimeSeriesCounter;
 import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
+import org.apache.iotdb.db.engine.flush.pool.FlushSubTaskPoolManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.version.VersionController;
 import org.apache.iotdb.db.exception.storageGroup.StorageGroupProcessorException;
@@ -78,6 +79,7 @@ public class SeqTsFileRecoverTest {
 
   @Before
   public void setup() throws IOException, WriteProcessException {
+    FlushSubTaskPoolManager.getInstance().start();
     tsF = SystemFileFactory.INSTANCE.getFile(logNodePrefix, "test.ts");
     tsF.getParentFile().mkdirs();
 
@@ -130,6 +132,7 @@ public class SeqTsFileRecoverTest {
     FileUtils.deleteDirectory(tsF.getParentFile());
     resource.close();
     node.delete();
+    FlushSubTaskPoolManager.getInstance().stop();
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/writelog/recover/UnseqTsFileRecoverTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/recover/UnseqTsFileRecoverTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.conf.adapter.ActiveTimeSeriesCounter;
 import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
+import org.apache.iotdb.db.engine.flush.pool.FlushSubTaskPoolManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.engine.version.VersionController;
 import org.apache.iotdb.db.exception.storageGroup.StorageGroupProcessorException;
@@ -80,6 +81,7 @@ public class UnseqTsFileRecoverTest {
 
   @Before
   public void setup() throws IOException, WriteProcessException {
+    FlushSubTaskPoolManager.getInstance().start();
     tsF = SystemFileFactory.INSTANCE.getFile(logNodePrefix, "test.ts");
     tsF.getParentFile().mkdirs();
 
@@ -138,6 +140,7 @@ public class UnseqTsFileRecoverTest {
   public void tearDown() throws IOException {
     FileUtils.deleteDirectory(tsF.getParentFile());
     node.delete();
+    FlushSubTaskPoolManager.getInstance().stop();
   }
 
   @Test


### PR DESCRIPTION
JIRA link: https://issues.apache.org/jira/browse/IOTDB-159

# To reproduce this bug:
The key to reproducing, is to test UnseqTsFileRecoverTest (or SeqTsFileRecoverTest) AFTER 
first testing an integration test under the test/java/org/apache/iotdb/db/integration directory, 
such as IoTDBAuthorizationIT.
```
git clone https://github.com/apache/incubator-iotdb.git
cd incubator-iotdb
mvn clean install -Dmaven.test.skip=true
cd server
mvn test -Dtest=org.apache.iotdb.db.integration.IoTDBAuthorizationIT,org.apache.iotdb.db.writelog.recover.UnseqTsFileRecoverTest
```

# The cause of this bug:
FlushSubTaskPoolManager.getInstance() is shared between IoTDBAuthorizationIT and UnseqTsFileRecoverTest. 

In the integration tests under the test/java/org/apache/iotdb/db/integration directory, tearDown() will call FlushSubTaskPoolManager.stop() and finally **set FlushSubTaskPoolManager.pool to be null**. 

In UnseqTsFileRecoverTest (or SeqTsFileRecoverTest), test() will call:
```
performer.recover()
->redoLogs(restorableTsFileIOWriter)
->new MemTableFlushTask
->subTaskPoolManager.submit(encodingTask)
```
Therefore, if UnseqTsFileRecoverTest (or SeqTsFileRecoverTest) is tested behind integration tests, it will find that **subTaskPoolManager.pool is null**. Thus, NullPointerException is thrown.

# To fix this bug:
Add `FlushSubTaskPoolManager.getInstance().start()` to setup() of SeqTsFileRecoverTest and UnseqTsFileRecoverTest. Accordingly, also add `FlushSubTaskPoolManager.getInstance().stop()` to tearDown().