### PR TITLE
[IOTDB-491] Constant  name `pool ` should be all uppercase

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/dataset/NewEngineDataSetWithoutValueFilter.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/dataset/NewEngineDataSetWithoutValueFilter.java
@@ -69,7 +69,7 @@ public class NewEngineDataSetWithoutValueFilter extends QueryDataSet {
             blockingQueue.put(batchData);
             // if the queue also has free space, just submit another itself
             if (blockingQueue.remainingCapacity() > 0) {
-              pool.submit(this);
+              TASK_POOL_MANAGER.submit(this);
             }
             // the queue has no more space
             // remove itself from the QueryTaskPoolManager
@@ -119,7 +119,7 @@ public class NewEngineDataSetWithoutValueFilter extends QueryDataSet {
   // capacity for blocking queue
   private static final int BLOCKING_QUEUE_CAPACITY = 5;
 
-  private static final QueryTaskPoolManager pool = QueryTaskPoolManager.getInstance();
+  private static final QueryTaskPoolManager TASK_POOL_MANAGER = QueryTaskPoolManager.getInstance();
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NewEngineDataSetWithoutValueFilter.class);
 
@@ -150,7 +150,7 @@ public class NewEngineDataSetWithoutValueFilter extends QueryDataSet {
       ManagedSeriesReader reader = seriesReaderWithoutValueFilterList.get(i);
       reader.setHasRemaining(true);
       reader.setManagedByQueryManager(true);
-      pool.submit(new ReadTask(reader, blockingQueueArray[i]));
+      TASK_POOL_MANAGER.submit(new ReadTask(reader, blockingQueueArray[i]));
     }
     for (int i = 0; i < seriesReaderWithoutValueFilterList.size(); i++) {
       fillCache(i);
@@ -349,7 +349,7 @@ public class NewEngineDataSetWithoutValueFilter extends QueryDataSet {
           // now we should submit it again
           if (!reader.isManagedByQueryManager() && reader.hasRemaining()) {
             reader.setManagedByQueryManager(true);
-            pool.submit(new ReadTask(reader, blockingQueueArray[seriesIndex]));
+            TASK_POOL_MANAGER.submit(new ReadTask(reader, blockingQueueArray[seriesIndex]));
           }
         }
       }


### PR DESCRIPTION
Constant name `pool ` should be all uppercase in `org.apache.iotdb.db.query.dataset.NewEngineDataSetWithoutValueFilter`

Renamed to `TASK_POOL_MANAGER `.