### PR TITLE
Change measures' data structure in group by device

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -218,7 +218,7 @@ public class PhysicalGenerator {
       for (int i = 0; i < suffixPaths.size(); i++) { // per suffix
         Path suffixPath = suffixPaths.get(i);
         Set<String> deviceSetOfGivenSuffix = new HashSet<>();
-        Set<String> measurementSetOfGivenSuffix = new TreeSet<>();
+        List<String> measurementSetOfGivenSuffix = new ArrayList<>();
 
         for (Path prefixPath : prefixPaths) { // per prefix
           Path fullPath = Path.addPrefixPath(suffixPath, prefixPath);


### PR DESCRIPTION
I changed the measures' data structure when calculating measures to be projected in group by device which was `Treeset` before and led to the result columns' sequence different from timeseries'. And there is no need to use Treeset actually here.