### PR TITLE
[IOTDB-397]fix gc log collection in start-server.sh scripts

### DIFF
--- a/docs/Documentation-CHN/UserGuide/3-Server/4-Config Manual.md
+++ b/docs/Documentation-CHN/UserGuide/3-Server/4-Config Manual.md
@@ -405,3 +405,20 @@
 |类型| String |
 |默认值|your principal |
 |改后生效方式|重启服务器生效|
+
+
+## 开启GC日志
+GC日志默认是关闭的。为了性能调优，用户可能会需要手机GC信息。
+若要打开GC日志，则需要在启动IoTDB Server的时候加上"printgc"参数：
+
+```bash
+sbin/start-server.sh printgc
+```
+或者
+
+```bash
+sbin\start-server.bat printgc
+```
+
+GC日志会被存储在`IOTDB_HOME/logs/gc.log`. 至多会存储10个gc.log文件，每个文件最多10MB。
+

--- a/docs/Documentation/UserGuide/3-Server/4-Config Manual.md
+++ b/docs/Documentation/UserGuide/3-Server/4-Config Manual.md
@@ -443,3 +443,21 @@ The detail of each variables are as follows:
 |Type| String |
 |Default|your principal |
 |Effective|After restart system|
+
+## Enable GC log
+GC log is off by default.
+For performance tuning, you may want to collect the GC info. 
+
+To enable GC log, just add a paramenter "printgc" when you start the server.
+
+```bash
+sbin/start-server.sh printgc
+```
+Or
+```bash
+sbin\start-server.bat printgc
+```
+
+GC log is stored at `IOTDB_HOME/logs/gc.log`.
+There will be at most 10 gc.log.* files and each one can reach to 10MB.
+

--- a/server/src/assembly/resources/conf/iotdb-env.bat
+++ b/server/src/assembly/resources/conf/iotdb-env.bat
@@ -54,24 +54,27 @@ for /f "tokens=1-3" %%j in ('java -version 2^>^&1') do (
 	set BIT_VERSION=%%l
 )
 IF "%BIT_VERSION%" == "64-Bit" (
-  rem 64bit, Maximum heap size
-  set MAX_HEAP_SIZE="2G"
-  rem 64bit, Minimum heap size
-  set HEAP_NEWSIZE="2G"
+	rem 64-bit Java
+	echo Detect 64-bit Java, maximum memory allocation pool = 2GB, initial memory allocation pool = 2GB
+	set IOTDB_HEAP_OPTS=-Xmx2G -Xms2G
 ) ELSE (
-  rem 32bit, Maximum heap size
-  set MAX_HEAP_SIZE="512M"
-  rem 32bit, Minimum heap size
-  set HEAP_NEWSIZE="512M"
+	rem 32-bit Java
+	echo Detect 32-bit Java, maximum memory allocation pool = 512MB, initial memory allocation pool = 512MB
+	set IOTDB_HEAP_OPTS=-Xmx512M -Xms512M
 )
-
-@REM MAX_HEAP_SIZE="2G"
-@REM HEAP_NEWSIZE="2G"
-
-set IOTDB_HEAP_OPTS=-Xmx%MAX_HEAP_SIZE% -Xms%HEAP_NEWSIZE%
 
 @REM You can put your env variable here
 @REM set JAVA_HOME=%JAVA_HOME%
 
 :end_config_setting
+@REM set gc log.
+IF "%1" equ "printgc" (
+	IF %JAVA_VERSION% == 8 (
+	    md %IOTDB_HOME%\logs
+		set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -Xloggc:"%IOTDB_HOME%\logs\gc.log" -XX:+PrintGCDateStamps -XX:+PrintGCDetails  -XX:+PrintGCApplicationStoppedTime -XX:+PrintPromotionFailure -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M
+	) ELSE (
+		md %IOTDB_HOME%\logs
+		set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS%  -Xlog:gc=info,heap*=trace,age*=debug,safepoint=info,promotion*=trace:file="%IOTDB_HOME%\logs\gc.log":time,uptime,pid,tid,level:filecount=10,filesize=10485760
+	)
+)
 echo If you want to change this configuration, please check conf/iotdb-env.sh(Unix or OS X, if you use Windows, check conf/iotdb-env.bat).

