### PR TITLE
Revert "[IOTDB-397]fix gc log collection in start-server.sh scripts"

### DIFF
--- a/docs/Documentation-CHN/UserGuide/3-Server/4-Config Manual.md
+++ b/docs/Documentation-CHN/UserGuide/3-Server/4-Config Manual.md
@@ -405,20 +405,3 @@
 |类型| String |
 |默认值|your principal |
 |改后生效方式|重启服务器生效|
-
-
-## 开启GC日志
-GC日志默认是关闭的。为了性能调优，用户可能会需要手机GC信息。
-若要打开GC日志，则需要在启动IoTDB Server的时候加上"printgc"参数：
-
-```bash
-sbin/start-server.sh printgc
-```
-或者
-
-```bash
-sbin\start-server.bat printgc
-```
-
-GC日志会被存储在`IOTDB_HOME/logs/gc.log`. 至多会存储10个gc.log文件，每个文件最多10MB。
-

--- a/docs/Documentation/UserGuide/3-Server/4-Config Manual.md
+++ b/docs/Documentation/UserGuide/3-Server/4-Config Manual.md
@@ -443,21 +443,3 @@ The detail of each variables are as follows:
 |Type| String |
 |Default|your principal |
 |Effective|After restart system|
-
-## Enable GC log
-GC log is off by default.
-For performance tuning, you may want to collect the GC info. 
-
-To enable GC log, just add a paramenter "printgc" when you start the server.
-
-```bash
-sbin/start-server.sh printgc
-```
-Or
-```bash
-sbin\start-server.bat printgc
-```
-
-GC log is stored at `IOTDB_HOME/logs/gc.log`.
-There will be at most 10 gc.log.* files and each one can reach to 10MB.
-

--- a/server/src/assembly/resources/conf/iotdb-env.bat
+++ b/server/src/assembly/resources/conf/iotdb-env.bat
@@ -54,27 +54,24 @@ for /f "tokens=1-3" %%j in ('java -version 2^>^&1') do (
 	set BIT_VERSION=%%l
 )
 IF "%BIT_VERSION%" == "64-Bit" (
-	rem 64-bit Java
-	echo Detect 64-bit Java, maximum memory allocation pool = 2GB, initial memory allocation pool = 2GB
-	set IOTDB_HEAP_OPTS=-Xmx2G -Xms2G
+  rem 64bit, Maximum heap size
+  set MAX_HEAP_SIZE="2G"
+  rem 64bit, Minimum heap size
+  set HEAP_NEWSIZE="2G"
 ) ELSE (
-	rem 32-bit Java
-	echo Detect 32-bit Java, maximum memory allocation pool = 512MB, initial memory allocation pool = 512MB
-	set IOTDB_HEAP_OPTS=-Xmx512M -Xms512M
+  rem 32bit, Maximum heap size
+  set MAX_HEAP_SIZE="512M"
+  rem 32bit, Minimum heap size
+  set HEAP_NEWSIZE="512M"
 )
+
+@REM MAX_HEAP_SIZE="2G"
+@REM HEAP_NEWSIZE="2G"
+
+set IOTDB_HEAP_OPTS=-Xmx%MAX_HEAP_SIZE% -Xms%HEAP_NEWSIZE%
 
 @REM You can put your env variable here
 @REM set JAVA_HOME=%JAVA_HOME%
 
 :end_config_setting
-@REM set gc log.
-IF "%1" equ "printgc" (
-	IF %JAVA_VERSION% == 8 (
-	    md %IOTDB_HOME%\logs
-		set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -Xloggc:"%IOTDB_HOME%\logs\gc.log" -XX:+PrintGCDateStamps -XX:+PrintGCDetails  -XX:+PrintGCApplicationStoppedTime -XX:+PrintPromotionFailure -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M
-	) ELSE (
-		md %IOTDB_HOME%\logs
-		set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS%  -Xlog:gc=info,heap*=trace,age*=debug,safepoint=info,promotion*=trace:file="%IOTDB_HOME%\logs\gc.log":time,uptime,pid,tid,level:filecount=10,filesize=10485760
-	)
-)
 echo If you want to change this configuration, please check conf/iotdb-env.sh(Unix or OS X, if you use Windows, check conf/iotdb-env.bat).

