### PR TITLE
Revert "[IOTDB-520] Result of IBatchReader should not cross partition"

### DIFF
--- a/docs/Documentation-CHN/SystemDesign/5-DataQuery/2-SeriesReader.md
+++ b/docs/Documentation-CHN/SystemDesign/5-DataQuery/2-SeriesReader.md
@@ -78,7 +78,7 @@ BatchData nextBatch() throws IOException;
 #### 一般使用流程
 
 ```
-while (batchReader. hasNextBatch()) {
+while (batchReader.hasNextBatch()) {
 	BatchData batchData = batchReader.nextBatch();
 	
 	// use batchData to do some work

--- a/docs/Documentation-CHN/SystemDesign/5-DataQuery/2-SeriesReader.md
+++ b/docs/Documentation-CHN/SystemDesign/5-DataQuery/2-SeriesReader.md
@@ -78,7 +78,7 @@ BatchData nextBatch() throws IOException;
 #### 一般使用流程
 
 ```
-while (batchReader.hasNextBatch()) {
+while (batchReader. hasNextBatch()) {
 	BatchData batchData = batchReader.nextBatch();
 	
 	// use batchData to do some work

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
@@ -80,9 +80,6 @@ public class IoTDBSeriesReaderIT {
     tsFileConfig.setGroupSizeInByte(1024 * 1024 * 150);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(1024 * 16);
 
-    // test result of IBatchReader should not cross partition
-    IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(2);
-
     EnvironmentUtils.envSetUp();
 
     insertData();
@@ -99,7 +96,6 @@ public class IoTDBSeriesReaderIT {
     tsFileConfig.setPageSizeInByte(pageSizeInByte);
     tsFileConfig.setGroupSizeInByte(groupSizeInByte);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(groupSizeInByte);
-    IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(604800);
 
     EnvironmentUtils.cleanEnv();
   }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSeriesReaderIT.java
@@ -79,6 +79,9 @@ public class IoTDBSeriesReaderIT {
     tsFileConfig.setPageSizeInByte(1024 * 1024 * 150);
     tsFileConfig.setGroupSizeInByte(1024 * 1024 * 150);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(1024 * 16);
+    
+    // test result of IBatchReader should not cross partition
+    IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(2);
 
     EnvironmentUtils.envSetUp();
 
@@ -96,6 +99,7 @@ public class IoTDBSeriesReaderIT {
     tsFileConfig.setPageSizeInByte(pageSizeInByte);
     tsFileConfig.setGroupSizeInByte(groupSizeInByte);
     IoTDBDescriptor.getInstance().getConfig().setMemtableSizeThreshold(groupSizeInByte);
+    IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(604800);
 
     EnvironmentUtils.cleanEnv();
   }


### PR DESCRIPTION
Reverts apache/incubator-iotdb#845

Currently, the writing process is divided by partition, so pages and chunks are not cross partition. The original logic is satisfied. The IT tests for partitions are retained to test the query process with partition.