### PR TITLE
abstract an interface ManagedSeriesReader from SeriesReaderWithoutValueFilter

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/executor/EngineExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/EngineExecutor.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.EngineDataSetWithValueFilter;
 import org.apache.iotdb.db.query.dataset.NewEngineDataSetWithoutValueFilter;
 import org.apache.iotdb.db.query.reader.IReaderByTimestamp;
+import org.apache.iotdb.db.query.reader.ManagedSeriesReader;
 import org.apache.iotdb.db.query.reader.seriesRelated.SeriesReaderByTimestamp;
 import org.apache.iotdb.db.query.reader.seriesRelated.SeriesReaderWithoutValueFilter;
 import org.apache.iotdb.db.query.timegenerator.EngineTimeGenerator;
@@ -70,12 +71,12 @@ public class EngineExecutor {
       timeFilter = ((GlobalTimeExpression) optimizedExpression).getFilter();
     }
 
-    List<SeriesReaderWithoutValueFilter> readersOfSelectedSeries = new ArrayList<>();
+    List<ManagedSeriesReader> readersOfSelectedSeries = new ArrayList<>();
     for (int i = 0; i < deduplicatedPaths.size(); i++) {
       Path path = deduplicatedPaths.get(i);
       TSDataType dataType = deduplicatedDataTypes.get(i);
 
-      SeriesReaderWithoutValueFilter reader = new SeriesReaderWithoutValueFilter(path, dataType, timeFilter, context,
+      ManagedSeriesReader reader = new SeriesReaderWithoutValueFilter(path, dataType, timeFilter, context,
           true);
       readersOfSelectedSeries.add(reader);
     }

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/ManagedSeriesReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/ManagedSeriesReader.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.reader;
+
+import org.apache.iotdb.tsfile.read.reader.IBatchReader;
+
+/**
+ * ManagedSeriesReader is a combination of IBatchReader and IPointReader that provides
+ * additional interfaces to make it able to be run in a thread pool concurrently within a query.
+ */
+public interface ManagedSeriesReader extends IBatchReader, IPointReader {
+
+  boolean isManagedByQueryManager();
+
+  void setManagedByQueryManager(boolean managedByQueryManager);
+
+  boolean hasRemaining();
+
+  void setHasRemaining(boolean hasRemaining);
+}

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/seriesRelated/SeriesReaderWithoutValueFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/seriesRelated/SeriesReaderWithoutValueFilter.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
-import org.apache.iotdb.db.query.reader.IPointReader;
+import org.apache.iotdb.db.query.reader.ManagedSeriesReader;
 import org.apache.iotdb.db.query.reader.resourceRelated.SeqResourceIterateReader;
 import org.apache.iotdb.db.query.reader.resourceRelated.NewUnseqResourceMergeReader;
 import org.apache.iotdb.db.utils.TimeValuePair;
@@ -40,7 +40,7 @@ import java.io.IOException;
  *
  * "without value filter" is equivalent to "with global time filter or without any filter".
  */
-public class SeriesReaderWithoutValueFilter implements IBatchReader, IPointReader {
+public class SeriesReaderWithoutValueFilter implements ManagedSeriesReader {
 
   private IBatchReader seqResourceIterateReader;
   private IBatchReader unseqResourceMergeReader;
@@ -111,18 +111,22 @@ public class SeriesReaderWithoutValueFilter implements IBatchReader, IPointReade
     this.unseqResourceMergeReader = unseqResourceMergeReader;
   }
 
+  @Override
   public boolean isManagedByQueryManager() {
     return managedByQueryManager;
   }
 
+  @Override
   public void setManagedByQueryManager(boolean managedByQueryManager) {
     this.managedByQueryManager = managedByQueryManager;
   }
 
+  @Override
   public boolean hasRemaining() {
     return hasRemaining;
   }
 
+  @Override
   public void setHasRemaining(boolean hasRemaining) {
     this.hasRemaining = hasRemaining;
   }

--- a/server/src/test/java/org/apache/iotdb/db/query/reader/seriesRelated/SeriesReaderWithValueFilterTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/reader/seriesRelated/SeriesReaderWithValueFilterTest.java
@@ -20,13 +20,14 @@
 package org.apache.iotdb.db.query.reader.seriesRelated;
 
 import java.io.IOException;
+import org.apache.iotdb.db.query.reader.ManagedSeriesReader;
 import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 import org.apache.iotdb.tsfile.read.filter.ValueFilter;
 import org.junit.Test;
 
 public class SeriesReaderWithValueFilterTest {
 
-  private SeriesReaderWithoutValueFilter reader;
+  private ManagedSeriesReader reader;
 
   private void init() throws IOException {
     // (100,0),(105,1),(110,0),(115,1),(120,0),...

--- a/server/src/test/java/org/apache/iotdb/db/query/reader/seriesRelated/SeriesReaderWithoutValueFilterTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/query/reader/seriesRelated/SeriesReaderWithoutValueFilterTest.java
@@ -20,13 +20,14 @@
 package org.apache.iotdb.db.query.reader.seriesRelated;
 
 import java.io.IOException;
+import org.apache.iotdb.db.query.reader.ManagedSeriesReader;
 import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 import org.junit.Test;
 
 public class SeriesReaderWithoutValueFilterTest {
 
-  private SeriesReaderWithoutValueFilter reader1;
-  private SeriesReaderWithoutValueFilter reader2;
+  private ManagedSeriesReader reader1;
+  private ManagedSeriesReader reader2;
 
   private void init() throws IOException {
     IBatchReader batchReader1 = new FakedIBatchPoint(100, 1000, 7, 11);


### PR DESCRIPTION
As the distributed version needs a remote implementation of series readers which reads data from another node, abstracting an interface from the currently used reader, which is SeriesReaderWithoutValueFilter, will minimize the code changes.