--- a/server/src/assembly/resources/conf/iotdb-env.sh
+++ b/server/src/assembly/resources/conf/iotdb-env.sh
@@ -128,31 +128,12 @@ fi
 
 version_arr=(${JVM_VERSION//./ })
 
-#GC log path has to be defined here because it needs to access CASSANDRA_HOME
 if [ "${version_arr[0]}" = "1" ] ; then
-    # Java 8
-    MAJOR_VERSION=${version_arr[1]}
-    echo "$IOTDB_JMX_OPTS" | grep -q "^-[X]loggc"
-    if [ "$?" = "1" ] ; then # [X] to prevent ccm from replacing this line
-        # only add -Xlog:gc if it's not mentioned in jvm-server.options file
-        mkdir -p ${IOTDB_HOME}/logs
-        if [ "$#" -ge "1" -a "$1" == "printgc" ]; then
-            IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xloggc:${IOTDB_HOME}/logs/gc.log  -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+PrintPromotionFailure -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M"
-        fi
-    fi
+  MAJOR_VERSION=${version_arr[1]}
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xloggc:${IOTDB_HOME}/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCDetails"
 else
-    #JDK 11 and others
-    MAJOR_VERSION=${version_arr[0]}
-    # See description of https://bugs.openjdk.java.net/browse/JDK-8046148 for details about the syntax
-    # The following is the equivalent to -XX:+PrintGCDetails -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M
-    echo "$IOTDB_JMX_OPTS" | grep -q "^-[X]log:gc"
-    if [ "$?" = "1" ] ; then # [X] to prevent ccm from replacing this line
-        # only add -Xlog:gc if it's not mentioned in jvm-server.options file
-        mkdir -p ${IOTDB_HOME}/logs
-        if [ "$#" -ge "1" -a "$1" == "printgc" ]; then
-            IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xlog:gc=info,heap*=trace,age*=debug,safepoint=info,promotion*=trace:file=${IOTDB_HOME}/logs/gc.log:time,uptime,pid,tid,level:filecount=10,filesize=10485760"
-        fi
-    fi
+  MAJOR_VERSION=${version_arr[0]}
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xloggc:${IOTDB_HOME}/gc.log"
 fi
 
 
@@ -169,10 +150,10 @@ JMX_LOCAL=no
 JMX_PORT="31999"
 
 if [ "JMX_LOCAL" = "yes" ]; then
-	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Diotdb.jmx.local.port=$JMX_PORT"
+	IOTDB_JMX_OPTS="-Diotdb.jmx.local.port=$JMX_PORT"
 	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 else
-	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false"
+	IOTDB_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false"
 	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
 fi
 

--- a/server/src/assembly/resources/conf/iotdb-env.sh
+++ b/server/src/assembly/resources/conf/iotdb-env.sh
@@ -150,7 +150,7 @@ else
         # only add -Xlog:gc if it's not mentioned in jvm-server.options file
         mkdir -p ${IOTDB_HOME}/logs
         if [ "$#" -ge "1" -a "$1" == "printgc" ]; then
-            IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xlog:gc=info,heap*=info,age*=info,safepoint=info,promotion*=info:file=${IOTDB_HOME}/logs/gc.log:time,uptime,pid,tid,level:filecount=10,filesize=10485760"
+            IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xlog:gc=info,heap*=trace,age*=debug,safepoint=info,promotion*=trace:file=${IOTDB_HOME}/logs/gc.log:time,uptime,pid,tid,level:filecount=10,filesize=10485760"
         fi
     fi
 fi

--- a/server/src/assembly/resources/sbin/start-server.bat
+++ b/server/src/assembly/resources/sbin/start-server.bat
@@ -59,7 +59,7 @@ set IOTDB_CONF=%IOTDB_HOME%\conf
 set IOTDB_LOGS=%IOTDB_HOME%\logs
 
 IF EXIST "%IOTDB_CONF%\iotdb-env.bat" (
-    CALL "%IOTDB_CONF%\iotdb-env.bat" %1
+    CALL "%IOTDB_CONF%\iotdb-env.bat"
     ) ELSE (
     echo "can't find %IOTDB_CONF%\iotdb-env.bat"
     )

--- a/server/src/assembly/resources/sbin/start-server.sh
+++ b/server/src/assembly/resources/sbin/start-server.sh
@@ -31,11 +31,7 @@ IOTDB_CONF=${IOTDB_HOME}/conf
 # IOTDB_LOGS=${IOTDB_HOME}/logs
 
 if [ -f "$IOTDB_CONF/iotdb-env.sh" ]; then
-    if [ "$#" -ge "1" -a "$1" == "printgc" ]; then
-      . "$IOTDB_CONF/iotdb-env.sh" "printgc"
-    else
-        . "$IOTDB_CONF/iotdb-env.sh"
-    fi
+    . "$IOTDB_CONF/iotdb-env.sh"
 else
     echo "can't find $IOTDB_CONF/iotdb-env.sh"
 fi


### PR DESCRIPTION
Reverts apache/incubator-iotdb#699

As the PR introduce a new problem: 

[ERROR] test(org.apache.iotdb.db.script.EnvScriptIT)  Time elapsed: 0.142 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[If you want to change this configuration, please check conf/iotdb-env.sh(Unix or OS X, if you use Windows, check conf/iotdb-env.bat)].> but was:<[( was unexpected at this time].>
	at org.apache.iotdb.db.script.EnvScriptIT.testOutput(EnvScriptIT.java:87)
	at org.apache.iotdb.db.script.EnvScriptIT.testStartClientOnWindows(EnvScriptIT.java:59)
	at org.apache.iotdb.db.script.EnvScriptIT.test(EnvScriptIT.java:46) 