### PR TITLE
[IOTDB-485] Fix the broken link for `Client/Shell tools`

### DIFF
--- a/docs/Documentation/UserGuide/5-Operation Manual/2-DML (Data Manipulation Language).md
+++ b/docs/Documentation/UserGuide/5-Operation Manual/2-DML (Data Manipulation Language).md
@@ -24,7 +24,7 @@
 ## INSERT
 ### Insert Real-time Data
 
-IoTDB provides users with a variety of ways to insert real-time data, such as directly inputting [INSERT SQL statement](/#/Documents/progress/chap5/sec4) in [Client/Shell tools](/#/Tools/Client), or using [Java JDBC](/#/Documents/progress/chap4/sec2) to perform single or batch execution of [INSERT SQL statement](/#/Documents/progress/chap5/sec4).
+IoTDB provides users with a variety of ways to insert real-time data, such as directly inputting [INSERT SQL statement](/#/Documents/progress/chap5/sec4) in [Client/Shell tools](/#/Documents/progress/chap4/sec1), or using [Java JDBC](/#/Documents/progress/chap4/sec2) to perform single or batch execution of [INSERT SQL statement](/#/Documents/progress/chap5/sec4).
 
 This section mainly introduces the use of [INSERT SQL statement](/#/Documents/progress/chap5/sec4) for real-time data import in the scenario. See Section 5.4 for a detailed syntax of [INSERT SQL statement](/#/Documents/progress/chap5/sec4).
 


### PR DESCRIPTION
Fix the broken link for `Client/Shell tools` in `Chapter 5: Operation Manual
DML`