### PR TITLE
[IOTDB-488] Static members shouldn't be accessed through class instances

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -471,7 +471,7 @@ public class PhysicalGenerator {
       return operator;
     }
 
-    Path concatPath = filterPath.addPrefixPath(filterPath, prefix);
+    Path concatPath = Path.addPrefixPath(filterPath, prefix);
     basicOperator.setSinglePath(concatPath);
 
     return basicOperator;


### PR DESCRIPTION
Static members shouldn't be accessed through class instances in `org.apache.iotdb.db.qp.strategy.PhysicalGenerator`