### PR TITLE
[IOTDB-422]close files before merge

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1297,6 +1297,7 @@ public class StorageGroupProcessor {
         }
         return;
       }
+      waitForAllCurrentTsFileProcessorsClosed();
       if (unSequenceFileList.isEmpty() || sequenceFileTreeSet.isEmpty()) {
         logger.info("{} no files to be merged", storageGroupName);
         return;


### PR DESCRIPTION
If some unseq file overlaps the unsealed seq file and a merge is triggered, the overlapped data may not be able to be merged into the right file.

To resolve this, the files should be closed before a merge starts.