### PR TITLE
[IOTDB-421]fix that selected seq files for merge are not sorted

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/manage/MergeResource.java
@@ -91,6 +91,9 @@ public class MergeResource {
     for (TsFileSequenceReader sequenceReader : fileReaderCache.values()) {
       sequenceReader.close();
     }
+    for (RestorableTsFileIOWriter writer : fileWriterCache.values()) {
+      writer.close();
+    }
 
     fileReaderCache.clear();
     fileWriterCache.clear();

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
@@ -65,6 +65,7 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
   private Map<TsFileResource, Long> maxSeriesQueryCostMap = new HashMap<>();
 
   List<TsFileResource> selectedUnseqFiles;
+  List<Integer> selectedSeqFileIndices;
   List<TsFileResource> selectedSeqFiles;
 
   private Collection<Integer> tmpSelectedSeqFiles;
@@ -134,6 +135,7 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
 
   void select(boolean useTightBound) throws IOException {
     tmpSelectedSeqFiles = new HashSet<>();
+    selectedSeqFileIndices = new ArrayList<>();
     seqSelected = new boolean[resource.getSeqFiles().size()];
     seqSelectedNum = 0;
     selectedSeqFiles = new ArrayList<>();
@@ -186,7 +188,7 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
         for (Integer seqIdx : tmpSelectedSeqFiles) {
           seqSelected[seqIdx] = true;
           seqSelectedNum++;
-          selectedSeqFiles.add(resource.getSeqFiles().get(seqIdx));
+          selectedSeqFileIndices.add(seqIdx);
         }
         totalCost += newCost;
         logger.debug("Adding a new unseqFile {} and seqFiles {} as candidates, new cost {}, total"
@@ -196,6 +198,10 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
       tmpSelectedSeqFiles.clear();
       unseqIndex++;
       timeConsumption = System.currentTimeMillis() - startTime;
+    }
+    selectedSeqFileIndices.sort(null);
+    for (Integer i : selectedSeqFileIndices) {
+      selectedSeqFiles.add(resource.getSeqFiles().get(i));
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
@@ -154,19 +154,13 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
       // select next unseq files
       TsFileResource unseqFile = resource.getUnseqFiles().get(unseqIndex);
 
-      selectOverlappedSeqFiles(unseqFile);
+      if (seqSelectedNum != resource.getSeqFiles().size() && !UpgradeUtils.isNeedUpgrade(unseqFile)) {
+        selectOverlappedSeqFiles(unseqFile);
+      }
 
       // skip if the unseqFile and tmpSelectedSeqFiles has TsFileResources that need to be upgraded
-      boolean isNeedUpgrade = false;
-      if (UpgradeUtils.isNeedUpgrade(unseqFile)) {
-        isNeedUpgrade = true;
-      }
-      for (Integer seqIdx : tmpSelectedSeqFiles) {
-        if (UpgradeUtils.isNeedUpgrade(resource.getSeqFiles().get(seqIdx))) {
-          isNeedUpgrade = true;
-          break;
-        }
-      }
+      boolean isNeedUpgrade = checkForUpgrade(unseqFile);
+
       if (isNeedUpgrade) {
         tmpSelectedSeqFiles.clear();
         unseqIndex++;
@@ -178,20 +172,8 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
       long newCost = useTightBound ? calculateTightMemoryCost(unseqFile, tmpSelectedSeqFiles,
           startTime, timeLimit) :
           calculateLooseMemoryCost(unseqFile, tmpSelectedSeqFiles, startTime, timeLimit);
+      updateSelectedFiles(newCost, unseqFile);
 
-      if (totalCost + newCost < memoryBudget) {
-        selectedUnseqFiles.add(unseqFile);
-        maxSeqFileCost = tempMaxSeqFileCost;
-
-        for (Integer seqIdx : tmpSelectedSeqFiles) {
-          seqSelected[seqIdx] = true;
-          seqSelectedNum++;
-        }
-        totalCost += newCost;
-        logger.debug("Adding a new unseqFile {} and seqFiles {} as candidates, new cost {}, total"
-                + " cost {}",
-            unseqFile, tmpSelectedSeqFiles, newCost, totalCost);
-      }
       tmpSelectedSeqFiles.clear();
       unseqIndex++;
       timeConsumption = System.currentTimeMillis() - startTime;
@@ -203,10 +185,39 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
     }
   }
 
-  private void selectOverlappedSeqFiles(TsFileResource unseqFile) {
-    if (seqSelectedNum == resource.getSeqFiles().size() || UpgradeUtils.isNeedUpgrade(unseqFile)) {
-      return;
+  private void updateSelectedFiles(long newCost, TsFileResource unseqFile) {
+    if (totalCost + newCost < memoryBudget) {
+      selectedUnseqFiles.add(unseqFile);
+      maxSeqFileCost = tempMaxSeqFileCost;
+
+      for (Integer seqIdx : tmpSelectedSeqFiles) {
+        seqSelected[seqIdx] = true;
+        seqSelectedNum++;
+      }
+      totalCost += newCost;
+      logger.debug("Adding a new unseqFile {} and seqFiles {} as candidates, new cost {}, total"
+              + " cost {}",
+          unseqFile, tmpSelectedSeqFiles, newCost, totalCost);
     }
+  }
+
+  private boolean checkForUpgrade(TsFileResource unseqFile) {
+    // reject the selection if it contains files that should be upgraded
+    boolean isNeedUpgrade = false;
+    if (UpgradeUtils.isNeedUpgrade(unseqFile)) {
+      isNeedUpgrade = true;
+    }
+    for (Integer seqIdx : tmpSelectedSeqFiles) {
+      if (UpgradeUtils.isNeedUpgrade(resource.getSeqFiles().get(seqIdx))) {
+        isNeedUpgrade = true;
+        break;
+      }
+    }
+    return isNeedUpgrade;
+  }
+
+  private void selectOverlappedSeqFiles(TsFileResource unseqFile) {
+
     int tmpSelectedNum = 0;
     for (Entry<String, Long> deviceStartTimeEntry : unseqFile.getStartTimeMap().entrySet()) {
       String deviceId = deviceStartTimeEntry.getKey();
@@ -219,7 +230,7 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
         if (seqSelected[i] || !seqFile.getEndTimeMap().containsKey(deviceId)) {
           continue;
         }
-        Long seqEndTime = seqFile.getEndTimeMap().get(deviceId);
+        long seqEndTime = seqFile.getEndTimeMap().get(deviceId);
         if (unseqEndTime <= seqEndTime) {
           // the unseqFile overlaps current seqFile
           tmpSelectedSeqFiles.add(i);

--- a/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/merge/selector/MaxFileMergeFileSelector.java
@@ -65,7 +65,6 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
   private Map<TsFileResource, Long> maxSeriesQueryCostMap = new HashMap<>();
 
   List<TsFileResource> selectedUnseqFiles;
-  List<Integer> selectedSeqFileIndices;
   List<TsFileResource> selectedSeqFiles;
 
   private Collection<Integer> tmpSelectedSeqFiles;
@@ -135,7 +134,6 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
 
   void select(boolean useTightBound) throws IOException {
     tmpSelectedSeqFiles = new HashSet<>();
-    selectedSeqFileIndices = new ArrayList<>();
     seqSelected = new boolean[resource.getSeqFiles().size()];
     seqSelectedNum = 0;
     selectedSeqFiles = new ArrayList<>();
@@ -188,7 +186,6 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
         for (Integer seqIdx : tmpSelectedSeqFiles) {
           seqSelected[seqIdx] = true;
           seqSelectedNum++;
-          selectedSeqFileIndices.add(seqIdx);
         }
         totalCost += newCost;
         logger.debug("Adding a new unseqFile {} and seqFiles {} as candidates, new cost {}, total"
@@ -199,9 +196,10 @@ public class MaxFileMergeFileSelector implements IMergeFileSelector {
       unseqIndex++;
       timeConsumption = System.currentTimeMillis() - startTime;
     }
-    selectedSeqFileIndices.sort(null);
-    for (Integer i : selectedSeqFileIndices) {
-      selectedSeqFiles.add(resource.getSeqFiles().get(i));
+    for (int i = 0; i < seqSelected.length; i++) {
+      if (seqSelected[i]) {
+        selectedSeqFiles.add(resource.getSeqFiles().get(i));
+      }
     }
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMergeTest.java
@@ -28,7 +28,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
@@ -202,8 +201,7 @@ public class IoTDBMergeTest {
         }
       }
 
-      //statement.execute("MERGE");
-      StorageEngine.getInstance().mergeAll(false);
+      statement.execute("MERGE");
 
       int cnt;
       try (ResultSet resultSet = statement.executeQuery("SELECT * FROM root.mergeTest")) {

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMergeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMergeTest.java
@@ -20,12 +20,16 @@
 package org.apache.iotdb.db.integration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.engine.StorageEngine;
+import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
 import org.junit.After;
@@ -36,18 +40,21 @@ import org.slf4j.LoggerFactory;
 
 public class IoTDBMergeTest {
   private static final Logger logger = LoggerFactory.getLogger(IoTDBMergeTest.class);
-
+  private long prevPartitionInterval;
   @Before
   public void setUp() throws Exception {
     EnvironmentUtils.closeStatMonitor();
 
     EnvironmentUtils.envSetUp();
+    prevPartitionInterval = IoTDBDescriptor.getInstance().getConfig().getPartitionInterval();
+    IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(1);
     Class.forName(Config.JDBC_DRIVER_NAME);
   }
 
   @After
   public void tearDown() throws Exception {
     EnvironmentUtils.cleanEnv();
+    IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(prevPartitionInterval);
   }
 
   @Test
@@ -95,6 +102,131 @@ public class IoTDBMergeTest {
         }
         assertEquals((i + 1) * 10, cnt);
       }
+    }
+  }
+
+  @Test
+  public void testInvertedOrder() {
+    // case: seq data and unseq data are written in reverted order
+    // e.g.: write 1. seq [10, 20), 2. seq [20, 30), 3. unseq [20, 30), 4. unseq [10, 20)
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("SET STORAGE GROUP TO root.mergeTest");
+      for (int i = 1; i <= 3; i++) {
+        try {
+          statement.execute("CREATE TIMESERIES root.mergeTest.s" + i + " WITH DATATYPE=INT64,"
+              + "ENCODING=PLAIN");
+        } catch (SQLException e) {
+          // ignore
+        }
+      }
+
+      for (int j = 10; j < 20; j++) {
+        statement.execute(String.format("INSERT INTO root.mergeTest(timestamp,s1,s2,s3) VALUES (%d,%d,"
+            + "%d,%d)", j, j+1, j+2, j+3));
+      }
+      statement.execute("FLUSH");
+      for (int j = 20; j < 30; j++) {
+        statement.execute(String.format("INSERT INTO root.mergeTest(timestamp,s1,s2,s3) VALUES (%d,%d,"
+            + "%d,%d)", j, j+1, j+2, j+3));
+      }
+      statement.execute("FLUSH");
+
+      for (int j = 20; j < 30; j++) {
+        statement.execute(String.format("INSERT INTO root.mergeTest(timestamp,s1,s2,s3) VALUES (%d,%d,"
+            + "%d,%d)", j, j+10, j+20, j+30));
+      }
+      statement.execute("FLUSH");
+      for (int j = 10; j < 20; j++) {
+        statement.execute(String.format("INSERT INTO root.mergeTest(timestamp,s1,s2,s3) VALUES (%d,%d,"
+            + "%d,%d)", j, j+10, j+20, j+30));
+      }
+      statement.execute("FLUSH");
+
+      statement.execute("MERGE");
+
+      int cnt;
+      try (ResultSet resultSet = statement.executeQuery("SELECT * FROM root.mergeTest")) {
+        cnt = 0;
+        while (resultSet.next()) {
+          long time = resultSet.getLong("Time");
+          long s1 = resultSet.getLong("root.mergeTest.s1");
+          long s2 = resultSet.getLong("root.mergeTest.s2");
+          long s3 = resultSet.getLong("root.mergeTest.s3");
+          assertEquals(cnt + 10, time);
+          assertEquals(time + 10, s1);
+          assertEquals(time + 20, s2);
+          assertEquals(time + 30, s3);
+          cnt++;
+        }
+      }
+      assertEquals(20, cnt);
+    } catch (SQLException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCrossPartition() throws SQLException, StorageEngineException {
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("SET STORAGE GROUP TO root.mergeTest");
+      for (int i = 1; i <= 3; i++) {
+        try {
+          statement.execute("CREATE TIMESERIES root.mergeTest.s" + i + " WITH DATATYPE=INT64,"
+              + "ENCODING=PLAIN");
+        } catch (SQLException e) {
+          // ignore
+        }
+      }
+
+      // file in partition
+      for (int k = 0; k < 7; k++) {
+        // partition num
+        for (int i = 0; i < 10; i++) {
+          // sequence files
+          for (int j = i * 1000 + 300 + k * 100; j <= i * 1000 + 399 + k * 100; j++) {
+            statement.execute(String.format("INSERT INTO root.mergeTest(timestamp,s1,s2,s3) VALUES (%d,%d,"
+                + "%d,%d)", j, j+1, j+2, j+3));
+          }
+          statement.execute("FLUSH");
+          // unsequence files
+          for (int j = i * 1000 + k * 100; j <= i * 1000 + 99 + k * 100; j++) {
+            statement.execute(String.format("INSERT INTO root.mergeTest(timestamp,s1,s2,s3) VALUES (%d,%d,"
+                + "%d,%d)", j, j+10, j+20, j+30));
+          }
+          statement.execute("FLUSH");
+        }
+      }
+
+      //statement.execute("MERGE");
+      StorageEngine.getInstance().mergeAll(false);
+
+      int cnt;
+      try (ResultSet resultSet = statement.executeQuery("SELECT * FROM root.mergeTest")) {
+        cnt = 0;
+        while (resultSet.next()) {
+          long time = resultSet.getLong("Time");
+          long s1 = resultSet.getLong("root.mergeTest.s1");
+          long s2 = resultSet.getLong("root.mergeTest.s2");
+          long s3 = resultSet.getLong("root.mergeTest.s3");
+          assertEquals(cnt, time);
+          if (time % 1000 < 700) {
+            assertEquals(time + 10, s1);
+            assertEquals(time + 20, s2);
+            assertEquals(time + 30, s3);
+          } else {
+            assertEquals(time + 1, s1);
+            assertEquals(time + 2, s2);
+            assertEquals(time + 3, s3);
+          }
+          cnt++;
+        }
+      }
+      assertEquals(10000, cnt);
     }
   }
 }


### PR DESCRIPTION
Because the current MergeFileSelector select merge files by unseq files if the unseq files overlap seq files in a reverted order, the selected seq files will be out of order.
Example:
1. write a seq file A, which ranges [10, 20]
2. write a seq file B, which ranges [20, 30]
3. write an unseq file C, which ranges [20, 30]
4. write an unseq file D, which ranges [10, 20]
C overlaps B and D overlaps and because C is generated before D, as a result, the selected seq files will be [B, A] instead of [A, B], which will make the following merge process write data into a wrong file.

To resolve this, the selected seq files are reordered before starting the actual merge task.