--- a/server/src/assembly/resources/conf/iotdb-env.sh
+++ b/server/src/assembly/resources/conf/iotdb-env.sh
@@ -150,7 +150,7 @@ else
         # only add -Xlog:gc if it's not mentioned in jvm-server.options file
         mkdir -p ${IOTDB_HOME}/logs
         if [ "$#" -ge "1" -a "$1" == "printgc" ]; then
-            IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xlog:gc=info,heap*=trace,age*=debug,safepoint=info,promotion*=trace:file=${IOTDB_HOME}/logs/gc.log:time,uptime,pid,tid,level:filecount=10,filesize=10485760"
+            IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xlog:gc=info,heap*=info,age*=info,safepoint=info,promotion*=info:file=${IOTDB_HOME}/logs/gc.log:time,uptime,pid,tid,level:filecount=10,filesize=10485760"
         fi
     fi
 fi

--- a/server/src/assembly/resources/sbin/start-server.bat
+++ b/server/src/assembly/resources/sbin/start-server.bat
@@ -59,7 +59,7 @@ set IOTDB_CONF=%IOTDB_HOME%\conf
 set IOTDB_LOGS=%IOTDB_HOME%\logs
 
 IF EXIST "%IOTDB_CONF%\iotdb-env.bat" (
-    CALL "%IOTDB_CONF%\iotdb-env.bat"
+    CALL "%IOTDB_CONF%\iotdb-env.bat" %1
     ) ELSE (
     echo "can't find %IOTDB_CONF%\iotdb-env.bat"
     )

--- a/server/src/assembly/resources/sbin/start-server.sh
+++ b/server/src/assembly/resources/sbin/start-server.sh
@@ -31,7 +31,11 @@ IOTDB_CONF=${IOTDB_HOME}/conf
 # IOTDB_LOGS=${IOTDB_HOME}/logs
 
 if [ -f "$IOTDB_CONF/iotdb-env.sh" ]; then
-    . "$IOTDB_CONF/iotdb-env.sh"
+    if [ "$#" -ge "1" -a "$1" == "printgc" ]; then
+      . "$IOTDB_CONF/iotdb-env.sh" "printgc"
+    else
+        . "$IOTDB_CONF/iotdb-env.sh"
+    fi
 else
     echo "can't find $IOTDB_CONF/iotdb-env.sh"
 fi


### PR DESCRIPTION
Current though we set the printGC parameter, but we forgot to enable it..

i.e., in iotdb-env.sh, though we set:

IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xloggc:${IOTDB_HOME}/gc.log"

, but latter, in line 153 and line 156, we set:

IOTDB_JMX_OPTS="-Diotdb.jmx.local.port=$JMX_PORT"

, which cleans all setting before...

This PR fixes the bug and fix the GC log setting.

using `start-server.sh printgc` to enable the script.

