### PR TITLE
[IOTDB-498] Support date format "2020-02-10"

### DIFF
--- a/server/src/main/antlr4/org/apache/iotdb/db/qp/strategy/SqlBase.g4
+++ b/server/src/main/antlr4/org/apache/iotdb/db/qp/strategy/SqlBase.g4
@@ -818,9 +818,9 @@ DURATION
 
 DATETIME
     : INT ('-'|'/') INT ('-'|'/') INT
-      (T | WS)
+      ((T | WS)
       INT ':' INT ':' INT (DOT INT)?
-      (('+' | '-') INT ':' INT)?
+      (('+' | '-') INT ':' INT)?)?
     ;
 /** Allow unicode rule/token names */
 ID : NameChar NameChar*;

--- a/server/src/main/java/org/apache/iotdb/db/qp/constant/DatetimeUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/constant/DatetimeUtils.java
@@ -464,6 +464,8 @@ public class DatetimeUtils {
     if (str.contains("Z")) {
       return convertDatetimeStrToLong(str.substring(0, str.indexOf('Z')) + "+00:00", offset,
           depth);
+    } else if (str.length() == 10) {
+      return convertDatetimeStrToLong(str + "T00:00:00", offset, depth);
     } else if (str.length() - str.lastIndexOf('+') != 6
         && str.length() - str.lastIndexOf('-') != 6) {
       return convertDatetimeStrToLong(str + offset, offset, depth + 1);

--- a/server/src/test/java/org/apache/iotdb/db/sql/DatetimeQueryDataSetUtilsTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/sql/DatetimeQueryDataSetUtilsTest.java
@@ -37,6 +37,8 @@ public class DatetimeQueryDataSetUtilsTest {
   // 1546413207689
   // 2019-01-02T15:13:27.689+08:00
   private final long timestamp = 1546413207689L;
+  // 2019-01-02T00:00:00.000+08:00
+  private final long timestamp1 = 1546358400000L;
   private long delta;
 
   @Before
@@ -69,6 +71,14 @@ public class DatetimeQueryDataSetUtilsTest {
     testConvertDatetimeStrToLongWithMS(zoneOffset, zoneId, timestamp + delta);
   }
 
+  @Test
+  public void test3() throws LogicalOperatorException{
+    zoneOffset = ZoneOffset.UTC;
+    zoneId = ZoneId.of("Etc/UTC");
+    delta = 8 * 3600000;
+    testConvertDateStrToLong(zoneOffset, zoneId, timestamp1 + delta);
+  }
+
   public void testConvertDatetimeStrToLongWithoutMS(ZoneOffset zoneOffset, ZoneId zoneId, long res) throws LogicalOperatorException {
     String[] timeFormatWithoutMs = new String[]{"2019-01-02 15:13:27", "2019/01/02 15:13:27",
         "2019.01.02 15:13:27", "2019-01-02T15:13:27", "2019/01/02T15:13:27", "2019.01.02T15:13:27",
@@ -93,6 +103,19 @@ public class DatetimeQueryDataSetUtilsTest {
         "2019/01/02 15:13:27.689" + zoneOffset, "2019.01.02 15:13:27.689" + zoneOffset,
         "2019-01-02T15:13:27.689" + zoneOffset, "2019/01/02T15:13:27.689" + zoneOffset,
         "2019.01.02T15:13:27.689" + zoneOffset,};
+    for (String str : timeFormatWithoutMs) {
+      assertEquals(res, DatetimeUtils.convertDatetimeStrToLong(str, zoneOffset, 0));
+    }
+
+    for (String str : timeFormatWithoutMs) {
+      assertEquals(res, DatetimeUtils.convertDatetimeStrToLong(str, zoneId));
+    }
+  }
+
+  public void testConvertDateStrToLong(ZoneOffset zoneOffset, ZoneId zoneId, long res) throws LogicalOperatorException {
+    String[] timeFormatWithoutMs = new String[]{"2019-01-02",
+        "2019/01/02",
+        "2019.01.02",};
     for (String str : timeFormatWithoutMs) {
       assertEquals(res, DatetimeUtils.convertDatetimeStrToLong(str, zoneOffset, 0));
     }


### PR DESCRIPTION
Now we can support sqls like 
`select s2 from root.group1.d1 where time >= 2020-02-10`.