### PR TITLE
Define disable align clause

### DIFF
--- a/server/src/main/antlr4/org/apache/iotdb/db/qp/strategy/SqlBase.g4
+++ b/server/src/main/antlr4/org/apache/iotdb/db/qp/strategy/SqlBase.g4
@@ -130,13 +130,13 @@ fromClause
 specialClause
     : specialLimit
     | groupByClause specialLimit?
-    | fillClause slimitClause? groupByDeviceClause?
+    | fillClause slimitClause? groupByDeviceClauseOrDisableAlign?
     ;
 
 specialLimit
-    : limitClause slimitClause? groupByDeviceClause?
-    | slimitClause limitClause? groupByDeviceClause?
-    | groupByDeviceClause
+    : limitClause slimitClause? groupByDeviceClauseOrDisableAlign?
+    | slimitClause limitClause? groupByDeviceClauseOrDisableAlign?
+    | groupByDeviceClauseOrDisableAlign
     ;
 
 limitClause
@@ -158,6 +158,15 @@ soffsetClause
 groupByDeviceClause
     :
     GROUP BY DEVICE
+    ;
+
+disableAlign
+    : DISABLE ALIGN
+    ;
+
+groupByDeviceClauseOrDisableAlign
+    : groupByDeviceClause
+    | disableAlign
     ;
 
 fillClause
@@ -631,6 +640,14 @@ REMOVE
     ;
 MOVE
     : M O V E
+    ;
+
+DISABLE
+    : D I S A B L E
+    ;
+
+ALIGN
+    : A L I G N
     ;
 
 //============================

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/QueryOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/QueryOperator.java
@@ -46,6 +46,7 @@ public class QueryOperator extends SFWOperator {
   private int seriesOffset = 0;
 
   private boolean isGroupByDevice = false;
+  private boolean isAlign = true;
 
   public QueryOperator(int tokenIntType) {
     super(tokenIntType);
@@ -154,5 +155,13 @@ public class QueryOperator extends SFWOperator {
 
   public void setGroupByDevice(boolean isGroupByDevice) {
     this.isGroupByDevice = isGroupByDevice;
+  }
+
+  public boolean isAlign() {
+    return isAlign;
+  }
+
+  public void setAlign(boolean align) {
+    isAlign = align;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -648,6 +648,12 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   }
 
   @Override
+  public void enterDisableAlign(SqlBaseParser.DisableAlignContext ctx) {
+    super.enterDisableAlign(ctx);
+    queryOp.setAlign(false);
+  }
+
+  @Override
   public void enterGroupByClause(GroupByClauseContext ctx) {
     super.enterGroupByClause(ctx);
     queryOp.setGroupBy(true);

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/LogicalPlanSmallTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/LogicalPlanSmallTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.qp.plan;
 
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
@@ -198,4 +199,28 @@ public class LogicalPlanSmallTest {
     Assert.assertEquals(path, ((DeleteStorageGroupOperator) operator).getDeletePathList().get(0));
   }
 
+  @Test
+  public void testDisableAlign() {
+    String sqlStr = "select * from root.vehicle disable align";
+    RootOperator operator = (RootOperator) parseDriver
+            .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    Assert.assertEquals(QueryOperator.class, operator.getClass());
+    Assert.assertFalse(((QueryOperator)operator).isAlign());
+  }
+
+  @Test
+  public void testNotDisableAlign() {
+    String sqlStr = "select * from root.vehicle";
+    RootOperator operator = (RootOperator) parseDriver
+            .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+    Assert.assertEquals(QueryOperator.class, operator.getClass());
+    Assert.assertTrue(((QueryOperator)operator).isAlign());
+  }
+
+  @Test (expected = ParseCancellationException.class)
+  public void testDisableAlignConflictGroupByDevice() {
+    String sqlStr = "select * from root.vehicle disable align group by device";
+    RootOperator operator = (RootOperator) parseDriver
+            .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
+  }
 }


### PR DESCRIPTION
The disable align clause is defined in the ANTLR file. And the logical plan can be generated now. 