In JDK8, the log looks like:
 ```
ava HotSpot(TM) 64-Bit Server VM (25.144-b01) for bsd-amd64 JRE (1.8.0_144-b01), built on Jul 21 2017 22:07:42 by "java_re" with gcc 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)
Memory: 4k page, physical 33554432k(419872k free)

/proc/meminfo:

CommandLine flags: -XX:GCLogFileSize=10485760 -XX:InitialHeapSize=1258291200 -XX:+ManagementServer -XX:MaxHeapSize=8589934592 -XX:NumberOfGCLogFiles=10 -XX:+PrintGC -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintPromotionFailure -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseGCLogFileRotation -XX:+UseParallelGC
2019-12-31T16:51:30.669-0800: 0.135: Total time for which application threads were stopped: 0.0000796 seconds, Stopping threads took: 0.0000073 seconds
2019-12-31T16:51:30.670-0800: 0.135: Total time for which application threads were stopped: 0.0000325 seconds, Stopping threads took: 0.0000049 seconds
2019-12-31T16:51:30.721-0800: 0.187: Total time for which application threads were stopped: 0.0000713 seconds, Stopping threads took: 0.0000064 seconds
2019-12-31T16:51:30.723-0800: 0.189: Total time for which application threads were stopped: 0.0000435 seconds, Stopping threads took: 0.0000046 seconds
2019-12-31T16:51:31.116-0800: 0.582: Total time for which application threads were stopped: 0.0002378 seconds, Stopping threads took: 0.0000095 seconds
2019-12-31T16:51:31.125-0800: 0.591: Total time for which application threads were stopped: 0.0001803 seconds, Stopping threads took: 0.0000126 seconds
2019-12-31T16:51:31.174-0800: 0.640: Total time for which application threads were stopped: 0.0001455 seconds, Stopping threads took: 0.0000089 seconds
2019-12-31T16:51:31.206-0800: 0.672: Total time for which application threads were stopped: 0.0001268 seconds, Stopping threads took: 0.0000094 seconds
2019-12-31T16:51:32.209-0800: 1.675: Total time for which application threads were stopped: 0.0000876 seconds, Stopping threads took: 0.0000262 seconds
2019-12-31T16:51:34.782-0800: 4.248: Total time for which application threads were stopped: 0.0002554 seconds, Stopping threads took: 0.0000235 seconds
2019-12-31T16:53:13.096-0800: 102.562: Total time for which application threads were stopped: 0.0000828 seconds, Stopping threads took: 0.0000195 seconds
2019-12-31T16:53:26.348-0800: 115.813: [GC (Metadata GC Threshold) [PSYoungGen: 172035K->13140K(358400K)] 172035K->13228K(1177600K), 0.0114719 secs] [Times: user=0.03 sys=0.00, real=0.01 secs]
2019-12-31T16:53:26.359-0800: 115.825: [Full GC (Metadata GC Threshold) [PSYoungGen: 13140K->0K(358400K)] [ParOldGen: 88K->12424K(819200K)] 13228K->12424K(1177600K), [Metaspace: 20673K->20673K(1069056K)], 0.0171284 secs] [Times: user=0.06 sys=0.02, real=0.02 secs]
```

In JDK11, the log looks like:
```
[2019-12-31T19:51:23.316-0800][0.694s][11418][13059][info ] GC(0) Pause Young (Concurrent Start) (Metadata GC Threshold) 42M->5M(1200M) 13.686ms
[2019-12-31T19:51:23.316-0800][0.694s][11418][13059][info ] Leaving safepoint region
[2019-12-31T19:51:23.316-0800][0.694s][11418][13059][info ] Total time for which application threads were stopped: 0.0201488 seconds, Stopping threads took: 0.0000139 seconds
[2019-12-31T19:51:23.316-0800][0.695s][11418][19971][info ] GC(1) Concurrent Cycle
[2019-12-31T19:51:23.318-0800][0.696s][11418][13059][info ] Application time: 0.0015954 seconds
[2019-12-31T19:51:23.318-0800][0.696s][11418][13059][info ] Entering safepoint region: CGC_Operation
[2019-12-31T19:51:23.319-0800][0.697s][11418][13059][info ] GC(1) Pause Remark 6M->6M(1200M) 0.835ms
[2019-12-31T19:51:23.319-0800][0.697s][11418][13059][info ] Leaving safepoint region
[2019-12-31T19:51:23.319-0800][0.697s][11418][13059][info ] Total time for which application threads were stopped: 0.0010833 seconds, Stopping threads took: 0.0001294 seconds
[2019-12-31T19:51:23.319-0800][0.697s][11418][13059][info ] Application time: 0.0000895 seconds
[2019-12-31T19:51:23.319-0800][0.697s][11418][13059][info ] Entering safepoint region: CGC_Operation
[2019-12-31T19:51:23.319-0800][0.697s][11418][13059][info ] GC(1) Pause Cleanup 6M->6M(1200M) 0.076ms
[2019-12-31T19:51:23.319-0800][0.698s][11418][13059][info ] Leaving safepoint region
[2019-12-31T19:51:23.319-0800][0.698s][11418][13059][info ] Total time for which application threads were stopped: 0.0001943 seconds, Stopping threads took: 0.0000523 seconds
```



