### PR TITLE
[IoTDB-468] Restructure QueryPlan

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -98,7 +98,7 @@ import org.apache.iotdb.db.qp.physical.sys.ShowPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowTTLPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowTimeSeriesPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
-import org.apache.iotdb.db.query.dataset.DeviceIterateDataSet;
+import org.apache.iotdb.db.query.dataset.AlignByDeviceDataSet;
 import org.apache.iotdb.db.query.dataset.ListDataSet;
 import org.apache.iotdb.db.query.dataset.SingleDataSet;
 import org.apache.iotdb.db.query.executor.IQueryRouter;
@@ -232,7 +232,7 @@ public class PlanExecutor implements IPlanExecutor {
       IOException {
     QueryDataSet queryDataSet;
     if (queryPlan instanceof AlignByDevicePlan) {
-      queryDataSet = new DeviceIterateDataSet((AlignByDevicePlan) queryPlan, context, queryRouter);
+      queryDataSet = new AlignByDeviceDataSet((AlignByDevicePlan) queryPlan, context, queryRouter);
     } else {
       if (queryPlan instanceof GroupByPlan) {
         GroupByPlan groupByPlan = (GroupByPlan) queryPlan;

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -18,7 +18,35 @@
  */
 package org.apache.iotdb.db.qp.executor;
 
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_CHILD_PATHS;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_COLUMN;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_COUNT;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_DEVICES;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_ITEM;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_PARAMETER;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_PRIVILEGE;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_ROLE;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_STORAGE_GROUP;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TIMESERIES;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TIMESERIES_COMPRESSION;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TIMESERIES_DATATYPE;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TIMESERIES_ENCODING;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TTL;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_USER;
+import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_VALUE;
+import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
+
+import java.io.File;
+import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.iotdb.db.auth.AuthException;
 import org.apache.iotdb.db.auth.authorizer.IAuthorizer;
 import org.apache.iotdb.db.auth.authorizer.LocalFileAuthorizer;
@@ -44,14 +72,37 @@ import org.apache.iotdb.db.qp.logical.sys.AuthorOperator;
 import org.apache.iotdb.db.qp.logical.sys.AuthorOperator.AuthorType;
 import org.apache.iotdb.db.qp.logical.sys.PropertyOperator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
-import org.apache.iotdb.db.qp.physical.crud.*;
-import org.apache.iotdb.db.qp.physical.sys.*;
+import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByDevicePlan;
+import org.apache.iotdb.db.qp.physical.crud.BatchInsertPlan;
+import org.apache.iotdb.db.qp.physical.crud.DeletePlan;
+import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
+import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.UpdatePlan;
+import org.apache.iotdb.db.qp.physical.sys.AuthorPlan;
+import org.apache.iotdb.db.qp.physical.sys.CountPlan;
+import org.apache.iotdb.db.qp.physical.sys.CreateTimeSeriesPlan;
+import org.apache.iotdb.db.qp.physical.sys.DataAuthPlan;
+import org.apache.iotdb.db.qp.physical.sys.DeleteStorageGroupPlan;
+import org.apache.iotdb.db.qp.physical.sys.DeleteTimeSeriesPlan;
+import org.apache.iotdb.db.qp.physical.sys.OperateFilePlan;
+import org.apache.iotdb.db.qp.physical.sys.PropertyPlan;
+import org.apache.iotdb.db.qp.physical.sys.SetStorageGroupPlan;
+import org.apache.iotdb.db.qp.physical.sys.SetTTLPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowChildPathsPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowDevicesPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowTTLPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowTimeSeriesPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.DeviceIterateDataSet;
 import org.apache.iotdb.db.query.dataset.ListDataSet;
 import org.apache.iotdb.db.query.dataset.SingleDataSet;
-import org.apache.iotdb.db.query.executor.QueryRouter;
 import org.apache.iotdb.db.query.executor.IQueryRouter;
+import org.apache.iotdb.db.query.executor.QueryRouter;
 import org.apache.iotdb.db.utils.AuthUtils;
 import org.apache.iotdb.db.utils.FileLoaderUtils;
 import org.apache.iotdb.db.utils.TypeInferenceUtils;
@@ -74,13 +125,6 @@ import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
-
-import static org.apache.iotdb.db.conf.IoTDBConstant.*;
-import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
 
 public class PlanExecutor implements IPlanExecutor {
 
@@ -187,8 +231,8 @@ public class PlanExecutor implements IPlanExecutor {
       throws StorageEngineException, QueryFilterOptimizationException, QueryProcessException,
       IOException {
     QueryDataSet queryDataSet;
-    if (queryPlan.isGroupByDevice()) {
-      queryDataSet = new DeviceIterateDataSet(queryPlan, context, queryRouter);
+    if (queryPlan instanceof AlignByDevicePlan) {
+      queryDataSet = new DeviceIterateDataSet((AlignByDevicePlan) queryPlan, context, queryRouter);
     } else {
       if (queryPlan instanceof GroupByPlan) {
         GroupByPlan groupByPlan = (GroupByPlan) queryPlan;
@@ -200,7 +244,7 @@ public class PlanExecutor implements IPlanExecutor {
         FillQueryPlan fillQueryPlan = (FillQueryPlan) queryPlan;
         queryDataSet = queryRouter.fill(fillQueryPlan, context);
       } else {
-        queryDataSet = queryRouter.rawDataQuery(queryPlan, context);
+        queryDataSet = queryRouter.rawDataQuery((RawDataQueryPlan) queryPlan, context);
       }
     }
     queryDataSet.setRowLimit(queryPlan.getRowLimit());

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/QueryOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/QueryOperator.java
@@ -45,8 +45,8 @@ public class QueryOperator extends SFWOperator {
   private int seriesLimit = 0;
   private int seriesOffset = 0;
 
-  private boolean isGroupByDevice = false;
-  private boolean isAlign = true;
+  private boolean isAlignByDevice = false;
+  private boolean isAlignByTime = true;
 
   public QueryOperator(int tokenIntType) {
     super(tokenIntType);
@@ -149,19 +149,19 @@ public class QueryOperator extends SFWOperator {
     this.slidingStep = slidingStep;
   }
 
-  public boolean isGroupByDevice() {
-    return isGroupByDevice;
+  public boolean isAlignByDevice() {
+    return isAlignByDevice;
   }
 
-  public void setGroupByDevice(boolean isGroupByDevice) {
-    this.isGroupByDevice = isGroupByDevice;
+  public void setAlignByDevice(boolean isAlignByDevice) {
+    this.isAlignByDevice = isAlignByDevice;
   }
 
-  public boolean isAlign() {
-    return isAlign;
+  public boolean isAlignByTime() {
+    return isAlignByTime;
   }
 
-  public void setAlign(boolean align) {
-    isAlign = align;
+  public void setAlignByTime(boolean isAlignByTime) {
+    this.isAlignByTime = isAlignByTime;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AggregationPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AggregationPlan.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.db.qp.logical.Operator;
 
-public class AggregationPlan extends QueryPlan {
+public class AggregationPlan extends RawDataQueryPlan {
 
   private List<String> aggregations = new ArrayList<>();
   private List<String> deduplicatedAggregations = new ArrayList<>();

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AlignByDevicePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AlignByDevicePlan.java
@@ -52,10 +52,6 @@ public class AlignByDevicePlan extends QueryPlan {
     super();
   }
 
-  public AlignByDevicePlan(boolean isQuery, Operator.OperatorType operatorType) {
-    super(isQuery, operatorType);
-  }
-
   public void setMeasurements(List<String> measurements) {
     this.measurements = measurements;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AlignByDevicePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AlignByDevicePlan.java
@@ -29,14 +29,24 @@ import org.apache.iotdb.tsfile.read.expression.IExpression;
 
 public class AlignByDevicePlan extends QueryPlan {
 
-  private List<String> measurements; // for group by device sql, e.g. temperature
-  private Map<String, Set<String>> deviceToMeasurementsMap; // for group by device sql, e.g. root.ln.d1 -> temperature
-  private Map<String, TSDataType> dataTypeConsistencyChecker; // for group by device sql, e.g. root.ln.d1.temperature -> Float
-  private Map<String, IExpression> deviceToFilterMap; // for group by device sql
+  private List<String> measurements; // e.g. temperature, status, speed
+  private Map<String, Set<String>> deviceToMeasurementsMap; // e.g. root.ln.d1 -> temperature
+  // to check data type consistency for the same name sensor of different devices
+  private Map<String, TSDataType> dataTypeConsistencyChecker;
+  private Map<String, IExpression> deviceToFilterMap;
 
   private GroupByPlan groupByPlan;
   private FillQueryPlan fillQueryPlan;
   private AggregationPlan aggregationPlan;
+
+  // the measurements that do not exist in any device,
+  // data type is considered as Boolean. The value is considered as null
+  private List<String> notExistMeasurements = new ArrayList<>();
+  private List<Integer> positionOfNotExistMeasurements = new ArrayList<>();
+  // the measurements that have quotation mark. e.g. "abc",
+  // '11', the data type is considered as String and the value is considered is the same with measurement name
+  private List<String> constMeasurements = new ArrayList<>();
+  private List<Integer> positionOfConstMeasurements = new ArrayList<>();
 
   public AlignByDevicePlan() {
     super();
@@ -107,16 +117,6 @@ public class AlignByDevicePlan extends QueryPlan {
     this.setOperatorType(Operator.OperatorType.AGGREGATION);
   }
 
-  //the measurements that do not exist in any device,
-  // data type is considered as Boolean. The value is considered as null
-  private List<String> notExistMeasurements = new ArrayList<>();
-  ; // for group by device sql
-  private List<Integer> positionOfNotExistMeasurements = new ArrayList<>(); // for group by device sql
-  //the measurements that have quotation mark. e.g., "abc",
-  // '11', the data type is considered as String and the value  is considered is the same with measurement name
-  private List<String> constMeasurements = new ArrayList<>(); // for group by device sql
-  private List<Integer> positionOfConstMeasurements = new ArrayList<>(); // for group by device sql
-
   //we use the following algorithm to reproduce the order of measurements that user writes.
   //suppose user writes SELECT 'c1',a1,b1,b2,'c2',a2,a3,'c3',b3,a4,a5 FROM ... where for each a_i
   // column there is at least one device having it, and for each b_i column there is no device
@@ -177,5 +177,4 @@ public class AlignByDevicePlan extends QueryPlan {
   public void setPositionOfConstMeasurements(List<Integer> positionOfConstMeasurements) {
     this.positionOfConstMeasurements = positionOfConstMeasurements;
   }
-
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AlignByDevicePlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/AlignByDevicePlan.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.qp.physical.crud;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iotdb.db.qp.logical.Operator;
+import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.expression.IExpression;
+
+public class AlignByDevicePlan extends QueryPlan {
+
+  private List<String> measurements; // for group by device sql, e.g. temperature
+  private Map<String, Set<String>> deviceToMeasurementsMap; // for group by device sql, e.g. root.ln.d1 -> temperature
+  private Map<String, TSDataType> dataTypeConsistencyChecker; // for group by device sql, e.g. root.ln.d1.temperature -> Float
+  private Map<String, IExpression> deviceToFilterMap; // for group by device sql
+
+  private GroupByPlan groupByPlan;
+  private FillQueryPlan fillQueryPlan;
+  private AggregationPlan aggregationPlan;
+
+  public AlignByDevicePlan() {
+    super();
+  }
+
+  public AlignByDevicePlan(boolean isQuery, Operator.OperatorType operatorType) {
+    super(isQuery, operatorType);
+  }
+
+  public void setMeasurements(List<String> measurements) {
+    this.measurements = measurements;
+  }
+
+  public List<String> getMeasurements() {
+    return measurements;
+  }
+
+  public void setMeasurementsGroupByDevice(
+      Map<String, Set<String>> deviceToMeasurementsMap) {
+    this.deviceToMeasurementsMap = deviceToMeasurementsMap;
+  }
+
+  public Map<String, Set<String>> getDeviceToMeasurementsMap() {
+    return deviceToMeasurementsMap;
+  }
+
+  public void setDataTypeConsistencyChecker(
+      Map<String, TSDataType> dataTypeConsistencyChecker) {
+    this.dataTypeConsistencyChecker = dataTypeConsistencyChecker;
+  }
+
+  public Map<String, TSDataType> getDataTypeConsistencyChecker() {
+    return dataTypeConsistencyChecker;
+  }
+
+  public Map<String, IExpression> getDeviceToFilterMap() {
+    return deviceToFilterMap;
+  }
+
+  public void setDeviceToFilterMap(Map<String, IExpression> deviceToFilterMap) {
+    this.deviceToFilterMap = deviceToFilterMap;
+  }
+
+  public GroupByPlan getGroupByPlan() {
+    return groupByPlan;
+  }
+
+  public void setGroupByPlan(GroupByPlan groupByPlan) {
+    this.groupByPlan = groupByPlan;
+    this.setOperatorType(OperatorType.GROUPBY);
+  }
+
+  public FillQueryPlan getFillQueryPlan() {
+    return fillQueryPlan;
+  }
+
+  public void setFillQueryPlan(FillQueryPlan fillQueryPlan) {
+    this.fillQueryPlan = fillQueryPlan;
+    this.setOperatorType(OperatorType.FILL);
+  }
+
+  public AggregationPlan getAggregationPlan() {
+    return aggregationPlan;
+  }
+
+  public void setAggregationPlan(AggregationPlan aggregationPlan) {
+    this.aggregationPlan = aggregationPlan;
+    this.setOperatorType(Operator.OperatorType.AGGREGATION);
+  }
+
+  //the measurements that do not exist in any device,
+  // data type is considered as Boolean. The value is considered as null
+  private List<String> notExistMeasurements = new ArrayList<>();
+  ; // for group by device sql
+  private List<Integer> positionOfNotExistMeasurements = new ArrayList<>(); // for group by device sql
+  //the measurements that have quotation mark. e.g., "abc",
+  // '11', the data type is considered as String and the value  is considered is the same with measurement name
+  private List<String> constMeasurements = new ArrayList<>(); // for group by device sql
+  private List<Integer> positionOfConstMeasurements = new ArrayList<>(); // for group by device sql
+
+  //we use the following algorithm to reproduce the order of measurements that user writes.
+  //suppose user writes SELECT 'c1',a1,b1,b2,'c2',a2,a3,'c3',b3,a4,a5 FROM ... where for each a_i
+  // column there is at least one device having it, and for each b_i column there is no device
+  // having it, and 'c_i' is a const column.
+  // Then, measurements = {a1, a2, a3, a4, a5};
+  // notExistMeasurements = {b1, b2, b3}, and positionOfNotExistMeasurements = {2, 3, 8};
+  // constMeasurements = {'c1', 'c2', 'c3'}, and positionOfConstMeasurements = {0, 4, 7}.
+  // When to reproduce the order of measurements. The pseudocode is:
+  //<pre>
+  // current = 0;
+  // if (min(notExist, const) <= current) {
+  //  pull min_element(notExist, const);
+  // } else {
+  //  pull from measurements;
+  // }
+  // current ++;
+  //</pre>
+
+  public void addNotExistMeasurement(int position, String measurement) {
+    notExistMeasurements.add(measurement);
+    positionOfNotExistMeasurements.add(position);
+  }
+
+  public void addConstMeasurement(int position, String measurement) {
+    constMeasurements.add(measurement);
+    positionOfConstMeasurements.add(position);
+  }
+
+  public List<String> getNotExistMeasurements() {
+    return notExistMeasurements;
+  }
+
+  public void setNotExistMeasurements(List<String> notExistMeasurements) {
+    this.notExistMeasurements = notExistMeasurements;
+  }
+
+  public List<Integer> getPositionOfNotExistMeasurements() {
+    return positionOfNotExistMeasurements;
+  }
+
+  public void setPositionOfNotExistMeasurements(
+      List<Integer> positionOfNotExistMeasurements) {
+    this.positionOfNotExistMeasurements = positionOfNotExistMeasurements;
+  }
+
+  public List<String> getConstMeasurements() {
+    return constMeasurements;
+  }
+
+  public void setConstMeasurements(List<String> constMeasurements) {
+    this.constMeasurements = constMeasurements;
+  }
+
+  public List<Integer> getPositionOfConstMeasurements() {
+    return positionOfConstMeasurements;
+  }
+
+  public void setPositionOfConstMeasurements(List<Integer> positionOfConstMeasurements) {
+    this.positionOfConstMeasurements = positionOfConstMeasurements;
+  }
+
+}

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/FillQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/FillQueryPlan.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.query.fill.IFill;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
-public class FillQueryPlan extends QueryPlan {
+public class FillQueryPlan extends RawDataQueryPlan {
 
   private long queryTime;
   private Map<TSDataType, IFill> fillType;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/GroupByPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/GroupByPlan.java
@@ -20,8 +20,7 @@ package org.apache.iotdb.db.qp.physical.crud;
 
 import org.apache.iotdb.db.qp.logical.Operator;
 
-public class
-GroupByPlan extends AggregationPlan {
+public class GroupByPlan extends AggregationPlan {
 
   // [startTime, endTime)
   private long startTime;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/GroupByPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/GroupByPlan.java
@@ -20,7 +20,8 @@ package org.apache.iotdb.db.qp.physical.crud;
 
 import org.apache.iotdb.db.qp.logical.Operator;
 
-public class GroupByPlan extends AggregationPlan {
+public class
+GroupByPlan extends AggregationPlan {
 
   // [startTime, endTime)
   private long startTime;

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/QueryPlan.java
@@ -18,108 +18,23 @@
  */
 package org.apache.iotdb.db.qp.physical.crud;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
-import org.apache.iotdb.tsfile.read.expression.IExpression;
 
 public class QueryPlan extends PhysicalPlan {
 
   private List<Path> paths = null;
   private List<TSDataType> dataTypes = null;
-
-  private List<Path> deduplicatedPaths = new ArrayList<>();
-  private List<TSDataType> deduplicatedDataTypes = new ArrayList<>();
-
-  private IExpression expression = null;
+  private Map<Path, TSDataType> dataTypeMapping = new HashMap<>();
+  private boolean alignByTime = true; // for disable align sql
 
   private int rowLimit = 0;
   private int rowOffset = 0;
-
-  private boolean alignByTime = true; // for disable align sql
-
-  private boolean isGroupByDevice = false; // for group by device sql
-  private List<String> measurements; // for group by device sql, e.g. temperature
-  private Map<String, Set<String>> measurementsGroupByDevice; // for group by device sql, e.g. root.ln.d1 -> temperature
-  private Map<String, TSDataType> dataTypeConsistencyChecker; // for group by device sql, e.g. root.ln.d1.temperature -> Float
-  private Map<String, IExpression> deviceToFilterMap; // for group by device sql
-  private Map<Path, TSDataType> dataTypeMapping = new HashMap<>(); // for group by device sql
-
-  public List<String> getNotExistMeasurements() {
-    return notExistMeasurements;
-  }
-
-  public void setNotExistMeasurements(List<String> notExistMeasurements) {
-    this.notExistMeasurements = notExistMeasurements;
-  }
-
-  public List<Integer> getPositionOfNotExistMeasurements() {
-    return positionOfNotExistMeasurements;
-  }
-
-  public void setPositionOfNotExistMeasurements(
-      List<Integer> positionOfNotExistMeasurements) {
-    this.positionOfNotExistMeasurements = positionOfNotExistMeasurements;
-  }
-
-  public List<String> getConstMeasurements() {
-    return constMeasurements;
-  }
-
-  public void setConstMeasurements(List<String> constMeasurements) {
-    this.constMeasurements = constMeasurements;
-  }
-
-  public List<Integer> getPositionOfConstMeasurements() {
-    return positionOfConstMeasurements;
-  }
-
-  public void setPositionOfConstMeasurements(List<Integer> positionOfConstMeasurements) {
-    this.positionOfConstMeasurements = positionOfConstMeasurements;
-  }
-
-  //the measurements that do not exist in any device,
-  // data type is considered as Boolean. The value is considered as null
-  private List<String> notExistMeasurements = new ArrayList<>();; // for group by device sql
-  private List<Integer> positionOfNotExistMeasurements = new ArrayList<>(); // for group by device sql
-  //the measurements that have quotation mark. e.g., "abc",
-  // '11', the data type is considered as String and the value  is considered is the same with measurement name
-  private List<String> constMeasurements = new ArrayList<>(); // for group by device sql
-  private List<Integer> positionOfConstMeasurements = new ArrayList<>(); // for group by device sql
-
-  //we use the following algorithm to reproduce the order of measurements that user writes.
-  //suppose user writes SELECT 'c1',a1,b1,b2,'c2',a2,a3,'c3',b3,a4,a5 FROM ... where for each a_i
-  // column there is at least one device having it, and for each b_i column there is no device
-  // having it, and 'c_i' is a const column.
-  // Then, measurements = {a1, a2, a3, a4, a5};
-  // notExistMeasurements = {b1, b2, b3}, and positionOfNotExistMeasurements = {2, 3, 8};
-  // constMeasurements = {'c1', 'c2', 'c3'}, and positionOfConstMeasurements = {0, 4, 7}.
-  // When to reproduce the order of measurements. The pseudocode is:
-  //<pre>
-  // current = 0;
-  // if (min(notExist, const) <= current) {
-  //  pull min_element(notExist, const);
-  // } else {
-  //  pull from measurements;
-  // }
-  // current ++;
-  //</pre>
-
-  public void addNotExistMeasurement(int position, String measurement) {
-    notExistMeasurements.add(measurement);
-    positionOfNotExistMeasurements.add(position);
-  }
-
-  public void addConstMeasurement(int position, String measurement) {
-    constMeasurements.add(measurement);
-    positionOfConstMeasurements.add(position);
-  }
 
   public QueryPlan() {
     super(true);
@@ -128,14 +43,6 @@ public class QueryPlan extends PhysicalPlan {
 
   public QueryPlan(boolean isQuery, Operator.OperatorType operatorType) {
     super(isQuery, operatorType);
-  }
-
-  public IExpression getExpression() {
-    return expression;
-  }
-
-  public void setExpression(IExpression expression) {
-    this.expression = expression;
   }
 
   @Override
@@ -153,22 +60,6 @@ public class QueryPlan extends PhysicalPlan {
 
   public void setDataTypes(List<TSDataType> dataTypes) {
     this.dataTypes = dataTypes;
-  }
-
-  public List<Path> getDeduplicatedPaths() {
-    return deduplicatedPaths;
-  }
-
-  public void addDeduplicatedPaths(Path path) {
-    this.deduplicatedPaths.add(path);
-  }
-
-  public List<TSDataType> getDeduplicatedDataTypes() {
-    return deduplicatedDataTypes;
-  }
-
-  public void addDeduplicatedDataTypes(TSDataType dataType) {
-    this.deduplicatedDataTypes.add(dataType);
   }
 
   public int getRowLimit() {
@@ -191,46 +82,12 @@ public class QueryPlan extends PhysicalPlan {
     return rowLimit > 0;
   }
 
-  public boolean isGroupByDevice() {
-    return isGroupByDevice;
-  }
-
-  public void setGroupByDevice(boolean groupByDevice) {
-    isGroupByDevice = groupByDevice;
-  }
-  
   public boolean isAlignByTime() {
     return alignByTime;
   }
-  
+
   public void setAlignByTime(boolean align) {
     alignByTime = align;
-  }
-
-  public void setMeasurements(List<String> measurements) {
-    this.measurements = measurements;
-  }
-
-  public List<String> getMeasurements() {
-    return measurements;
-  }
-
-  public void setMeasurementsGroupByDevice(
-      Map<String, Set<String>> measurementsGroupByDevice) {
-    this.measurementsGroupByDevice = measurementsGroupByDevice;
-  }
-
-  public Map<String, Set<String>> getMeasurementsGroupByDevice() {
-    return measurementsGroupByDevice;
-  }
-
-  public void setDataTypeConsistencyChecker(
-      Map<String, TSDataType> dataTypeConsistencyChecker) {
-    this.dataTypeConsistencyChecker = dataTypeConsistencyChecker;
-  }
-
-  public Map<String, TSDataType> getDataTypeConsistencyChecker() {
-    return dataTypeConsistencyChecker;
   }
 
   public Map<Path, TSDataType> getDataTypeMapping() {
@@ -239,23 +96,6 @@ public class QueryPlan extends PhysicalPlan {
 
   public void addTypeMapping(Path path, TSDataType dataType) {
     dataTypeMapping.put(path, dataType);
-  }
-
-  public void setDeduplicatedPaths(
-      List<Path> deduplicatedPaths) {
-    this.deduplicatedPaths = deduplicatedPaths;
-  }
-
-  public void setDeduplicatedDataTypes(List<TSDataType> deduplicatedDataTypes) {
-    this.deduplicatedDataTypes = deduplicatedDataTypes;
-  }
-
-  public Map<String, IExpression> getDeviceToFilterMap() {
-    return deviceToFilterMap;
-  }
-
-  public void setDeviceToFilterMap(Map<String, IExpression> deviceToFilterMap) {
-    this.deviceToFilterMap = deviceToFilterMap;
   }
 
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/RawDataQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/RawDataQueryPlan.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.qp.physical.crud;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.iotdb.db.qp.logical.Operator;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.read.expression.IExpression;
+
+public class RawDataQueryPlan extends QueryPlan {
+
+  private List<Path> deduplicatedPaths = new ArrayList<>();
+  private List<TSDataType> deduplicatedDataTypes = new ArrayList<>();
+  private IExpression expression = null;
+
+  public RawDataQueryPlan() {
+    super();
+  }
+
+  public RawDataQueryPlan(boolean isQuery, Operator.OperatorType operatorType) {
+    super(isQuery, operatorType);
+  }
+
+  public IExpression getExpression() {
+    return expression;
+  }
+
+  public void setExpression(IExpression expression) {
+    this.expression = expression;
+  }
+
+  public List<Path> getDeduplicatedPaths() {
+    return deduplicatedPaths;
+  }
+
+  public void addDeduplicatedPaths(Path path) {
+    this.deduplicatedPaths.add(path);
+  }
+
+  public void setDeduplicatedPaths(
+      List<Path> deduplicatedPaths) {
+    this.deduplicatedPaths = deduplicatedPaths;
+  }
+
+  public List<TSDataType> getDeduplicatedDataTypes() {
+    return deduplicatedDataTypes;
+  }
+
+  public void addDeduplicatedDataTypes(TSDataType dataType) {
+    this.deduplicatedDataTypes.add(dataType);
+  }
+
+  public void setDeduplicatedDataTypes(
+      List<TSDataType> deduplicatedDataTypes) {
+    this.deduplicatedDataTypes = deduplicatedDataTypes;
+  }
+
+}

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -727,7 +727,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   @Override
   public void enterDisableAlign(SqlBaseParser.DisableAlignContext ctx) {
     super.enterDisableAlign(ctx);
-    queryOp.setAlign(false);
+    queryOp.setAlignByTime(false);
   }
 
   @Override
@@ -810,7 +810,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   @Override
   public void enterGroupByDeviceClause(GroupByDeviceClauseContext ctx) {
     super.enterGroupByDeviceClause(ctx);
-    queryOp.setGroupByDevice(true);
+    queryOp.setAlignByDevice(true);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -246,7 +246,7 @@ public class PhysicalGenerator {
     } else {
       queryPlan = new RawDataQueryPlan();
     }
-    if (queryOperator.isGroupByDevice()) {
+    if (queryOperator.isAlignByDevice()) {
       // below is the core realization of ALIGN_BY_DEVICE sql logic
       AlignByDevicePlan alignByDevicePlan = new AlignByDevicePlan();
       if (queryPlan instanceof GroupByPlan) {
@@ -399,7 +399,7 @@ public class PhysicalGenerator {
             .setDeviceToFilterMap(concatFilterByDivice(prefixPaths, filterOperator));
       }
     } else {
-      queryPlan.setAlignByTime(queryOperator.isAlign());
+      queryPlan.setAlignByTime(queryOperator.isAlignByTime());
       List<Path> paths = queryOperator.getSelectedPaths();
       queryPlan.setPaths(paths);
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -282,8 +282,6 @@ public class PhysicalGenerator {
         Set<String> nonExistMeasurement = new HashSet<>();
         for (Path prefixPath : prefixPaths) { // per prefix
           Path fullPath = Path.addPrefixPath(suffixPath, prefixPath);
-          // for constant path
-
           Set<String> tmpDeviceSet = new HashSet<>();
           try {
             List<String> actualPaths = MManager.getInstance()

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -239,7 +239,7 @@ public class PhysicalGenerator {
       long time = Long.parseLong(((BasicFunctionOperator) timeFilter).getValue());
       ((FillQueryPlan) queryPlan).setQueryTime(time);
       ((FillQueryPlan) queryPlan).setFillType(queryOperator.getFillTypes());
-    } else if (queryOperator.hasAggregation()) { // ordinary query
+    } else if (queryOperator.hasAggregation()) {
       queryPlan = new AggregationPlan();
       ((AggregationPlan) queryPlan)
           .setAggregations(queryOperator.getSelectOperator().getAggregations());

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
@@ -77,7 +77,7 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
 
     boolean isGroupByDevice = false;
     if (operator instanceof QueryOperator) {
-      if (!((QueryOperator) operator).isGroupByDevice()) {
+      if (!((QueryOperator) operator).isAlignByDevice()) {
         concatSelect(prefixPaths, select); // concat and remove star
 
         if (((QueryOperator) operator).hasSlimit()) {

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/AlignByDeviceDataSet.java
@@ -44,9 +44,9 @@ import org.apache.iotdb.tsfile.utils.Binary;
 
 
 /**
- * This QueryDataSet is used for GROUP_BY_DEVICE query result.
+ * This QueryDataSet is used for ALIGN_BY_DEVICE query result.
  */
-public class DeviceIterateDataSet extends QueryDataSet {
+public class AlignByDeviceDataSet extends QueryDataSet {
 
   private DataSetType dataSetType;
   private IQueryRouter queryRouter;
@@ -69,6 +69,7 @@ public class DeviceIterateDataSet extends QueryDataSet {
   private GroupByPlan groupByPlan;
   private FillQueryPlan fillQueryPlan;
   private AggregationPlan aggregationPlan;
+  private RawDataQueryPlan rawDataQueryPlan;
 
   private boolean curDataSetInitialized;
   private Iterator<String> deviceIterator;
@@ -77,7 +78,7 @@ public class DeviceIterateDataSet extends QueryDataSet {
   private int[] currentColumnMapRelation;
   private Map<Path, TSDataType> tsDataTypeMap;
 
-  public DeviceIterateDataSet(AlignByDevicePlan alignByDevicePlan, QueryContext context,
+  public AlignByDeviceDataSet(AlignByDevicePlan alignByDevicePlan, QueryContext context,
       IQueryRouter queryRouter) {
     super(null, alignByDevicePlan.getDataTypes());
 
@@ -108,6 +109,7 @@ public class DeviceIterateDataSet extends QueryDataSet {
         break;
       default:
         this.dataSetType = DataSetType.QUERY;
+        this.rawDataQueryPlan = new RawDataQueryPlan();
     }
 
     this.curDataSetInitialized = false;
@@ -191,11 +193,10 @@ public class DeviceIterateDataSet extends QueryDataSet {
             currentDataSet = queryRouter.fill(fillQueryPlan, context);
             break;
           case QUERY:
-            RawDataQueryPlan queryPlan = new RawDataQueryPlan();
-            queryPlan.setDeduplicatedPaths(executePaths);
-            queryPlan.setDeduplicatedDataTypes(tsDataTypes);
-            queryPlan.setExpression(expression);
-            currentDataSet = queryRouter.rawDataQuery(queryPlan, context);
+            rawDataQueryPlan.setDeduplicatedPaths(executePaths);
+            rawDataQueryPlan.setDeduplicatedDataTypes(tsDataTypes);
+            rawDataQueryPlan.setExpression(expression);
+            currentDataSet = queryRouter.rawDataQuery(rawDataQueryPlan, context);
             break;
           default:
             throw new IOException("unsupported DataSetType");

--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/DeviceIterateDataSet.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/DeviceIterateDataSet.java
@@ -18,12 +18,19 @@
  */
 package org.apache.iotdb.db.query.dataset;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByDevicePlan;
 import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.executor.IQueryRouter;
 import org.apache.iotdb.db.query.fill.IFill;
@@ -35,9 +42,6 @@ import org.apache.iotdb.tsfile.read.common.RowRecord;
 import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.iotdb.tsfile.utils.Binary;
-
-import java.io.IOException;
-import java.util.*;
 
 
 /**
@@ -80,39 +84,39 @@ public class DeviceIterateDataSet extends QueryDataSet {
   private int[] currentColumnMapRelation;
   private Map<Path, TSDataType> tsDataTypeMap;
 
-  public DeviceIterateDataSet(QueryPlan queryPlan, QueryContext context,
+  public DeviceIterateDataSet(AlignByDevicePlan alignByDevicePlan, QueryContext context,
       IQueryRouter queryRouter) {
-    super(null, queryPlan.getDataTypes());
+    super(null, alignByDevicePlan.getDataTypes());
 
     // get deduplicated measurement columns (already deduplicated in TSServiceImpl.executeDataQuery)
-    this.deduplicatedMeasurementColumns = queryPlan.getMeasurements();
-    this.tsDataTypeMap = queryPlan.getDataTypeMapping();
+    this.deduplicatedMeasurementColumns = alignByDevicePlan.getMeasurements();
+    this.tsDataTypeMap = alignByDevicePlan.getDataTypeMapping();
     this.queryRouter = queryRouter;
     this.context = context;
-    this.measurementColumnsGroupByDevice = queryPlan.getMeasurementsGroupByDevice();
-    this.deviceToFilterMap = queryPlan.getDeviceToFilterMap();
-    this.notExistMeasurements = queryPlan.getNotExistMeasurements();
-    this.constMeasurements = queryPlan.getConstMeasurements();
-    this.positionOfNotExistMeasurements = queryPlan.getPositionOfNotExistMeasurements();
-    this.positionOfConstMeasurements = queryPlan.getPositionOfConstMeasurements();
+    this.measurementColumnsGroupByDevice = alignByDevicePlan.getDeviceToMeasurementsMap();
+    this.deviceToFilterMap = alignByDevicePlan.getDeviceToFilterMap();
+    this.notExistMeasurements = alignByDevicePlan.getNotExistMeasurements();
+    this.constMeasurements = alignByDevicePlan.getConstMeasurements();
+    this.positionOfNotExistMeasurements = alignByDevicePlan.getPositionOfNotExistMeasurements();
+    this.positionOfConstMeasurements = alignByDevicePlan.getPositionOfConstMeasurements();
     //BuildOutDataTypes();
 
-    if (queryPlan instanceof GroupByPlan) {
+    if (alignByDevicePlan.getGroupByPlan() != null) {
       this.dataSetType = DataSetType.GROUPBY;
       // assign parameters
-      this.unit = ((GroupByPlan) queryPlan).getInterval();
-      this.slidingStep = ((GroupByPlan) queryPlan).getSlidingStep();
-      this.startTime = ((GroupByPlan) queryPlan).getStartTime();
-      this.endTime = ((GroupByPlan) queryPlan).getEndTime();
+      this.unit = alignByDevicePlan.getGroupByPlan().getInterval();
+      this.slidingStep = alignByDevicePlan.getGroupByPlan().getSlidingStep();
+      this.startTime = alignByDevicePlan.getGroupByPlan().getStartTime();
+      this.endTime = alignByDevicePlan.getGroupByPlan().getEndTime();
 
-    } else if (queryPlan instanceof AggregationPlan) {
+    } else if (alignByDevicePlan.getAggregationPlan() != null) {
       this.dataSetType = DataSetType.AGGREGATE;
 
-    } else if (queryPlan instanceof FillQueryPlan) {
+    } else if (alignByDevicePlan.getFillQueryPlan() != null) {
       this.dataSetType = DataSetType.FILL;
       // assign parameters
-      this.queryTime = ((FillQueryPlan) queryPlan).getQueryTime();
-      this.fillType = ((FillQueryPlan) queryPlan).getFillType();
+      this.queryTime = alignByDevicePlan.getFillQueryPlan().getQueryTime();
+      this.fillType = alignByDevicePlan.getFillQueryPlan().getFillType();
     } else {
       this.dataSetType = DataSetType.QUERY;
     }
@@ -207,7 +211,7 @@ public class DeviceIterateDataSet extends QueryDataSet {
             currentDataSet = queryRouter.fill(fillQueryPlan, context);
             break;
           case QUERY:
-            QueryPlan queryPlan = new QueryPlan();
+            RawDataQueryPlan queryPlan = new RawDataQueryPlan();
             queryPlan.setDeduplicatedPaths(executePaths);
             queryPlan.setDeduplicatedDataTypes(tsDataTypes);
             queryPlan.setExpression(expression);

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/IQueryRouter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/IQueryRouter.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
 import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.tsfile.exception.filter.QueryFilterOptimizationException;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
@@ -35,7 +35,7 @@ public interface IQueryRouter {
   /**
    * Execute physical plan.
    */
-  QueryDataSet rawDataQuery(QueryPlan queryPlan, QueryContext context) throws StorageEngineException;
+  QueryDataSet rawDataQuery(RawDataQueryPlan queryPlan, QueryContext context) throws StorageEngineException;
 
   /**
    * Execute aggregation query.

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/QueryRouter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/QueryRouter.java
@@ -19,12 +19,15 @@
 
 package org.apache.iotdb.db.query.executor;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
 import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.dataset.groupby.GroupByWithValueFilterDataSet;
 import org.apache.iotdb.db.query.dataset.groupby.GroupByWithoutValueFilterDataSet;
@@ -40,10 +43,6 @@ import org.apache.iotdb.tsfile.read.expression.util.ExpressionOptimizer;
 import org.apache.iotdb.tsfile.read.filter.GroupByFilter;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
 /**
  * Query entrance class of IoTDB query process. All query clause will be transformed to physical
  * plan, physical plan will be executed by EngineQueryRouter.
@@ -51,7 +50,7 @@ import java.util.Map;
 public class QueryRouter implements IQueryRouter {
 
   @Override
-  public QueryDataSet rawDataQuery(QueryPlan queryPlan, QueryContext context)
+  public QueryDataSet rawDataQuery(RawDataQueryPlan queryPlan, QueryContext context)
       throws StorageEngineException {
     IExpression expression = queryPlan.getExpression();
     List<Path> deduplicatedPaths = queryPlan.getDeduplicatedPaths();

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/RawDataQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/RawDataQueryExecutor.java
@@ -18,8 +18,10 @@
  */
 package org.apache.iotdb.db.query.executor;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.iotdb.db.exception.StorageEngineException;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.dataset.EngineDataSetWithValueFilter;
@@ -37,9 +39,6 @@ import org.apache.iotdb.tsfile.read.expression.impl.GlobalTimeExpression;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.query.dataset.QueryDataSet;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * IoTDB query executor.
  */
@@ -49,7 +48,7 @@ public class RawDataQueryExecutor {
   private List<TSDataType> deduplicatedDataTypes;
   private IExpression optimizedExpression;
 
-  public RawDataQueryExecutor(QueryPlan queryPlan) {
+  public RawDataQueryExecutor(RawDataQueryPlan queryPlan) {
     this.deduplicatedPaths = queryPlan.getDeduplicatedPaths();
     this.deduplicatedDataTypes = queryPlan.getDeduplicatedDataTypes();
     this.optimizedExpression = queryPlan.getExpression();

--- a/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionQueryTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionQueryTest.java
@@ -35,7 +35,7 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.storageGroup.StorageGroupException;
 import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.query.executor.QueryRouter;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
@@ -113,7 +113,7 @@ public class DeletionQueryTest {
     dataTypes.add(TSDataType.valueOf(dataType));
     dataTypes.add(TSDataType.valueOf(dataType));
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet dataSet = router.rawDataQuery(queryPlan, TEST_QUERY_CONTEXT);
@@ -152,7 +152,7 @@ public class DeletionQueryTest {
     dataTypes.add(TSDataType.valueOf(dataType));
     dataTypes.add(TSDataType.valueOf(dataType));
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet dataSet = router.rawDataQuery(queryPlan, TEST_QUERY_CONTEXT);
@@ -201,7 +201,7 @@ public class DeletionQueryTest {
     dataTypes.add(TSDataType.valueOf(dataType));
     dataTypes.add(TSDataType.valueOf(dataType));
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet dataSet = router.rawDataQuery(queryPlan, TEST_QUERY_CONTEXT);
@@ -251,7 +251,7 @@ public class DeletionQueryTest {
     dataTypes.add(TSDataType.valueOf(dataType));
     dataTypes.add(TSDataType.valueOf(dataType));
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet dataSet = router.rawDataQuery(queryPlan, TEST_QUERY_CONTEXT);
@@ -321,7 +321,7 @@ public class DeletionQueryTest {
     dataTypes.add(TSDataType.valueOf(dataType));
     dataTypes.add(TSDataType.valueOf(dataType));
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet dataSet = router.rawDataQuery(queryPlan, TEST_QUERY_CONTEXT);

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSequenceDataQueryIT.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.executor.QueryRouter;
@@ -182,7 +182,7 @@ public class IoTDBSequenceDataQueryIT {
 
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet queryDataSet = queryRouter.rawDataQuery(queryPlan, TEST_QUERY_CONTEXT);
@@ -214,7 +214,7 @@ public class IoTDBSequenceDataQueryIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     queryPlan.setExpression(globalTimeExpression);
@@ -262,7 +262,7 @@ public class IoTDBSequenceDataQueryIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     queryPlan.setExpression(singleSeriesExpression);

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.query.control.QueryResourceManager;
 import org.apache.iotdb.db.query.executor.QueryRouter;
@@ -45,7 +45,6 @@ import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
-import org.apache.iotdb.tsfile.read.common.RowRecord;
 import org.apache.iotdb.tsfile.read.expression.impl.SingleSeriesExpression;
 import org.apache.iotdb.tsfile.read.filter.TimeFilter;
 import org.apache.iotdb.tsfile.read.filter.ValueFilter;
@@ -260,7 +259,7 @@ public class IoTDBSeriesReaderIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     QueryDataSet queryDataSet = queryRouter.rawDataQuery(queryPlan, TEST_QUERY_CONTEXT);
@@ -289,7 +288,7 @@ public class IoTDBSeriesReaderIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     queryPlan.setExpression(singleSeriesExpression);
@@ -315,7 +314,7 @@ public class IoTDBSeriesReaderIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(Collections.singletonList(path));
     queryPlan.setExpression(expression);
@@ -348,7 +347,7 @@ public class IoTDBSeriesReaderIT {
     TEST_QUERY_JOB_ID = QueryResourceManager.getInstance().assignQueryId(true);
     TEST_QUERY_CONTEXT = new QueryContext(TEST_QUERY_JOB_ID);
 
-    QueryPlan queryPlan = new QueryPlan();
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
     queryPlan.setDeduplicatedDataTypes(dataTypes);
     queryPlan.setDeduplicatedPaths(pathList);
     queryPlan.setExpression(singleSeriesExpression);

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/LogicalPlanSmallTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/LogicalPlanSmallTest.java
@@ -197,7 +197,7 @@ public class LogicalPlanSmallTest {
     RootOperator operator = (RootOperator) parseDriver
             .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
-    Assert.assertFalse(((QueryOperator)operator).isAlign());
+    Assert.assertFalse(((QueryOperator)operator).isAlignByTime());
   }
 
   @Test
@@ -206,7 +206,7 @@ public class LogicalPlanSmallTest {
     RootOperator operator = (RootOperator) parseDriver
             .parse(sqlStr, IoTDBDescriptor.getInstance().getConfig().getZoneID());
     Assert.assertEquals(QueryOperator.class, operator.getClass());
-    Assert.assertTrue(((QueryOperator)operator).isAlign());
+    Assert.assertTrue(((QueryOperator)operator).isAlignByTime());
   }
 
   @Test (expected = ParseCancellationException.class)

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
@@ -37,6 +37,7 @@ import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
 import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
 import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
 import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.qp.physical.sys.AuthorPlan;
 import org.apache.iotdb.db.qp.physical.sys.CreateTimeSeriesPlan;
 import org.apache.iotdb.db.qp.physical.sys.DataAuthPlan;
@@ -243,7 +244,7 @@ public class PhysicalPlanTest {
   public void testQuery1() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 5000";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(TimeFilter.gt(5000L));
     assertEquals(expect.toString(), queryFilter.toString());
   }
@@ -252,7 +253,7 @@ public class PhysicalPlanTest {
   public void testQuery2() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 50 and time <= 100";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(
         FilterFactory.and(TimeFilter.gt(50L), TimeFilter.ltEq(100L)));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -263,7 +264,7 @@ public class PhysicalPlanTest {
   public void testQuery3() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 50 and time <= 100 or s1 < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(
         FilterFactory.and(TimeFilter.gt(50L), TimeFilter.ltEq(100L)));
     expect = BinaryExpression.or(expect,
@@ -275,7 +276,7 @@ public class PhysicalPlanTest {
   public void testQuery4() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 50 and time <= 100 and s1 < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
 
     IExpression expect = BinaryExpression.and(
         new SingleSeriesExpression(new Path("root.vehicle.d1.s1"), ValueFilter.lt(10.0)),
@@ -291,7 +292,7 @@ public class PhysicalPlanTest {
   public void testQuery5() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 20 or s1 < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         FilterFactory.or(ValueFilter.gt(20.0), ValueFilter.lt(10.0)));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -302,7 +303,7 @@ public class PhysicalPlanTest {
   public void testQuery6() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 20 or time < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(
         FilterFactory.or(TimeFilter.gt(20L), TimeFilter.lt(10L)));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -313,7 +314,7 @@ public class PhysicalPlanTest {
   public void testQuery7() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE time > 2019-10-16 10:59:00+08:00 - 1d5h or time < 10";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new GlobalTimeExpression(
         FilterFactory.or(TimeFilter.gt(1571090340000L), TimeFilter.lt(10L)));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -334,7 +335,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat1() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 20.5e3";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(20.5e3));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -344,7 +345,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat2() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 20.5E-3";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(20.5e-3));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -354,7 +355,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat3() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.5";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(2.5));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -364,7 +365,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat4() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.5";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(2.5));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -374,7 +375,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat5() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -2.5";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(-2.5));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -384,7 +385,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat6() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -2.5E-1";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(-2.5e-1));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -394,7 +395,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat7() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.5E2";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(2.5e+2));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -404,7 +405,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat8() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > .2e2";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(0.2e+2));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -414,7 +415,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat9() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > .2";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(0.2));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -424,7 +425,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat10() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(2.0));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -434,7 +435,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat11() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > 2.";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(2.0));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -444,7 +445,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat12() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -2.";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(-2.0));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -454,7 +455,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat13() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -.2";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(-0.2));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -464,7 +465,7 @@ public class PhysicalPlanTest {
   public void testQueryFloat14() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 > -.2e2";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     IExpression expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.gt(-20.0));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -474,7 +475,7 @@ public class PhysicalPlanTest {
   public void testInOperator() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 in (25, 30, 40)";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     Set<Float> values = new HashSet<>();
     values.add(25.0f);
     values.add(30.0f);
@@ -488,7 +489,7 @@ public class PhysicalPlanTest {
   public void testNotInOperator() throws QueryProcessException {
     String sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE s1 not in (25, 30, 40)";
     PhysicalPlan plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    IExpression queryFilter = ((QueryPlan) plan).getExpression();
+    IExpression queryFilter = ((RawDataQueryPlan) plan).getExpression();
     Set<Float> values = new HashSet<>();
     values.add(25.0f);
     values.add(30.0f);
@@ -499,7 +500,7 @@ public class PhysicalPlanTest {
 
     sqlStr = "SELECT s1 FROM root.vehicle.d1 WHERE not(s1 not in (25, 30, 40))";
     plan = processor.parseSQLToPhysicalPlan(sqlStr);
-    queryFilter = ((QueryPlan) plan).getExpression();
+    queryFilter = ((RawDataQueryPlan) plan).getExpression();
     expect = new SingleSeriesExpression(new Path("root.vehicle.d1.s1"),
         ValueFilter.in(values, false));
     assertEquals(expect.toString(), queryFilter.toString());
@@ -607,38 +608,15 @@ public class PhysicalPlanTest {
   @Test
   public void testDeduplicatedPath() throws Exception {
     String sqlStr = "select * from root.vehicle.d1,root.vehicle.d1,root.vehicle.d1";
-    QueryPlan plan = (QueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
+    RawDataQueryPlan plan = (RawDataQueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
     Assert.assertEquals(1, plan.getDeduplicatedPaths().size());
     Assert.assertEquals(1, plan.getDeduplicatedDataTypes().size());
     Assert.assertEquals(new Path("root.vehicle.d1.s1"), plan.getDeduplicatedPaths().get(0));
 
     sqlStr = "select count(*) from root.vehicle.d1,root.vehicle.d1,root.vehicle.d1";
-    plan = (QueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
+    plan = (RawDataQueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
     Assert.assertEquals(1, plan.getDeduplicatedPaths().size());
     Assert.assertEquals(1, plan.getDeduplicatedDataTypes().size());
     Assert.assertEquals(new Path("root.vehicle.d1.s1"), plan.getDeduplicatedPaths().get(0));
-
-    //'group by device' is deduplication in DeviceIterateDataSet
-    MManager manager = MManager.getInstance();
-    manager.setStorageGroupToMTree("root.vehicle");
-    manager.addPathToMTree("root.vehicle.d0.s1", "INT64", "PLAIN");
-    manager.addPathToMTree("root.vehicle.d0.s0", "INT64", "PLAIN");
-    manager.addPathToMTree("root.vehicle.d1.s0", "INT64", "PLAIN");
-    manager.addPathToMTree("root.vehicle.d1.s1", "INT64", "PLAIN");
-
-    sqlStr = "select s0,s0,s1 from root.vehicle.d0, root.vehicle.d1 group by device";
-    plan = (QueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
-    Assert.assertEquals(0, plan.getDeduplicatedPaths().size());
-    Assert.assertEquals(0, plan.getDeduplicatedDataTypes().size());
-    Assert.assertEquals(6, plan.getPaths().size());
-    Assert.assertEquals(6, plan.getDataTypes().size());
-
-    sqlStr = "select COUNT(s0),COUNT(s0),COUNT(s1) from root.vehicle.d0, root.vehicle.d1 group by device";
-    plan = (QueryPlan) processor.parseSQLToPhysicalPlan(sqlStr);
-    Assert.assertEquals(0, plan.getDeduplicatedPaths().size());
-    Assert.assertEquals(0, plan.getDeduplicatedPaths().size());
-    Assert.assertEquals(0, plan.getDeduplicatedDataTypes().size());
-    Assert.assertEquals(6, plan.getPaths().size());
-    Assert.assertEquals(6, plan.getDataTypes().size());
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/TestConcatOptimizer.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/TestConcatOptimizer.java
@@ -28,7 +28,7 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.qp.Planner;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
-import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
 import org.apache.iotdb.db.qp.strategy.optimizer.ConcatPathOptimizer;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -97,7 +97,7 @@ public class TestConcatOptimizer {
     SingleSeriesExpression seriesExpression = new SingleSeriesExpression(
         new Path("root.laptop.d1.s1"),
         ValueFilter.lt(10));
-    assertEquals(seriesExpression.toString(), ((QueryPlan) plan).getExpression().toString());
+    assertEquals(seriesExpression.toString(), ((RawDataQueryPlan) plan).getExpression().toString());
   }
 
 }


### PR DESCRIPTION
The AlignByDevice query ( which is called groupByDevice before ) and general query aligning by time are both storaged in QueryPlan now. However, they invoke different query process bascially, so it's necessary to restructure the QueryPlan and seperate the AlignByDeviceQuery from it.

The QueryPlan is designed as base class, which has RawDataQueryPlan and AlignByDevicePlan as subclasses. This restructure may bring some usage changes, because the general query which uses QueryPlan directly before has to instantiate RawDataQueryPlan now.

If you think the design is not friendly to users, welcome to comment.