### PR TITLE
[IOTDB-502] Fix possible NPE in `org.apache.iotdb.db.service.TSServiceImpl`

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -821,7 +821,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       }
       // constant
       else if (constMeasurementsLoc < plan.getConstMeasurements().size()
-          && loc == plan.getPositionOfConstMeasurements().get(constMeasurementsLoc)) {
+              && loc == plan.getPositionOfConstMeasurements().get(constMeasurementsLoc)) {
         // for shifting
         plan.getPositionOfConstMeasurements().set(constMeasurementsLoc, loc - shiftLoc);
 
@@ -1114,10 +1114,13 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
   @Override
   public TSGetTimeZoneResp getTimeZone(long sessionId) {
     TSStatus tsStatus;
-    TSGetTimeZoneResp resp;
+    TSGetTimeZoneResp resp = null;
     try {
       tsStatus = getStatus(TSStatusCode.SUCCESS_STATUS);
-      resp = new TSGetTimeZoneResp(tsStatus, sessionIdZoneIdMap.get(sessionId).toString());
+      ZoneId zoneId = sessionIdZoneIdMap.get(sessionId);
+      if (zoneId != null) {
+        resp = new TSGetTimeZoneResp(tsStatus, zoneId.toString());
+      }
     } catch (Exception e) {
       logger.error("meet error while generating time zone.", e);
       tsStatus = getStatus(TSStatusCode.GENERATE_TIME_ZONE_ERROR);


### PR DESCRIPTION
`ZoneId` in `org.apache.iotdb.db.service.TSServiceImpl#getTimeZone` may be `null`

One of the scenes may trigger the bug:

> The IoTDB server throws the following error when accessing 0.10 server(master) by 0.9 shell client (latest release).

Exception trace:

> java.lang.NullPointerException: null at org.apache.iotdb.db.service.TSServiceImpl.getTimeZone(TSServiceImpl.java:1120) at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$getTimeZone.getResult(TSIService.java:1853) at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$getTimeZone.getResult(TSIService.java:1833) at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:313) at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) at java.lang.Thread.run(Thread.java:748)

 