### PR TITLE
[IoTDB-468] Restructure QueryPlan

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/AbstractQueryProcessExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/AbstractQueryProcessExecutor.java
@@ -53,6 +53,8 @@ import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.metadata.MNode;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByDevicePlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByTimePlan;
 import org.apache.iotdb.db.qp.physical.crud.DeletePlan;
 import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
@@ -341,8 +343,8 @@ public abstract class AbstractQueryProcessExecutor implements IQueryProcessExecu
       throws StorageEngineException, QueryFilterOptimizationException, QueryProcessException,
       IOException {
     QueryDataSet queryDataSet;
-    if (queryPlan.isGroupByDevice()) {
-      queryDataSet = new DeviceIterateDataSet(queryPlan, context, queryRouter);
+    if (queryPlan instanceof AlignByDevicePlan) {
+      queryDataSet = new DeviceIterateDataSet((AlignByDevicePlan) queryPlan, context, queryRouter);
     } else {
       if (queryPlan instanceof GroupByPlan) {
         GroupByPlan groupByPlan = (GroupByPlan) queryPlan;
@@ -354,7 +356,7 @@ public abstract class AbstractQueryProcessExecutor implements IQueryProcessExecu
         FillQueryPlan fillQueryPlan = (FillQueryPlan) queryPlan;
         queryDataSet = fill(fillQueryPlan, context);
       } else {
-        queryDataSet = queryRouter.query(queryPlan, context);
+        queryDataSet = queryRouter.query((AlignByTimePlan) queryPlan, context);
       }
     }
     queryDataSet.setRowLimit(queryPlan.getRowLimit());

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AggregationPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AggregationPlan.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.db.qp.logical.Operator;
 
-public class AggregationPlan extends QueryPlan {
+public class AggregationPlan extends AlignByTimePlan {
 
   private List<String> aggregations = new ArrayList<>();
   private List<String> deduplicatedAggregations = new ArrayList<>();

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AlignByDevicePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AlignByDevicePlan.java
@@ -1,0 +1,162 @@
+package org.apache.iotdb.db.qp.physical.crud;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iotdb.db.qp.logical.Operator;
+import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.expression.IExpression;
+
+public class AlignByDevicePlan extends QueryPlan {
+
+  private List<String> measurements; // for group by device sql, e.g. temperature
+  private Map<String, Set<String>> deviceToMeasurementsMap; // for group by device sql, e.g. root.ln.d1 -> temperature
+  private Map<String, TSDataType> dataTypeConsistencyChecker; // for group by device sql, e.g. root.ln.d1.temperature -> Float
+  private Map<String, IExpression> deviceToFilterMap; // for group by device sql
+
+  private GroupByPlan groupByPlan;
+  private FillQueryPlan fillQueryPlan;
+  private AggregationPlan aggregationPlan;
+
+  public AlignByDevicePlan() {
+    super();
+  }
+
+  public AlignByDevicePlan(boolean isQuery, Operator.OperatorType operatorType) {
+    super(isQuery, operatorType);
+  }
+
+  public void setMeasurements(List<String> measurements) {
+    this.measurements = measurements;
+  }
+
+  public List<String> getMeasurements() {
+    return measurements;
+  }
+
+  public void setDeviceToMeasurementsMap(
+      Map<String, Set<String>> deviceToMeasurementsMap) {
+    this.deviceToMeasurementsMap = deviceToMeasurementsMap;
+  }
+
+  public Map<String, Set<String>> getDeviceToMeasurementsMap() {
+    return deviceToMeasurementsMap;
+  }
+
+  public void setDataTypeConsistencyChecker(
+      Map<String, TSDataType> dataTypeConsistencyChecker) {
+    this.dataTypeConsistencyChecker = dataTypeConsistencyChecker;
+  }
+
+  public Map<String, TSDataType> getDataTypeConsistencyChecker() {
+    return dataTypeConsistencyChecker;
+  }
+
+  public Map<String, IExpression> getDeviceToFilterMap() {
+    return deviceToFilterMap;
+  }
+
+  public void setDeviceToFilterMap(Map<String, IExpression> deviceToFilterMap) {
+    this.deviceToFilterMap = deviceToFilterMap;
+  }
+
+  public GroupByPlan getGroupByPlan() {
+    return groupByPlan;
+  }
+
+  public void setGroupByPlan(GroupByPlan groupByPlan) {
+    this.groupByPlan = groupByPlan;
+    this.setOperatorType(OperatorType.GROUPBY);
+  }
+
+  public FillQueryPlan getFillQueryPlan() {
+    return fillQueryPlan;
+  }
+
+  public void setFillQueryPlan(FillQueryPlan fillQueryPlan) {
+    this.fillQueryPlan = fillQueryPlan;
+    this.setOperatorType(OperatorType.FILL);
+  }
+
+  public AggregationPlan getAggregationPlan() {
+    return aggregationPlan;
+  }
+
+  public void setAggregationPlan(AggregationPlan aggregationPlan) {
+    this.aggregationPlan = aggregationPlan;
+    this.setOperatorType(Operator.OperatorType.AGGREGATION);
+  }
+
+  //the measurements that do not exist in any device,
+  // data type is considered as Boolean. The value is considered as null
+  private List<String> notExistMeasurements = new ArrayList<>(); // for group by device sql
+  private List<Integer> positionOfNotExistMeasurements = new ArrayList<>(); // for group by device sql
+  //the measurements that have quotation mark. e.g., "abc",
+  // '11', the data type is considered as String and the value  is considered is the same with measurement name
+  private List<String> constMeasurements = new ArrayList<>(); // for group by device sql
+  private List<Integer> positionOfConstMeasurements = new ArrayList<>(); // for group by device sql
+
+  //we use the following algorithm to reproduce the order of measurements that user writes.
+  //suppose user writes SELECT 'c1',a1,b1,b2,'c2',a2,a3,'c3',b3,a4,a5 FROM ... where for each a_i
+  // column there is at least one device having it, and for each b_i column there is no device
+  // having it, and 'c_i' is a const column.
+  // Then, measurements = {a1, a2, a3, a4, a5};
+  // notExistMeasurements = {b1, b2, b3}, and positionOfNotExistMeasurements = {2, 3, 8};
+  // constMeasurements = {'c1', 'c2', 'c3'}, and positionOfConstMeasurements = {0, 4, 7}.
+  // When to reproduce the order of measurements. The pseudocode is:
+  //<pre>
+  // current = 0;
+  // if (min(notExist, const) <= current) {
+  //  pull min_element(notExist, const);
+  // } else {
+  //  pull from measurements;
+  // }
+  // current ++;
+  //</pre>
+
+  public List<String> getNotExistMeasurements() {
+    return notExistMeasurements;
+  }
+
+  public void setNotExistMeasurements(List<String> notExistMeasurements) {
+    this.notExistMeasurements = notExistMeasurements;
+  }
+
+  public List<Integer> getPositionOfNotExistMeasurements() {
+    return positionOfNotExistMeasurements;
+  }
+
+  public void setPositionOfNotExistMeasurements(
+      List<Integer> positionOfNotExistMeasurements) {
+    this.positionOfNotExistMeasurements = positionOfNotExistMeasurements;
+  }
+
+  public List<String> getConstMeasurements() {
+    return constMeasurements;
+  }
+
+  public void setConstMeasurements(List<String> constMeasurements) {
+    this.constMeasurements = constMeasurements;
+  }
+
+  public List<Integer> getPositionOfConstMeasurements() {
+    return positionOfConstMeasurements;
+  }
+
+  public void setPositionOfConstMeasurements(List<Integer> positionOfConstMeasurements) {
+    this.positionOfConstMeasurements = positionOfConstMeasurements;
+  }
+
+  public void addNotExistMeasurement(int position, String measurement) {
+    notExistMeasurements.add(measurement);
+    positionOfNotExistMeasurements.add(position);
+  }
+
+  public void addConstMeasurement(int position, String measurement) {
+    constMeasurements.add(measurement);
+    positionOfConstMeasurements.add(position);
+  }
+
+}

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AlignByTimePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AlignByTimePlan.java
@@ -1,0 +1,58 @@
+package org.apache.iotdb.db.qp.physical.crud;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.iotdb.db.qp.logical.Operator;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.read.expression.IExpression;
+
+public class AlignByTimePlan extends QueryPlan {
+
+  private List<Path> deduplicatedPaths = new ArrayList<>();
+  private List<TSDataType> deduplicatedDataTypes = new ArrayList<>();
+  private IExpression expression = null;
+
+  public AlignByTimePlan() {
+    super();
+  }
+
+  public AlignByTimePlan(boolean isQuery, Operator.OperatorType operatorType) {
+    super(isQuery, operatorType);
+  }
+
+
+  public IExpression getExpression() {
+    return expression;
+  }
+
+  public void setExpression(IExpression expression) {
+    this.expression = expression;
+  }
+
+  public List<Path> getDeduplicatedPaths() {
+    return deduplicatedPaths;
+  }
+
+  public void addDeduplicatedPaths(Path path) {
+    this.deduplicatedPaths.add(path);
+  }
+
+  public List<TSDataType> getDeduplicatedDataTypes() {
+    return deduplicatedDataTypes;
+  }
+
+  public void addDeduplicatedDataTypes(TSDataType dataType) {
+    this.deduplicatedDataTypes.add(dataType);
+  }
+
+  public void setDeduplicatedPaths(
+      List<Path> deduplicatedPaths) {
+    this.deduplicatedPaths = deduplicatedPaths;
+  }
+
+  public void setDeduplicatedDataTypes(
+      List<TSDataType> deduplicatedDataTypes) {
+    this.deduplicatedDataTypes = deduplicatedDataTypes;
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/FillQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/FillQueryPlan.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.query.fill.IFill;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
-public class FillQueryPlan extends QueryPlan {
+public class FillQueryPlan extends AlignByTimePlan {
 
   private long queryTime;
   private Map<TSDataType, IFill> fillType;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
@@ -18,110 +18,25 @@
  */
 package org.apache.iotdb.db.qp.physical.crud;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.executor.IQueryProcessExecutor;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
-import org.apache.iotdb.tsfile.read.expression.IExpression;
 
 public class QueryPlan extends PhysicalPlan {
 
   private List<Path> paths = null;
   private List<TSDataType> dataTypes = null;
-
-  private List<Path> deduplicatedPaths = new ArrayList<>();
-  private List<TSDataType> deduplicatedDataTypes = new ArrayList<>();
-
-
-  private IExpression expression = null;
+  private Map<Path, TSDataType> dataTypeMapping = new HashMap<>();
+  private boolean isAlign = true; // for disable align sql
 
   private int rowLimit = 0;
   private int rowOffset = 0;
-
-  private boolean isAlign = true; // for disable align sql
-  private boolean isGroupByDevice = false; // for group by device sql
-  private List<String> measurements; // for group by device sql, e.g. temperature
-  private Map<String, Set<String>> measurementsGroupByDevice; // for group by device sql, e.g. root.ln.d1 -> temperature
-  private Map<String, TSDataType> dataTypeConsistencyChecker; // for group by device sql, e.g. root.ln.d1.temperature -> Float
-  private Map<String, IExpression> deviceToFilterMap; // for group by device sql
-  private Map<Path, TSDataType> dataTypeMapping = new HashMap<>(); // for group by device sql
-
-  public List<String> getNotExistMeasurements() {
-    return notExistMeasurements;
-  }
-
-  public void setNotExistMeasurements(List<String> notExistMeasurements) {
-    this.notExistMeasurements = notExistMeasurements;
-  }
-
-  public List<Integer> getPositionOfNotExistMeasurements() {
-    return positionOfNotExistMeasurements;
-  }
-
-  public void setPositionOfNotExistMeasurements(
-      List<Integer> positionOfNotExistMeasurements) {
-    this.positionOfNotExistMeasurements = positionOfNotExistMeasurements;
-  }
-
-  public List<String> getConstMeasurements() {
-    return constMeasurements;
-  }
-
-  public void setConstMeasurements(List<String> constMeasurements) {
-    this.constMeasurements = constMeasurements;
-  }
-
-  public List<Integer> getPositionOfConstMeasurements() {
-    return positionOfConstMeasurements;
-  }
-
-  public void setPositionOfConstMeasurements(List<Integer> positionOfConstMeasurements) {
-    this.positionOfConstMeasurements = positionOfConstMeasurements;
-  }
-
-  //the measurements that do not exist in any device,
-  // data type is considered as Boolean. The value is considered as null
-  private List<String> notExistMeasurements = new ArrayList<>();; // for group by device sql
-  private List<Integer> positionOfNotExistMeasurements = new ArrayList<>(); // for group by device sql
-  //the measurements that have quotation mark. e.g., "abc",
-  // '11', the data type is considered as String and the value  is considered is the same with measurement name
-  private List<String> constMeasurements = new ArrayList<>(); // for group by device sql
-  private List<Integer> positionOfConstMeasurements = new ArrayList<>(); // for group by device sql
-
-  //we use the following algorithm to reproduce the order of measurements that user writes.
-  //suppose user writes SELECT 'c1',a1,b1,b2,'c2',a2,a3,'c3',b3,a4,a5 FROM ... where for each a_i
-  // column there is at least one device having it, and for each b_i column there is no device
-  // having it, and 'c_i' is a const column.
-  // Then, measurements = {a1, a2, a3, a4, a5};
-  // notExistMeasurements = {b1, b2, b3}, and positionOfNotExistMeasurements = {2, 3, 8};
-  // constMeasurements = {'c1', 'c2', 'c3'}, and positionOfConstMeasurements = {0, 4, 7}.
-  // When to reproduce the order of measurements. The pseudocode is:
-  //<pre>
-  // current = 0;
-  // if (min(notExist, const) <= current) {
-  //  pull min_element(notExist, const);
-  // } else {
-  //  pull from measurements;
-  // }
-  // current ++;
-  //</pre>
-
-  public void addNotExistMeasurement(int position, String measurement) {
-    notExistMeasurements.add(measurement);
-    positionOfNotExistMeasurements.add(position);
-  }
-
-  public void addConstMeasurement(int position, String measurement) {
-    constMeasurements.add(measurement);
-    positionOfConstMeasurements.add(position);
-  }
 
   public QueryPlan() {
     super(true);
@@ -130,25 +45,6 @@ public class QueryPlan extends PhysicalPlan {
 
   public QueryPlan(boolean isQuery, Operator.OperatorType operatorType) {
     super(isQuery, operatorType);
-  }
-
-  /**
-   * Check if all paths exist.
-   */
-  public void checkPaths(IQueryProcessExecutor executor) throws QueryProcessException {
-    for (Path path : paths) {
-      if (!executor.judgePathExists(path)) {
-        throw new QueryProcessException("Path doesn't exist: " + path);
-      }
-    }
-  }
-
-  public IExpression getExpression() {
-    return expression;
-  }
-
-  public void setExpression(IExpression expression) {
-    this.expression = expression;
   }
 
   @Override
@@ -168,20 +64,20 @@ public class QueryPlan extends PhysicalPlan {
     this.dataTypes = dataTypes;
   }
 
-  public List<Path> getDeduplicatedPaths() {
-    return deduplicatedPaths;
+  public Map<Path, TSDataType> getDataTypeMapping() {
+    return dataTypeMapping;
   }
 
-  public void addDeduplicatedPaths(Path path) {
-    this.deduplicatedPaths.add(path);
+  public void addTypeMapping(Path path, TSDataType dataType) {
+    dataTypeMapping.put(path, dataType);
   }
 
-  public List<TSDataType> getDeduplicatedDataTypes() {
-    return deduplicatedDataTypes;
+  public boolean isAlign() {
+    return isAlign;
   }
 
-  public void addDeduplicatedDataTypes(TSDataType dataType) {
-    this.deduplicatedDataTypes.add(dataType);
+  public void setAlign(boolean align) {
+    isAlign = align;
   }
 
   public int getRowLimit() {
@@ -204,72 +100,15 @@ public class QueryPlan extends PhysicalPlan {
     return rowLimit > 0;
   }
 
-  public boolean isGroupByDevice() {
-    return isGroupByDevice;
-  }
-
-  public void setGroupByDevice(boolean groupByDevice) {
-    isGroupByDevice = groupByDevice;
-  }
-  
-  public boolean isAlign() {
-    return isAlign;
-  }
-  
-  public void setAlign(boolean align) {
-    isAlign = align;
-  }
-
-  public void setMeasurements(List<String> measurements) {
-    this.measurements = measurements;
-  }
-
-  public List<String> getMeasurements() {
-    return measurements;
-  }
-
-  public void setMeasurementsGroupByDevice(
-      Map<String, Set<String>> measurementsGroupByDevice) {
-    this.measurementsGroupByDevice = measurementsGroupByDevice;
-  }
-
-  public Map<String, Set<String>> getMeasurementsGroupByDevice() {
-    return measurementsGroupByDevice;
-  }
-
-  public void setDataTypeConsistencyChecker(
-      Map<String, TSDataType> dataTypeConsistencyChecker) {
-    this.dataTypeConsistencyChecker = dataTypeConsistencyChecker;
-  }
-
-  public Map<String, TSDataType> getDataTypeConsistencyChecker() {
-    return dataTypeConsistencyChecker;
-  }
-
-  public Map<Path, TSDataType> getDataTypeMapping() {
-    return dataTypeMapping;
-  }
-
-  public void addTypeMapping(Path path, TSDataType dataType) {
-    dataTypeMapping.put(path, dataType);
-  }
-
-  public void setDeduplicatedPaths(
-      List<Path> deduplicatedPaths) {
-    this.deduplicatedPaths = deduplicatedPaths;
-  }
-
-  public void setDeduplicatedDataTypes(
-      List<TSDataType> deduplicatedDataTypes) {
-    this.deduplicatedDataTypes = deduplicatedDataTypes;
-  }
-
-  public Map<String, IExpression> getDeviceToFilterMap() {
-    return deviceToFilterMap;
-  }
-
-  public void setDeviceToFilterMap(Map<String, IExpression> deviceToFilterMap) {
-    this.deviceToFilterMap = deviceToFilterMap;
+  /**
+   * Check if all paths exist.
+   */
+  public void checkPaths(IQueryProcessExecutor executor) throws QueryProcessException {
+    for (Path path : getPaths()) {
+      if (!executor.judgePathExists(path)) {
+        throw new QueryProcessException("Path doesn't exist: " + path);
+      }
+    }
   }
 
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -61,6 +61,8 @@ import org.apache.iotdb.db.qp.logical.sys.ShowTTLOperator;
 import org.apache.iotdb.db.qp.logical.sys.ShowTimeSeriesOperator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByDevicePlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByTimePlan;
 import org.apache.iotdb.db.qp.physical.crud.DeletePlan;
 import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
@@ -249,16 +251,27 @@ public class PhysicalGenerator {
       ((AggregationPlan) queryPlan)
           .setAggregations(queryOperator.getSelectOperator().getAggregations());
     } else {
-      queryPlan = new QueryPlan();
+      queryPlan = new AlignByTimePlan();
     }
+
     if (queryOperator.isGroupByDevice()) {
-      // below is the core realization of GROUP_BY_DEVICE sql logic
+      AlignByDevicePlan alignByDevicePlan = new AlignByDevicePlan();
+      if (queryPlan instanceof GroupByPlan) {
+        alignByDevicePlan.setGroupByPlan((GroupByPlan) queryPlan);
+      } else if (queryPlan instanceof FillQueryPlan) {
+        alignByDevicePlan.setFillQueryPlan((FillQueryPlan) queryPlan);
+      } else if (queryPlan instanceof AggregationPlan) {
+        alignByDevicePlan.setAggregationPlan((AggregationPlan) queryPlan);
+      }
+
+      queryPlan = alignByDevicePlan;
+      // below is the core realization of ALIGN_BY_DEVICE sql logic
       List<Path> prefixPaths = queryOperator.getFromOperator().getPrefixPaths();
       List<Path> suffixPaths = queryOperator.getSelectOperator().getSuffixPaths();
       List<String> originAggregations = queryOperator.getSelectOperator().getAggregations();
 
       List<String> measurements = new ArrayList<>();
-      Map<String, Set<String>> measurementsGroupByDevice = new LinkedHashMap<>();
+      Map<String, Set<String>> deviceToMeasurementsMap = new LinkedHashMap<>();
       // to check the same measure in different devices having the same datatype
       Map<String, TSDataType> dataTypeConsistencyChecker = new HashMap<>();
       List<Path> paths = new ArrayList<>();
@@ -270,8 +283,8 @@ public class PhysicalGenerator {
         Path suffixPath = suffixPaths.get(i);
         Set<String> deviceSetOfGivenSuffix = new HashSet<>();
         Set<String> measurementSetOfGivenSuffix = new LinkedHashSet<>();
-        if(suffixPath.startWith("'") || suffixPath.startWith("\"")){
-          queryPlan.addConstMeasurement(loc++, suffixPath.getMeasurement());
+        if (suffixPath.startWith("'") || suffixPath.startWith("\"")) {
+          ((AlignByDevicePlan) queryPlan).addConstMeasurement(loc++, suffixPath.getMeasurement());
           continue;
         }
 
@@ -285,7 +298,7 @@ public class PhysicalGenerator {
             List<String> actualPaths = executor
                 .getAllMatchedPaths(fullPath.getFullPath());  // remove stars to get actual paths
 
-            if(actualPaths.isEmpty() && originAggregations.isEmpty()){
+            if (actualPaths.isEmpty() && originAggregations.isEmpty()) {
               // for actual non exist path
               nonExistMeasurement.add(fullPath.getMeasurement());
             }
@@ -332,14 +345,14 @@ public class PhysicalGenerator {
               }
 
               // update measurementSetOfGivenSuffix
-              if(measurementSetOfGivenSuffix.add(measurementChecked)){
+              if (measurementSetOfGivenSuffix.add(measurementChecked)) {
                 loc++;
               }
               // update measurementColumnsGroupByDevice
-              if (!measurementsGroupByDevice.containsKey(device)) {
-                measurementsGroupByDevice.put(device, new HashSet<>());
+              if (!deviceToMeasurementsMap.containsKey(device)) {
+                deviceToMeasurementsMap.put(device, new HashSet<>());
               }
-              measurementsGroupByDevice.get(device).add(measurementChecked);
+              deviceToMeasurementsMap.get(device).add(measurementChecked);
               // update paths
               paths.add(path);
             }
@@ -354,8 +367,8 @@ public class PhysicalGenerator {
         }
 
         nonExistMeasurement.removeAll(measurementSetOfGivenSuffix);
-        for(String notExistMeasurementString : nonExistMeasurement){
-          queryPlan.addNotExistMeasurement(loc++, notExistMeasurementString);
+        for (String notExistMeasurementString : nonExistMeasurement) {
+          ((AlignByDevicePlan) queryPlan).addNotExistMeasurement(loc++, notExistMeasurementString);
         }
         // update measurements
         // Note that in the loop of a suffix path, set is used.
@@ -368,8 +381,8 @@ public class PhysicalGenerator {
       }
 
       if (measurements.isEmpty()
-          && queryPlan.getConstMeasurements().isEmpty()
-          && queryPlan.getNotExistMeasurements().isEmpty()) {
+          && ((AlignByDevicePlan) queryPlan).getConstMeasurements().isEmpty()
+          && ((AlignByDevicePlan) queryPlan).getNotExistMeasurements().isEmpty()) {
         throw new QueryProcessException("do not select any existing series");
       }
 
@@ -381,17 +394,17 @@ public class PhysicalGenerator {
       }
 
       // assigns to queryPlan
-      queryPlan.setGroupByDevice(true);
-      queryPlan.setMeasurements(measurements);
-      queryPlan.setMeasurementsGroupByDevice(measurementsGroupByDevice);
-      queryPlan.setDataTypeConsistencyChecker(dataTypeConsistencyChecker);
+      ((AlignByDevicePlan) queryPlan).setMeasurements(measurements);
+      ((AlignByDevicePlan) queryPlan).setDeviceToMeasurementsMap(deviceToMeasurementsMap);
+      ((AlignByDevicePlan) queryPlan).setDataTypeConsistencyChecker(dataTypeConsistencyChecker);
       queryPlan.setPaths(paths);
 
       // get device to filter map
       FilterOperator filterOperator = queryOperator.getFilterOperator();
 
       if (filterOperator != null) {
-        queryPlan.setDeviceToFilterMap(concatFilterByDivice(prefixPaths, filterOperator));
+        ((AlignByDevicePlan) queryPlan)
+            .setDeviceToFilterMap(concatFilterByDivice(prefixPaths, filterOperator));
       }
     } else {
       queryPlan.setAlign(queryOperator.isAlign());
@@ -403,7 +416,7 @@ public class PhysicalGenerator {
 
       if (filterOperator != null) {
         IExpression expression = filterOperator.transformToExpression(executor);
-        queryPlan.setExpression(expression);
+        ((AlignByTimePlan) queryPlan).setExpression(expression);
       }
     }
     generateDataTypes(queryPlan);
@@ -491,7 +504,7 @@ public class PhysicalGenerator {
 
   private void deduplicate(QueryPlan queryPlan) {
     //The deduplication of a GroupByDevice query is done in the dataset
-    if (queryPlan.isGroupByDevice()) {
+    if (queryPlan instanceof AlignByDevicePlan) {
       return;
     }
     if (queryPlan instanceof AggregationPlan) {
@@ -499,17 +512,18 @@ public class PhysicalGenerator {
       deduplicateAggregation(aggregationPlan);
       return;
     }
+    AlignByTimePlan alignByTimePlan = (AlignByTimePlan) queryPlan;
     List<Path> paths = queryPlan.getPaths();
 
     Set<String> columnSet = new HashSet<>();
-    Map<Path, TSDataType> dataTypeMapping = queryPlan.getDataTypeMapping();
+    Map<Path, TSDataType> dataTypeMapping = alignByTimePlan.getDataTypeMapping();
     for (int i = 0; i < paths.size(); i++) {
       Path path = paths.get(i);
       String column = path.toString();
       if (!columnSet.contains(column)) {
         TSDataType seriesType = dataTypeMapping.get(path);
-        queryPlan.addDeduplicatedPaths(path);
-        queryPlan.addDeduplicatedDataTypes(seriesType);
+        alignByTimePlan.addDeduplicatedPaths(path);
+        alignByTimePlan.addDeduplicatedDataTypes(seriesType);
         columnSet.add(column);
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/EngineQueryRouter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/EngineQueryRouter.java
@@ -19,12 +19,15 @@
 
 package org.apache.iotdb.db.query.executor;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByTimePlan;
 import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.groupby.GroupByWithValueFilterDataSet;
 import org.apache.iotdb.db.query.dataset.groupby.GroupByWithoutValueFilterDataSet;
@@ -40,10 +43,6 @@ import org.apache.iotdb.tsfile.read.expression.util.ExpressionOptimizer;
 import org.apache.iotdb.tsfile.read.filter.GroupByFilter;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
 /**
  * Query entrance class of IoTDB query process. All query clause will be transformed to physical
  * plan, physical plan will be executed by EngineQueryRouter.
@@ -51,7 +50,7 @@ import java.util.Map;
 public class EngineQueryRouter implements IEngineQueryRouter {
 
   @Override
-  public QueryDataSet query(QueryPlan queryPlan, QueryContext context)
+  public QueryDataSet query(AlignByTimePlan queryPlan, QueryContext context)
       throws StorageEngineException {
     IExpression expression = queryPlan.getExpression();
     List<Path> deduplicatedPaths = queryPlan.getDeduplicatedPaths();

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/IEngineQueryRouter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/IEngineQueryRouter.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByTimePlan;
 import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.tsfile.exception.filter.QueryFilterOptimizationException;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
@@ -35,7 +35,7 @@ public interface IEngineQueryRouter {
   /**
    * Execute physical plan.
    */
-  QueryDataSet query(QueryPlan queryPlan, QueryContext context) throws StorageEngineException;
+  QueryDataSet query(AlignByTimePlan queryPlan, QueryContext context) throws StorageEngineException;
 
   /**
    * Execute aggregation query.

--- a/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionQueryTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionQueryTest.java
@@ -34,8 +34,8 @@ import org.apache.iotdb.db.exception.path.PathException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.storageGroup.StorageGroupException;
 import org.apache.iotdb.db.metadata.MManager;
+import org.apache.iotdb.db.qp.physical.crud.AlignByTimePlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
 import org.apache.iotdb.db.query.executor.EngineQueryRouter;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
@@ -43,7 +43,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.common.Path;
-import org.apache.iotdb.tsfile.read.expression.QueryExpression;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.iotdb.tsfile.write.record.TSRecord;
 import org.apache.iotdb.tsfile.write.record.datapoint.DoubleDataPoint;
@@ -114,7 +113,7 @@ public class DeletionQueryTest {
     dataTypes.add(TSDataType.valueOf(dataType));
     dataTypes.add(TSDataType.valueOf(dataType));
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet dataSet = router.query(queryPlan, TEST_QUERY_CONTEXT);
@@ -153,7 +152,7 @@ public class DeletionQueryTest {
     dataTypes.add(TSDataType.valueOf(dataType));
     dataTypes.add(TSDataType.valueOf(dataType));
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet dataSet = router.query(queryPlan, TEST_QUERY_CONTEXT);
@@ -202,7 +201,7 @@ public class DeletionQueryTest {
     dataTypes.add(TSDataType.valueOf(dataType));
     dataTypes.add(TSDataType.valueOf(dataType));
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet dataSet = router.query(queryPlan, TEST_QUERY_CONTEXT);
@@ -252,7 +251,7 @@ public class DeletionQueryTest {
     dataTypes.add(TSDataType.valueOf(dataType));
     dataTypes.add(TSDataType.valueOf(dataType));
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet dataSet = router.query(queryPlan, TEST_QUERY_CONTEXT);
@@ -322,7 +321,7 @@ public class DeletionQueryTest {
     dataTypes.add(TSDataType.valueOf(dataType));
     dataTypes.add(TSDataType.valueOf(dataType));
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet dataSet = router.query(queryPlan, TEST_QUERY_CONTEXT);

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByTimePlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.executor.EngineQueryRouter;
@@ -43,7 +43,6 @@ import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.common.RowRecord;
-import org.apache.iotdb.tsfile.read.expression.QueryExpression;
 import org.apache.iotdb.tsfile.read.expression.impl.GlobalTimeExpression;
 import org.apache.iotdb.tsfile.read.expression.impl.SingleSeriesExpression;
 import org.apache.iotdb.tsfile.read.filter.TimeFilter;
@@ -183,7 +182,7 @@ public class IoTDBSequenceDataQueryIT {
 
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet queryDataSet = engineExecutor.query(queryPlan, TEST_QUERY_CONTEXT);
@@ -215,7 +214,7 @@ public class IoTDBSequenceDataQueryIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     queryPlan.setExpression(globalTimeExpression);
@@ -263,7 +262,7 @@ public class IoTDBSequenceDataQueryIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     queryPlan.setExpression(singleSeriesExpression);

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
@@ -35,11 +35,10 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByTimePlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.executor.EngineQueryRouter;
-import org.apache.iotdb.db.service.IoTDB;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
@@ -47,7 +46,6 @@ import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.common.RowRecord;
-import org.apache.iotdb.tsfile.read.expression.QueryExpression;
 import org.apache.iotdb.tsfile.read.expression.impl.SingleSeriesExpression;
 import org.apache.iotdb.tsfile.read.filter.TimeFilter;
 import org.apache.iotdb.tsfile.read.filter.ValueFilter;
@@ -266,7 +264,7 @@ public class IoTDBSeriesReaderIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet queryDataSet = engineExecutor.query(queryPlan, TEST_QUERY_CONTEXT);
@@ -299,7 +297,7 @@ public class IoTDBSeriesReaderIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     queryPlan.setExpression(singleSeriesExpression);
@@ -330,7 +328,7 @@ public class IoTDBSeriesReaderIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(Collections.singletonList(path));
     queryPlan.setExpression(expression);
@@ -366,7 +364,7 @@ public class IoTDBSeriesReaderIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    AlignByTimePlan queryPlan = new AlignByTimePlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     queryPlan.setExpression(singleSeriesExpression);

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
@@ -23,12 +23,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import org.apache.iotdb.db.exception.StartupException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.MManager;
@@ -36,6 +32,7 @@ import org.apache.iotdb.db.qp.QueryProcessor;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByTimePlan;
 import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
@@ -266,7 +263,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 5000";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(TimeFilter.gt(5000L));
     assertEquals(expect.toString(), queryFilter.toString());
   }
@@ -276,7 +273,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 50 and time <= 100";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(
         FilterFactory.and(TimeFilter.gt(50L), TimeFilter.ltEq(100L)));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -288,7 +285,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 50 and time <= 100 or s1 < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(
         FilterFactory.and(TimeFilter.gt(50L), TimeFilter.ltEq(100L)));
     expect = BinaryExpression.or(expect,
@@ -301,7 +298,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException, MetadataException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 50 and time <= 100 and s1 < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
 
     IExpression expect = BinaryExpression.and(
         new SingleSeriesExpression(new Path("root.vehicle.d1.s1"), ValueFilter.lt(10.0)),
@@ -318,7 +315,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 20 or s1 < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         FilterFactory.or(ValueFilter.gt(20.0), ValueFilter.lt(10.0)));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -330,7 +327,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 20 or time < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(
         FilterFactory.or(TimeFilter.gt(20L), TimeFilter.lt(10L)));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -342,7 +339,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 2019-10-16 10:59:00+08:00 - 1d5h or time < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(
         FilterFactory.or(TimeFilter.gt(1571090340000L), TimeFilter.lt(10L)));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -365,7 +362,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 20.5e3";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(20.5e3));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -376,7 +373,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 20.5E-3";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(20.5e-3));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -387,7 +384,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.5";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(2.5));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -398,7 +395,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.5";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(2.5));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -409,7 +406,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -2.5";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(-2.5));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -420,7 +417,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -2.5E-1";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(-2.5e-1));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -431,7 +428,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.5E2";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(2.5e+2));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -442,7 +439,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > .2e2";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(0.2e+2));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -453,7 +450,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > .2";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(0.2));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -464,7 +461,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(2.0));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -475,7 +472,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(2.0));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -486,7 +483,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -2.";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(-2.0));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -497,7 +494,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -.2";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(-0.2));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -508,7 +505,7 @@ public class PhysicalPlanTest {
       throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -.2e2";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(-20.0));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -518,7 +515,7 @@ public class PhysicalPlanTest {
   public void testInOperator() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 in (25, 30, 40)";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     Set<Float> values = new HashSet<>();
     values.add(25.0f);
     values.add(30.0f);
@@ -532,7 +529,7 @@ public class PhysicalPlanTest {
   public void testNotInOperator() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 not in (25, 30, 40)";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((AlignByTimePlan) plan).getExpression();
     Set<Float> values = new HashSet<>();
     values.add(25.0f);
     values.add(30.0f);
@@ -543,7 +540,7 @@ public class PhysicalPlanTest {
 
     sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE not(s1 not in (25, 30, 40))";
     plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    queryFilter = ((QueryPlan) plan).getExpression();
+    queryFilter = ((AlignByTimePlan) plan).getExpression();
     expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.in(values, false));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -653,13 +650,13 @@ public class PhysicalPlanTest {
   @Test
   public void testDeduplicatedPath() throws Exception {
     String sqlStr = "select * from root.sg.d1,root.sg.d1,root.sg.d1";
-    QueryPlan plan = (QueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
+    AlignByTimePlan plan = (AlignByTimePlan) processor.parseSQLToPhysicalPlan(sqlStr);
     Assert.assertEquals(1, plan.getDeduplicatedPaths().size());
     Assert.assertEquals(1, plan.getDeduplicatedDataTypes().size());
     Assert.assertEquals(new Path("root.sg.d1.*"), plan.getDeduplicatedPaths().get(0));
 
     sqlStr = "select count(*) from root.sg.d1,root.sg.d1,root.sg.d1";
-    plan = (QueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
+    plan = (AlignByTimePlan) processor.parseSQLToPhysicalPlan(sqlStr);
     Assert.assertEquals(1, plan.getDeduplicatedPaths().size());
     Assert.assertEquals(1, plan.getDeduplicatedDataTypes().size());
     Assert.assertEquals(new Path("root.sg.d1.*"), plan.getDeduplicatedPaths().get(0));
@@ -673,14 +670,14 @@ public class PhysicalPlanTest {
     manager.addPathToMTree("root.vehicle.d1.s1", "INT64", "PLAIN");
 
     sqlStr = "select s0,s0,s1 from root.vehicle.d0, root.vehicle.d1 group by device";
-    plan = (QueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
+    plan = (AlignByTimePlan) processor.parseSQLToPhysicalPlan(sqlStr);
     Assert.assertEquals(0, plan.getDeduplicatedPaths().size());
     Assert.assertEquals(0, plan.getDeduplicatedDataTypes().size());
     Assert.assertEquals(6, plan.getPaths().size());
     Assert.assertEquals(6, plan.getDataTypes().size());
 
     sqlStr = "select COUNT(s0),COUNT(s0),COUNT(s1) from root.vehicle.d0, root.vehicle.d1 group by device";
-    plan = (QueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
+    plan = (AlignByTimePlan) processor.parseSQLToPhysicalPlan(sqlStr);
     Assert.assertEquals(0, plan.getDeduplicatedPaths().size());
     Assert.assertEquals(0, plan.getDeduplicatedPaths().size());
     Assert.assertEquals(0, plan.getDeduplicatedDataTypes().size());

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
@@ -650,38 +650,15 @@ public class PhysicalPlanTest {
   @Test
   public void testDeduplicatedPath() throws Exception {
     String sqlStr = "select * from root.sg.d1,root.sg.d1,root.sg.d1";
-    AlignByTimePlan plan = (AlignByTimePlan) processor.parseSQLToPhysicalPlan(sqlStr);
-    Assert.assertEquals(1, plan.getDeduplicatedPaths().size());
-    Assert.assertEquals(1, plan.getDeduplicatedDataTypes().size());
-    Assert.assertEquals(new Path("root.sg.d1.*"), plan.getDeduplicatedPaths().get(0));
+    QueryPlan plan = (AlignByTimePlan) processor.parseSQLToPhysicalPlan(sqlStr);
+    Assert.assertEquals(1, ((AlignByTimePlan) plan).getDeduplicatedPaths().size());
+    Assert.assertEquals(1, ((AlignByTimePlan) plan).getDeduplicatedDataTypes().size());
+    Assert.assertEquals(new Path("root.sg.d1.*"), ((AlignByTimePlan) plan).getDeduplicatedPaths().get(0));
 
     sqlStr = "select count(*) from root.sg.d1,root.sg.d1,root.sg.d1";
     plan = (AlignByTimePlan) processor.parseSQLToPhysicalPlan(sqlStr);
-    Assert.assertEquals(1, plan.getDeduplicatedPaths().size());
-    Assert.assertEquals(1, plan.getDeduplicatedDataTypes().size());
-    Assert.assertEquals(new Path("root.sg.d1.*"), plan.getDeduplicatedPaths().get(0));
-
-    //'group by device' is deduplication in DeviceIterateDataSet
-    MManager manager = MManager.getInstance();
-    manager.setStorageGroupToMTree("root.vehicle");
-    manager.addPathToMTree("root.vehicle.d0.s1", "INT64", "PLAIN");
-    manager.addPathToMTree("root.vehicle.d0.s0", "INT64", "PLAIN");
-    manager.addPathToMTree("root.vehicle.d1.s0", "INT64", "PLAIN");
-    manager.addPathToMTree("root.vehicle.d1.s1", "INT64", "PLAIN");
-
-    sqlStr = "select s0,s0,s1 from root.vehicle.d0, root.vehicle.d1 group by device";
-    plan = (AlignByTimePlan) processor.parseSQLToPhysicalPlan(sqlStr);
-    Assert.assertEquals(0, plan.getDeduplicatedPaths().size());
-    Assert.assertEquals(0, plan.getDeduplicatedDataTypes().size());
-    Assert.assertEquals(6, plan.getPaths().size());
-    Assert.assertEquals(6, plan.getDataTypes().size());
-
-    sqlStr = "select COUNT(s0),COUNT(s0),COUNT(s1) from root.vehicle.d0, root.vehicle.d1 group by device";
-    plan = (AlignByTimePlan) processor.parseSQLToPhysicalPlan(sqlStr);
-    Assert.assertEquals(0, plan.getDeduplicatedPaths().size());
-    Assert.assertEquals(0, plan.getDeduplicatedPaths().size());
-    Assert.assertEquals(0, plan.getDeduplicatedDataTypes().size());
-    Assert.assertEquals(6, plan.getPaths().size());
-    Assert.assertEquals(6, plan.getDataTypes().size());
+    Assert.assertEquals(1, ((AlignByTimePlan) plan).getDeduplicatedPaths().size());
+    Assert.assertEquals(1, ((AlignByTimePlan) plan).getDeduplicatedDataTypes().size());
+    Assert.assertEquals(new Path("root.sg.d1.*"), ((AlignByTimePlan) plan).getDeduplicatedPaths().get(0));
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/TestConcatOptimizer.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/TestConcatOptimizer.java
@@ -29,7 +29,7 @@ import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.QueryProcessor;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByTimePlan;
 import org.apache.iotdb.db.qp.strategy.optimizer.ConcatPathOptimizer;
 import org.apache.iotdb.db.qp.utils.MemIntQpExecutor;
 import org.apache.iotdb.tsfile.read.common.Path;
@@ -128,7 +128,7 @@ public class TestConcatOptimizer {
     SingleSeriesExpression seriesExpression = new SingleSeriesExpression(
         new Path("root.laptop.d1.s1"),
         ValueFilter.lt(10));
-    assertEquals(seriesExpression.toString(), ((QueryPlan) plan).getExpression().toString());
+    assertEquals(seriesExpression.toString(), ((AlignByTimePlan) plan).getExpression().toString());
   }
 
 }


### PR DESCRIPTION
The AlignByDevice query ( which is called groupByDevice before ) and general query aligning by time are both storaged in QueryPlan now. However, they invoke different query process bascially, so it's necessary to restructure the QueryPlan and seperate the AlignByDeviceQuery from it. 

The QueryPlan is designed as base class, which has AlignByTimePlan and AlignByDevicePlan as subclasses. This restructure may bring some usage changes, because the general query which uses QueryPlan directly before has to instantiate AlignByTimePlan now.

If you think the design is not friendly for users, welcome to comment.