### PR TITLE
[IOTDB-545] Update checkPathValidity in Session

### DIFF
--- a/session/src/main/java/org/apache/iotdb/session/Config.java
+++ b/session/src/main/java/org/apache/iotdb/session/Config.java
@@ -28,11 +28,12 @@ public class Config {
   public static final int DEFAULT_FETCH_SIZE = 10000;
   public static final int DEFAULT_TIMEOUT_MS = 0;
 
-  public static final String NODE_MATCHER = "([a-zA-Z0-9_-]+)";
+  public static final String NODE_MATCHER = "[" + PATH_SEPARATOR + "]" + "([a-zA-Z0-9_]+)";
 
   // for path like: root.sg1.d1."1.2.3" or root.sg1.d1.'1.2.3', only occurs in the end of the path and only occurs once
-  public static final String NODE_WITH_QUOTATION_MARK_MATCHER = "\"|\'a-zA-Z0-9_-[.a-zA-Z0-9_-]+\"|\'";
-  public static final String PATH_MATCHER = PATH_ROOT + "([" + PATH_SEPARATOR + "]" + NODE_MATCHER
-      + ")+[" + NODE_WITH_QUOTATION_MARK_MATCHER + "]?";
+  public static final String NODE_WITH_QUOTATION_MARK_MATCHER =
+      "[" + PATH_SEPARATOR + "][\"|\']([a-zA-Z0-9_]+)(" + NODE_MATCHER + ")+[\"|\']";
+  public static final String PATH_MATCHER =
+      PATH_ROOT + "(" + NODE_MATCHER + ")+(" + NODE_WITH_QUOTATION_MARK_MATCHER + ")?";
 
 }

--- a/session/src/main/java/org/apache/iotdb/session/Config.java
+++ b/session/src/main/java/org/apache/iotdb/session/Config.java
@@ -28,8 +28,11 @@ public class Config {
   public static final int DEFAULT_FETCH_SIZE = 10000;
   public static final int DEFAULT_TIMEOUT_MS = 0;
 
-  public static final String PATH_MATCHER =
-      PATH_ROOT + "([" + PATH_SEPARATOR + "]([+-]?[a-zA-Z0-9_-]+))+"
-          + "[\"|\'a-zA-Z0-9_-[" + PATH_SEPARATOR + "a-zA-Z0-9_-]+\"|\']?";
+  public static final String NODE_MATCHER = "([a-zA-Z0-9_-]+)";
+
+  // for path like: root.sg1.d1."1.2.3" or root.sg1.d1.'1.2.3', only occurs in the end of the path and only occurs once
+  public static final String NODE_WITH_QUOTATION_MARK_MATCHER = "\"|\'a-zA-Z0-9_-[.a-zA-Z0-9_-]+\"|\'";
+  public static final String PATH_MATCHER = PATH_ROOT + "([" + PATH_SEPARATOR + "]" + NODE_MATCHER
+      + ")+[" + NODE_WITH_QUOTATION_MARK_MATCHER + "]?";
 
 }

--- a/session/src/main/java/org/apache/iotdb/session/Config.java
+++ b/session/src/main/java/org/apache/iotdb/session/Config.java
@@ -21,6 +21,8 @@ package org.apache.iotdb.session;
 import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_ROOT;
 import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
 
