### PR TITLE
[IOTDB-503] Add checkTimeseriesExists for session

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -44,9 +44,15 @@ public class SessionExample {
     session.open();
 
     session.setStorageGroup("root.sg1");
-    session.createTimeseries("root.sg1.d1.s1", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
-    session.createTimeseries("root.sg1.d1.s2", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
-    session.createTimeseries("root.sg1.d1.s3", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
+    if (session.checkTimeseriesExists("root.sg1.d1.s1")) {
+      session.createTimeseries("root.sg1.d1.s1", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
+    }
+    if (session.checkTimeseriesExists("root.sg1.d1.s2")) {
+      session.createTimeseries("root.sg1.d1.s2", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
+    }
+    if (session.checkTimeseriesExists("root.sg1.d1.s3")) {
+      session.createTimeseries("root.sg1.d1.s3", TSDataType.INT64, TSEncoding.RLE, CompressionType.SNAPPY);
+    }
 
     insert();
     insertInBatch();

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -558,6 +558,15 @@ public class Session {
     }
   }
 
+  public boolean checkTimeseriesExists(String path) throws IoTDBSessionException {
+    checkPathValidity(path);
+    try {
+      return executeQueryStatement(String.format("SHOW TIMESERIES %s", path)).hasNext();
+    } catch (Exception e) {
+      throw new IoTDBSessionException(e);
+    }
+  }
+
   private TSStatus checkAndReturn(TSStatus resp) {
     if (resp.statusType.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       logger.error(resp.statusType.getMessage());


### PR DESCRIPTION
In most scenarios, we should check whether timeseries already exists before creating, otherwise the following exception may be thrown from server:

 

> org.apache.iotdb.db.exception.query.QueryProcessException: Timeseries [root.sg.d1.s1] already existorg.apache.iotdb.db.exception.query.QueryProcessException: Timeseries [root.sg.d1.s1] already exist at org.apache.iotdb.db.qp.executor.QueryProcessExecutor.createTimeSeries(QueryProcessExecutor.java:552) at org.apache.iotdb.db.qp.executor.QueryProcessExecutor.processNonQuery(QueryProcessExecutor.java:122) at org.apache.iotdb.db.service.TSServiceImpl.executeNonQuery(TSServiceImpl.java:1044) at org.apache.iotdb.db.service.TSServiceImpl.executePlan(TSServiceImpl.java:1387) at org.apache.iotdb.db.service.TSServiceImpl.createTimeseries(TSServiceImpl.java:1342) at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$createTimeseries.getResult(TSIService.java:1953) at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$createTimeseries.getResult(TSIService.java:1933) at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:313) at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) at java.lang.Thread.run(Thread.java:748)

 The changes are as following:
* Added method `checkTimeseriesExists` for `org.apache.iotdb.session.Session`
* Updated the `SessionExample` 