+import java.util.regex.Pattern;
+
 public class Config {
 
   public static final String DEFAULT_USER = "user";
@@ -33,7 +35,7 @@ public class Config {
   // for path like: root.sg1.d1."1.2.3" or root.sg1.d1.'1.2.3', only occurs in the end of the path and only occurs once
   public static final String NODE_WITH_QUOTATION_MARK_MATCHER =
       "[" + PATH_SEPARATOR + "][\"|\']([a-zA-Z0-9_]+)(" + NODE_MATCHER + ")+[\"|\']";
-  public static final String PATH_MATCHER =
-      PATH_ROOT + "(" + NODE_MATCHER + ")+(" + NODE_WITH_QUOTATION_MARK_MATCHER + ")?";
+  public static final Pattern PATH_PATTERN = Pattern
+      .compile(PATH_ROOT + "(" + NODE_MATCHER + ")+(" + NODE_WITH_QUOTATION_MARK_MATCHER + ")?");
 
 }

--- a/session/src/main/java/org/apache/iotdb/session/Config.java
+++ b/session/src/main/java/org/apache/iotdb/session/Config.java
@@ -29,6 +29,7 @@ public class Config {
   public static final int DEFAULT_TIMEOUT_MS = 0;
 
   public static final String PATH_MATCHER =
-      PATH_ROOT + "([" + PATH_SEPARATOR + "](([a-zA-Z_][a-zA-Z0-9_-]*)|([+-]?[0-9]+)))+";
+      PATH_ROOT + "([" + PATH_SEPARATOR + "]([+-]?[a-zA-Z0-9_-]+))+"
+          + "[\"|\'a-zA-Z0-9_-[" + PATH_SEPARATOR + "a-zA-Z0-9_-]+\"|\']?";
 
 }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -646,10 +646,9 @@ public class Session {
   }
 
   private void checkPathValidity(String path) throws IoTDBSessionException {
-    if (!Pattern.compile(PATH_MATCHER).matcher(path).find()) {
+    if (!Pattern.matches(PATH_MATCHER, path)) {
       throw new IoTDBSessionException(
           String.format("Path [%s] is invalid", path));
     }
   }
-
 }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Pattern;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.iotdb.rpc.IoTDBRPCException;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -258,12 +257,7 @@ public class Session {
     for (int i = 0; i < rowBatch.batchSize; i++) {
       index[i] = i;
     }
-    Arrays.sort(index, new Comparator<Integer>() {
-      @Override
-      public int compare(Integer o1, Integer o2) {
-        return Long.compare(rowBatch.timestamps[o1], rowBatch.timestamps[o2]);
-      }
-    });
+    Arrays.sort(index, Comparator.comparingLong(o -> rowBatch.timestamps[o]));
     Arrays.sort(rowBatch.timestamps, 0, rowBatch.batchSize);
     for (int i = 0; i < rowBatch.measurements.size(); i++) {
       rowBatch.values[i] =

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iotdb.session;
 
-import static org.apache.iotdb.session.Config.PATH_MATCHER;
+import static org.apache.iotdb.session.Config.PATH_PATTERN;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.regex.Pattern;
 import org.apache.iotdb.rpc.IoTDBRPCException;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -646,7 +645,7 @@ public class Session {
   }
 
   private void checkPathValidity(String path) throws IoTDBSessionException {
-    if (!Pattern.matches(PATH_MATCHER, path)) {
+    if (!PATH_PATTERN.matcher(path).matches()) {
       throw new IoTDBSessionException(
           String.format("Path [%s] is invalid", path));
     }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -652,9 +652,9 @@ public class Session {
   }
 
   private void checkPathValidity(String path) throws IoTDBSessionException {
-    if (!Pattern.matches(PATH_MATCHER, path)) {
+    if (!Pattern.compile(PATH_MATCHER).matcher(path).find()) {
       throw new IoTDBSessionException(
-          String.format("Path [%s] is invalid", StringEscapeUtils.escapeJava(path)));
+          String.format("Path [%s] is invalid", path));
     }
   }
 

--- a/session/src/test/java/org/apache/iotdb/session/CheckPathValidityTest.java
+++ b/session/src/test/java/org/apache/iotdb/session/CheckPathValidityTest.java
@@ -19,32 +19,31 @@
 
 package org.apache.iotdb.session;
 
-import static org.apache.iotdb.session.Config.PATH_MATCHER;
+import static org.apache.iotdb.session.Config.PATH_PATTERN;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.regex.Pattern;
 import org.junit.Test;
 
 public class CheckPathValidityTest {
 
   @Test
   public void testCheckPathValidity() {
-    assertTrue(Pattern.matches(PATH_MATCHER, "root.vehicle"));
-    assertTrue(Pattern.matches(PATH_MATCHER, "root.123456"));
-    assertTrue(Pattern.matches(PATH_MATCHER, "root._1234"));
-    assertTrue(Pattern.matches(PATH_MATCHER, "root._vehicle"));
-    assertTrue(Pattern.matches(PATH_MATCHER, "root.1234a4"));
-    assertTrue(Pattern.matches(PATH_MATCHER, "root.1_2"));
-    assertTrue(Pattern.matches(PATH_MATCHER, "root.vehicle.1245.1.2.3"));
-    assertTrue(Pattern.matches(PATH_MATCHER, "root.vehicle.1245.\"1.2.3\""));
-    assertTrue(Pattern.matches(PATH_MATCHER, "root.vehicle.1245.\'1.2.3\'"));
+    assertTrue(PATH_PATTERN.matcher("root.vehicle").matches());
+    assertTrue(PATH_PATTERN.matcher("root.123456").matches());
+    assertTrue(PATH_PATTERN.matcher("root._1234").matches());
+    assertTrue(PATH_PATTERN.matcher("root._vehicle").matches());
+    assertTrue(PATH_PATTERN.matcher("root.1234a4").matches());
+    assertTrue(PATH_PATTERN.matcher("root.1_2").matches());
+    assertTrue(PATH_PATTERN.matcher("root.vehicle.1245.1.2.3").matches());
+    assertTrue(PATH_PATTERN.matcher("root.vehicle.1245.\"1.2.3\"").matches());
+    assertTrue(PATH_PATTERN.matcher("root.vehicle.1245.\'1.2.3\'").matches());
 
-    assertFalse(Pattern.matches(PATH_MATCHER, "vehicle"));
-    assertFalse(Pattern.matches(PATH_MATCHER, "root.\tvehicle"));
-    assertFalse(Pattern.matches(PATH_MATCHER, "root.\nvehicle"));
-    assertFalse(Pattern.matches(PATH_MATCHER, "root..vehicle"));
-    assertFalse(Pattern.matches(PATH_MATCHER, "root.%12345"));
-    assertFalse(Pattern.matches(PATH_MATCHER, "root.a{12345}"));
+    assertFalse(PATH_PATTERN.matcher("vehicle").matches());
+    assertFalse(PATH_PATTERN.matcher("root.\tvehicle").matches());
+    assertFalse(PATH_PATTERN.matcher("root.\nvehicle").matches());
+    assertFalse(PATH_PATTERN.matcher("root..vehicle").matches());
+    assertFalse(PATH_PATTERN.matcher("root.%12345").matches());
+    assertFalse(PATH_PATTERN.matcher("root.a{12345}").matches());
   }
 }

--- a/session/src/test/java/org/apache/iotdb/session/CheckPathValidityTest.java
+++ b/session/src/test/java/org/apache/iotdb/session/CheckPathValidityTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iotdb.session;
 
 import static org.apache.iotdb.session.Config.PATH_MATCHER;

--- a/session/src/test/java/org/apache/iotdb/session/CheckPathValidityTest.java
+++ b/session/src/test/java/org/apache/iotdb/session/CheckPathValidityTest.java
@@ -1,0 +1,31 @@
+package org.apache.iotdb.session;
+
+import static org.apache.iotdb.session.Config.PATH_MATCHER;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+public class CheckPathValidityTest {
+
+  @Test
+  public void testCheckPathValidity() {
+    assertTrue(Pattern.matches(PATH_MATCHER, "root.vehicle"));
+    assertTrue(Pattern.matches(PATH_MATCHER, "root.123456"));
+    assertTrue(Pattern.matches(PATH_MATCHER, "root._1234"));
+    assertTrue(Pattern.matches(PATH_MATCHER, "root._vehicle"));
+    assertTrue(Pattern.matches(PATH_MATCHER, "root.1234a4"));
+    assertTrue(Pattern.matches(PATH_MATCHER, "root.1_2"));
+    assertTrue(Pattern.matches(PATH_MATCHER, "root.vehicle.1245.1.2.3"));
+    assertTrue(Pattern.matches(PATH_MATCHER, "root.vehicle.1245.\"1.2.3\""));
+    assertTrue(Pattern.matches(PATH_MATCHER, "root.vehicle.1245.\'1.2.3\'"));
+
+    assertFalse(Pattern.matches(PATH_MATCHER, "vehicle"));
+    assertFalse(Pattern.matches(PATH_MATCHER, "root.\tvehicle"));
+    assertFalse(Pattern.matches(PATH_MATCHER, "root.\nvehicle"));
+    assertFalse(Pattern.matches(PATH_MATCHER, "root..vehicle"));
+    assertFalse(Pattern.matches(PATH_MATCHER, "root.%12345"));
+    assertFalse(Pattern.matches(PATH_MATCHER, "root.a{12345}"));
+  }
+}

--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionIT.java
@@ -589,9 +589,8 @@ public class IoTDBSessionIT {
     checkSetSG(session, "root.\tvehicle", false);
     checkSetSG(session, "root.\nvehicle", false);
     checkSetSG(session, "root..vehicle", false);
-    checkSetSG(session, "root.1234a4", false);
-    checkSetSG(session, "root.+12345", true);
-    checkSetSG(session, "root.-12345", true);
+    checkSetSG(session, "root.1234a4", true);
+    checkSetSG(session, "root.1_2", true);
     checkSetSG(session, "root.%12345", false);
     checkSetSG(session, "root.a{12345}", false);
 
@@ -600,7 +599,8 @@ public class IoTDBSessionIT {
     checkCreateTimeseries(session, "root.vehicle.1110.s0", true);
     checkCreateTimeseries(session, "root.vehicle.d0.1220", true);
     checkCreateTimeseries(session, "root.vehicle._1234.s0", true);
-    checkCreateTimeseries(session, "root.vehicle.+1245.-1256", true);
+    checkCreateTimeseries(session, "root.vehicle.1245.\"1.2.3\"", true);
+    checkCreateTimeseries(session, "root.vehicle.1245.\'1.2.4\'", true);
     checkCreateTimeseries(session, "root.vehicle./d0.s0", false);
     checkCreateTimeseries(session, "root.vehicle.d\t0.s0", false);
     checkCreateTimeseries(session, "root.vehicle.!d\t0.s0", false);
@@ -616,18 +616,18 @@ public class IoTDBSessionIT {
     } catch (IoTDBSessionException e) {
       status = false;
     }
-    assertEquals(status, correctStatus);
+    assertEquals(correctStatus, status);
   }
 
-  private void checkCreateTimeseries(Session session, String timeseris, boolean correctStatus) {
+  private void checkCreateTimeseries(Session session, String timeseries, boolean correctStatus) {
     boolean status = true;
     try {
-      session.createTimeseries(timeseris, TSDataType.INT64, TSEncoding.RLE,
+      session.createTimeseries(timeseries, TSDataType.INT64, TSEncoding.RLE,
           CompressionType.SNAPPY);
     } catch (IoTDBSessionException e) {
       status = false;
     }
-    assertEquals(status, correctStatus);
+    assertEquals(correctStatus, status);
   }
 
   private void insertRowBatchTest2(String deviceId) throws IoTDBSessionException {

--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionIT.java
@@ -47,8 +47,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class IoTDBSessionIT {
 
@@ -112,7 +110,7 @@ public class IoTDBSessionIT {
     try (Connection connection = DriverManager
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
-      statement.execute("flush");
+      statement.execute("FLUSH");
     }
     //
     insertRowBatchTest3("root.sg1.d1");
@@ -229,6 +227,19 @@ public class IoTDBSessionIT {
     insertInBatch();
 
     query4();
+
+    // special characters
+    session.createTimeseries("root.sg1.d1.1_2", TSDataType.INT64, TSEncoding.RLE,
+        CompressionType.SNAPPY);
+    session.createTimeseries("root.sg1.d1.\"1.2.3\"", TSDataType.INT64, TSEncoding.RLE,
+        CompressionType.SNAPPY);
+    session.createTimeseries("root.sg1.d1.\'1.2.4\'", TSDataType.INT64, TSEncoding.RLE,
+        CompressionType.SNAPPY);
+
+    session.setStorageGroup("root.1");
+    session.createTimeseries("root.1.2.3", TSDataType.INT64, TSEncoding.RLE,
+        CompressionType.SNAPPY);
+
     // Add another storage group to test the deletion of storage group
     session.setStorageGroup("root.sg2");
     session.createTimeseries("root.sg2.d1.s1", TSDataType.INT64, TSEncoding.RLE,
@@ -391,6 +402,10 @@ public class IoTDBSessionIT {
 
   private void deleteTimeseries() throws IoTDBSessionException {
     session.deleteTimeseries("root.sg1.d1.s1");
+    session.deleteTimeseries("root.laptop.d1.1_2");
+    session.deleteTimeseries("root.laptop.d1.\"1.2.3\"");
+    session.deleteTimeseries("root.laptop.d1.\'1.2.4\'");
+    session.deleteTimeseries("root.1.2.3");
   }
 
   private void query() throws ClassNotFoundException, SQLException {
@@ -401,7 +416,7 @@ public class IoTDBSessionIT {
     try (Connection connection = DriverManager
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
-      ResultSet resultSet = statement.executeQuery("select * from root");
+      ResultSet resultSet = statement.executeQuery("SELECT * FROM root");
       final ResultSetMetaData metaData = resultSet.getMetaData();
       final int colCount = metaData.getColumnCount();
       StringBuilder resultStr = new StringBuilder();
@@ -419,8 +434,9 @@ public class IoTDBSessionIT {
   }
 
   private void queryForAlignByDevice()
-      throws  SQLException, TException, IoTDBRPCException {
-    SessionDataSet sessionDataSet = session.executeQueryStatement("select '11', s1, '11' from root.sg1.d1 align by device");
+      throws SQLException, TException, IoTDBRPCException {
+    SessionDataSet sessionDataSet = session
+        .executeQueryStatement("select '11', s1, '11' from root.sg1.d1 align by device");
     sessionDataSet.setBatchSize(1024);
     int count = 0;
     while (sessionDataSet.hasNext()) {
@@ -437,8 +453,9 @@ public class IoTDBSessionIT {
   }
 
   private void queryForAlignByDevice2()
-      throws  SQLException, TException, IoTDBRPCException {
-    SessionDataSet sessionDataSet = session.executeQueryStatement("select '11', s1, '11', s5, s1, s5 from root.sg1.d1 align by device");
+      throws SQLException, TException, IoTDBRPCException {
+    SessionDataSet sessionDataSet = session.executeQueryStatement(
+        "select '11', s1, '11', s5, s1, s5 from root.sg1.d1 align by device");
     sessionDataSet.setBatchSize(1024);
     int count = 0;
     while (sessionDataSet.hasNext()) {
@@ -463,7 +480,7 @@ public class IoTDBSessionIT {
     try (Connection connection = DriverManager
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
-      ResultSet resultSet = statement.executeQuery("select * from root");
+      ResultSet resultSet = statement.executeQuery("SELECT * FROM root");
       final ResultSetMetaData metaData = resultSet.getMetaData();
       final int colCount = metaData.getColumnCount();
       StringBuilder resultStr = new StringBuilder();
@@ -495,11 +512,11 @@ public class IoTDBSessionIT {
         CompressionType.SNAPPY);
     // using the query result as the QueryTest to verify the deletion and the new insertion
     Class.forName(Config.JDBC_DRIVER_NAME);
-    String standard = "Time\n" + "root.sg2.d1.s1\n" + "root.sg1.d1.s1\n";
+    String standard = "Time\n" + "root.1.2.3\n" + "root.sg2.d1.s1\n" + "root.sg1.d1.s1\n";
     try (Connection connection = DriverManager
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
-      ResultSet resultSet = statement.executeQuery("select * from root");
+      ResultSet resultSet = statement.executeQuery("SELECT * FROM root");
       final ResultSetMetaData metaData = resultSet.getMetaData();
       final int colCount = metaData.getColumnCount();
       StringBuilder resultStr = new StringBuilder();
@@ -512,7 +529,7 @@ public class IoTDBSessionIT {
         }
         resultStr.append("\n");
       }
-      Assert.assertEquals(resultStr.toString(), standard);
+      Assert.assertEquals(standard, resultStr.toString());
       List<String> storageGroups = new ArrayList<>();
       storageGroups.add("root.sg1.d1");
       storageGroups.add("root.sg2");
@@ -710,7 +727,6 @@ public class IoTDBSessionIT {
     if (rowBatch.batchSize != 0) {
       long start = System.currentTimeMillis();
       session.insertBatch(rowBatch);
-      countTime += System.currentTimeMillis() - start;
       rowBatch.reset();
     }
 
@@ -724,7 +740,7 @@ public class IoTDBSessionIT {
     try (Connection connection = DriverManager
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
-      ResultSet resultSet = statement.executeQuery("select * from root");
+      ResultSet resultSet = statement.executeQuery("SELECT * FROM root");
       final ResultSetMetaData metaData = resultSet.getMetaData();
       final int colCount = metaData.getColumnCount();
       StringBuilder resultStr = new StringBuilder();
@@ -752,7 +768,7 @@ public class IoTDBSessionIT {
     try (Connection connection = DriverManager
         .getConnection(Config.IOTDB_URL_PREFIX + "192.168.130.18:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
-      ResultSet resultSet = statement.executeQuery("select s_0 from root.group_0.d_0 limit 10000");
+      ResultSet resultSet = statement.executeQuery("SELECT s_0 FROM root.group_0.d_0 LIMIT 10000");
       final ResultSetMetaData metaData = resultSet.getMetaData();
       final int colCount = metaData.getColumnCount();
       StringBuilder resultStr = new StringBuilder();
@@ -792,7 +808,7 @@ public class IoTDBSessionIT {
     try (Connection connection = DriverManager
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
-      ResultSet resultSet = statement.executeQuery("select * from root");
+      ResultSet resultSet = statement.executeQuery("SELECT * FROM root");
       final ResultSetMetaData metaData = resultSet.getMetaData();
       final int colCount = metaData.getColumnCount();
       StringBuilder resultStr = new StringBuilder();


### PR DESCRIPTION
In session,  support path like: `root.sg`, `root.sg.1.2.3`, `root.sg.d1.1_1`, `root.sg."1.2.3"`, `root.sg.'1.2.3'`