### PR TITLE
[IOTDB-549] Reorganize exception

### DIFF
--- a/example/rocketmq/src/main/java/org/apache/iotdb/rocketmq/RocketMQConsumer.java
+++ b/example/rocketmq/src/main/java/org/apache/iotdb/rocketmq/RocketMQConsumer.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.rocketmq;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
-import org.apache.iotdb.session.IoTDBSessionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.Session;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -45,7 +45,7 @@ public class RocketMQConsumer {
 
   public RocketMQConsumer(String producerGroup, String serverAddresses, String connectionHost,
       int connectionPort, String user, String password)
-      throws IoTDBConnectionException, IoTDBSessionException {
+      throws IoTDBConnectionException, StatementExecutionException {
     this.producerGroup = producerGroup;
     this.serverAddresses = serverAddresses;
     this.consumer = new DefaultMQPushConsumer(producerGroup);
@@ -54,7 +54,7 @@ public class RocketMQConsumer {
   }
 
   private void initIoTDB(String host, int port, String user, String password)
-      throws IoTDBConnectionException, IoTDBSessionException {
+      throws IoTDBConnectionException, StatementExecutionException {
     if (host == null) {
       host = Constant.IOTDB_CONNECTION_HOST;
       port = Constant.IOTDB_CONNECTION_PORT;
@@ -72,11 +72,11 @@ public class RocketMQConsumer {
   }
   
   private void addStorageGroup(String storageGroup)
-      throws IoTDBSessionException, IoTDBConnectionException {
+      throws IoTDBConnectionException, StatementExecutionException {
     session.setStorageGroup(storageGroup);
   }
   
-  private void createTimeseries(String[] sql) throws IoTDBSessionException, IoTDBConnectionException {
+  private void createTimeseries(String[] sql) throws StatementExecutionException, IoTDBConnectionException {
     String timeseries = sql[0];
     TSDataType dataType = TSDataType.valueOf(sql[1]);
     TSEncoding encoding = TSEncoding.valueOf(sql[2]);
@@ -149,7 +149,7 @@ public class RocketMQConsumer {
   }
 
   public static void main(String[] args)
-      throws MQClientException, IoTDBSessionException, IoTDBConnectionException {
+      throws MQClientException, StatementExecutionException, IoTDBConnectionException {
     /**
      *Instantiate with specified consumer group name and specify name server addresses.
      */

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -18,8 +18,8 @@
  */
 package org.apache.iotdb;
 
-import org.apache.iotdb.rpc.IoTDBRPCException;
-import org.apache.iotdb.session.IoTDBSessionException;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.session.Session;
 import org.apache.iotdb.session.SessionDataSet;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -28,9 +28,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.write.record.RowBatch;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.Schema;
-import org.apache.thrift.TException;
-
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,7 +36,7 @@ public class SessionExample {
   private static Session session;
 
   public static void main(String[] args)
-          throws IoTDBSessionException, TException, IoTDBRPCException, SQLException {
+      throws IoTDBConnectionException, StatementExecutionException {
     session = new Session("127.0.0.1", 6667, "root", "root");
     session.open();
 
@@ -64,7 +61,7 @@ public class SessionExample {
     session.close();
   }
 
-  private static void insert() throws IoTDBSessionException {
+  private static void insert() throws IoTDBConnectionException {
     String deviceId = "root.sg1.d1";
     List<String> measurements = new ArrayList<>();
     measurements.add("s1");
@@ -79,7 +76,7 @@ public class SessionExample {
     }
   }
 
-  private static void insertInBatch() throws IoTDBSessionException {
+  private static void insertInBatch() throws IoTDBConnectionException {
     String deviceId = "root.sg1.d1";
     List<String> measurements = new ArrayList<>();
     measurements.add("s1");
@@ -126,7 +123,7 @@ public class SessionExample {
    * Users need to control the count of RowBatch and write a batch when it reaches the maxBatchSize
    *
    */
-  private static void insertRowBatch() throws IoTDBSessionException {
+  private static void insertRowBatch() throws IoTDBConnectionException {
     // The schema of sensors of one device
     Schema schema = new Schema();
     schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.RLE));
@@ -157,13 +154,13 @@ public class SessionExample {
     }
   }
 
-  private static void deleteData() throws IoTDBSessionException {
+  private static void deleteData() throws IoTDBConnectionException {
     String path = "root.sg1.d1.s1";
     long deleteTime = 99;
     session.deleteData(path, deleteTime);
   }
 
-  private static void deleteTimeseries() throws IoTDBSessionException {
+  private static void deleteTimeseries() throws IoTDBConnectionException {
     List<String> paths = new ArrayList<>();
     paths.add("root.sg1.d1.s1");
     paths.add("root.sg1.d1.s2");
@@ -171,8 +168,9 @@ public class SessionExample {
     session.deleteTimeseries(paths);
   }
 
-  private static void query() throws TException, IoTDBRPCException, SQLException {
-    SessionDataSet dataSet = session.executeQueryStatement("select * from root.sg1.d1");
+  private static void query() throws IoTDBConnectionException, StatementExecutionException {
+    SessionDataSet dataSet;
+    dataSet = session.executeQueryStatement("select * from root.sg1.d1");
     dataSet.setBatchSize(1024); // default is 512
     while (dataSet.hasNext()){
       System.out.println(dataSet.next());
@@ -181,7 +179,7 @@ public class SessionExample {
     dataSet.closeOperationHandle();
   }
 
-  private static void nonQuery() throws TException, IoTDBRPCException, SQLException {
+  private static void nonQuery() throws IoTDBConnectionException, StatementExecutionException {
     session.executeNonQueryStatement("insert into root.sg1.d1(timestamp,s1) values(200, 1);");
   }
 }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/AbstractIoTDBResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/AbstractIoTDBResultSet.java
@@ -19,8 +19,8 @@
 
 package org.apache.iotdb.jdbc;
 
-import org.apache.iotdb.rpc.IoTDBRPCException;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.TSCloseOperationReq;
 import org.apache.iotdb.service.rpc.thrift.TSIService;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
@@ -144,8 +144,8 @@ public abstract class AbstractIoTDBResultSet implements ResultSet {
         closeReq.setQueryId(queryId);
         TSStatus closeResp = client.closeOperation(closeReq);
         RpcUtils.verifySuccess(closeResp);
-      } catch (IoTDBRPCException e) {
-        throw new SQLException("Error occurs for close opeation in server side becasuse ", e);
+      } catch (StatementExecutionException e) {
+        throw new SQLException("Error occurs for close operation in server side because ", e);
       } catch (TException e) {
         throw new SQLException("Error occurs when connecting to server for close operation ", e);
       }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -38,8 +38,9 @@ import java.time.ZoneId;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
-import org.apache.iotdb.rpc.IoTDBRPCException;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.*;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -448,7 +449,7 @@ public class IoTDBConnection implements Connection {
       }
       throw new SQLException(String.format("Can not establish connection with %s : %s. ",
           params.getJdbcUriString(), e.getMessage()), e);
-    } catch (IoTDBRPCException e) {
+    } catch (StatementExecutionException e) {
       // failed to connect, disconnect from the server
       transport.close();
       throw new IoTDBSQLException(e.getMessage(), openResp.getStatus());
@@ -493,7 +494,7 @@ public class IoTDBConnection implements Connection {
     TSGetTimeZoneResp resp = getClient().getTimeZone(sessionId);
     try {
       RpcUtils.verifySuccess(resp.getStatus());
-    } catch (IoTDBRPCException e) {
+    } catch (StatementExecutionException e) {
       throw new IoTDBSQLException(e.getMessage(), resp.getStatus());
     }
     return resp.getTimeZone();
@@ -504,7 +505,7 @@ public class IoTDBConnection implements Connection {
     TSStatus resp = getClient().setTimeZone(req);
     try {
       RpcUtils.verifySuccess(resp);
-    } catch (IoTDBRPCException e) {
+    } catch (StatementExecutionException e) {
       throw new IoTDBSQLException(e.getMessage(), resp);
     }
     this.zoneId = ZoneId.of(zoneId);

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadata.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadata.java
@@ -19,8 +19,8 @@
 package org.apache.iotdb.jdbc;
 
 import java.sql.*;
-import org.apache.iotdb.rpc.IoTDBRPCException;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataResp;
 import org.apache.iotdb.service.rpc.thrift.TSIService;
@@ -1013,7 +1013,7 @@ public class IoTDBDatabaseMetadata implements DatabaseMetaData {
     resp = client.fetchMetadata(req);
     try {
       RpcUtils.verifySuccess(resp.getStatus());
-    } catch (IoTDBRPCException e) {
+    } catch (StatementExecutionException e) {
       throw new IoTDBSQLException(e.getMessage(), resp.getStatus());
     }
     return resp.getMetadataInJson();

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignQueryResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBNonAlignQueryResultSet.java
@@ -19,8 +19,8 @@
 
 package org.apache.iotdb.jdbc;
 
-import org.apache.iotdb.rpc.IoTDBRPCException;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
 import org.apache.iotdb.service.rpc.thrift.TSIService;
@@ -101,7 +101,7 @@ public class IoTDBNonAlignQueryResultSet extends AbstractIoTDBResultSet {
 
       try {
         RpcUtils.verifySuccess(resp.getStatus());
-      } catch (IoTDBRPCException e) {
+      } catch (StatementExecutionException e) {
         throw new IoTDBSQLException(e.getMessage(), resp.getStatus());
       }
       if (!resp.hasResultSet) {

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBQueryResultSet.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBQueryResultSet.java
@@ -19,8 +19,8 @@
 
 package org.apache.iotdb.jdbc;
 
-import org.apache.iotdb.rpc.IoTDBRPCException;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
 import org.apache.iotdb.service.rpc.thrift.TSIService;
@@ -83,7 +83,7 @@ public class IoTDBQueryResultSet extends AbstractIoTDBResultSet {
 
       try {
         RpcUtils.verifySuccess(resp.getStatus());
-      } catch (IoTDBRPCException e) {
+      } catch (StatementExecutionException e) {
         throw new IoTDBSQLException(e.getMessage(), resp.getStatus());
       }
       if (!resp.hasResultSet) {

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -19,8 +19,8 @@
 
 package org.apache.iotdb.jdbc;
 
-import org.apache.iotdb.rpc.IoTDBRPCException;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.*;
 import org.apache.thrift.TException;
@@ -217,7 +217,7 @@ public class IoTDBStatement implements Statement {
     TSExecuteStatementResp execResp = client.executeStatement(execReq);
     try {
       RpcUtils.verifySuccess(execResp.getStatus());
-    } catch (IoTDBRPCException e) {
+    } catch (StatementExecutionException e) {
       throw new IoTDBSQLException(e.getMessage(), execResp.getStatus());
     }
     if (execResp.isSetColumns()) {
@@ -325,7 +325,7 @@ public class IoTDBStatement implements Statement {
     queryId = execResp.getQueryId();
     try {
       RpcUtils.verifySuccess(execResp.getStatus());
-    } catch (IoTDBRPCException e) {
+    } catch (StatementExecutionException e) {
       throw new IoTDBSQLException(e.getMessage(), execResp.getStatus());
     }
     if (execResp.queryDataSet == null) {
@@ -387,7 +387,7 @@ public class IoTDBStatement implements Statement {
     }
     try {
       RpcUtils.verifySuccess(execResp.getStatus());
-    } catch (IoTDBRPCException e) {
+    } catch (StatementExecutionException e) {
       throw new IoTDBSQLException(e.getMessage(), execResp.getStatus());
     }
     return 0;

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -617,7 +617,12 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       return resp;
     } catch (ParseCancellationException e) {
       logger.debug(e.getMessage());
-      return getTSExecuteStatementResp(getStatus(TSStatusCode.SQL_PARSE_ERROR, e.getMessage()));
+      return getTSExecuteStatementResp(getStatus(TSStatusCode.SQL_PARSE_ERROR,
+          "Statement format is not right: " + e.getMessage()));
+    } catch (SQLParserException e) {
+      logger.error("check metadata error: ", e);
+      return getTSExecuteStatementResp(
+          getStatus(TSStatusCode.METADATA_ERROR, "Check metadata error: " + e.getMessage()));
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -578,6 +578,49 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     }
   }
 
+  @Override
+  public TSExecuteStatementResp executeQueryStatement(TSExecuteStatementReq req) {
+    try {
+      long startTime = System.currentTimeMillis();
+      TSExecuteStatementResp resp;
+      SqlArgument sqlArgument;
+
+      if (!checkLogin(req.getSessionId())) {
+        logger.info(INFO_NOT_LOGIN, IoTDBConstant.GLOBAL_DB_NAME);
+        return getTSExecuteStatementResp(getStatus(TSStatusCode.NOT_LOGIN_ERROR));
+      }
+
+      String statement = req.getStatement();
+      PhysicalPlan physicalPlan;
+      try {
+        physicalPlan =
+            processor.parseSQLToPhysicalPlan(statement, sessionIdZoneIdMap.get(req.getSessionId()));
+      } catch (QueryProcessException | SQLParserException e) {
+        logger.info(ERROR_PARSING_SQL, e.getMessage());
+        return getTSExecuteStatementResp(getStatus(TSStatusCode.SQL_PARSE_ERROR, e.getMessage()));
+      }
+
+      if (!physicalPlan.isQuery()) {
+        return getTSExecuteStatementResp(
+            getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, "Statement is not a query statement."));
+      }
+
+      resp = internalExecuteQueryStatement(
+          req.statementId, physicalPlan, req.fetchSize,
+          sessionIdUsernameMap.get(req.getSessionId()));
+      long endTime = System.currentTimeMillis();
+      sqlArgument = new SqlArgument(resp, physicalPlan, statement, startTime, endTime);
+      sqlArgumentsList.add(sqlArgument);
+      if (sqlArgumentsList.size() > MAX_SIZE) {
+        sqlArgumentsList.subList(0, DELETE_SIZE).clear();
+      }
+      return resp;
+    } catch (ParseCancellationException e) {
+      logger.debug(e.getMessage());
+      return getTSExecuteStatementResp(getStatus(TSStatusCode.SQL_PARSE_ERROR, e.getMessage()));
+    }
+  }
+
   /**
    * @param plan must be a plan for Query: FillQueryPlan, AggregationPlan, GroupByPlan, some
    *             AuthorPlan
@@ -638,43 +681,6 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     } else {
       return getQueryColumnHeaders(plan, username);
     }
-  }
-
-  @Override
-  public TSExecuteStatementResp executeQueryStatement(TSExecuteStatementReq req) {
-    long startTime = System.currentTimeMillis();
-    TSExecuteStatementResp resp;
-    SqlArgument sqlArgument;
-
-    if (!checkLogin(req.getSessionId())) {
-      logger.info(INFO_NOT_LOGIN, IoTDBConstant.GLOBAL_DB_NAME);
-      return getTSExecuteStatementResp(getStatus(TSStatusCode.NOT_LOGIN_ERROR));
-    }
-
-    String statement = req.getStatement();
-    PhysicalPlan physicalPlan;
-    try {
-      physicalPlan =
-          processor.parseSQLToPhysicalPlan(statement, sessionIdZoneIdMap.get(req.getSessionId()));
-    } catch (QueryProcessException | SQLParserException e) {
-      logger.info(ERROR_PARSING_SQL, e.getMessage());
-      return getTSExecuteStatementResp(getStatus(TSStatusCode.SQL_PARSE_ERROR, e.getMessage()));
-    }
-
-    if (!physicalPlan.isQuery()) {
-      return getTSExecuteStatementResp(
-          getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, "Statement is not a query statement."));
-    }
-
-    resp = internalExecuteQueryStatement(
-        req.statementId, physicalPlan, req.fetchSize, sessionIdUsernameMap.get(req.getSessionId()));
-    long endTime = System.currentTimeMillis();
-    sqlArgument = new SqlArgument(resp, physicalPlan, statement, startTime, endTime);
-    sqlArgumentsList.add(sqlArgument);
-    if (sqlArgumentsList.size() > MAX_SIZE) {
-      sqlArgumentsList.subList(0, DELETE_SIZE).clear();
-    }
-    return resp;
   }
 
   private TSExecuteStatementResp getShowQueryColumnHeaders(ShowPlan showPlan)

--- a/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IOTDBGroupByIT.java
@@ -509,12 +509,12 @@ public class IOTDBGroupByIT {
   @Test
   public void countSumAvgNoDataTest() {
     String[] retArray1 = new String[]{
-        ",0,0.0,null",
-        ",0,0.0,null",
-        ",0,0.0,null",
-        ",0,0.0,null",
-        ",0,0.0,null",
-        ",0,0.0,null",
+        "10000,0,0.0,null",
+        "10005,0,0.0,null",
+        "10010,0,0.0,null",
+        "10015,0,0.0,null",
+        "10020,0,0.0,null",
+        "10025,0,0.0,null",
     };
 
     try (Connection connection = DriverManager.
@@ -523,17 +523,17 @@ public class IOTDBGroupByIT {
       boolean hasResultSet = statement.execute(
           "select count(temperature), sum(temperature), avg(temperature) from "
               + "root.ln.wf01.wt01 where temperature > 3 "
-              + "GROUP BY ([NOW()-30ms, NOW()), 5ms)");
+              + "GROUP BY ([10000, 10030), 5ms)");
 
       Assert.assertTrue(hasResultSet);
       int cnt;
       try (ResultSet resultSet = statement.getResultSet()) {
         cnt = 0;
         while (resultSet.next()) {
-          String ans = "," + resultSet
-              .getString(count("root.ln.wf01.wt01.temperature")) + "," +
-              resultSet.getString(sum("root.ln.wf01.wt01.temperature")) + "," + resultSet
-              .getString(avg("root.ln.wf01.wt01.temperature"));
+          String ans = resultSet.getString("Time") + "," +
+              resultSet.getString(count("root.ln.wf01.wt01.temperature")) + "," +
+              resultSet.getString(sum("root.ln.wf01.wt01.temperature")) + "," +
+              resultSet.getString(avg("root.ln.wf01.wt01.temperature"));
           Assert.assertEquals(retArray1[cnt], ans);
           cnt++;
         }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBConnectionException.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBConnectionException.java
@@ -16,21 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iotdb.session;
+package org.apache.iotdb.rpc;
 
-public class IoTDBSessionException extends Exception {
+public class IoTDBConnectionException extends Exception{
 
-  private static final long serialVersionUID = 2405104784097667293L;
+  private static final long serialVersionUID = -1268775292265203036L;
 
-  public IoTDBSessionException(String msg) {
-    super(msg);
+  public IoTDBConnectionException(String reason) {
+    super(reason);
   }
 
-  public IoTDBSessionException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public IoTDBSessionException(Throwable cause) {
+  public IoTDBConnectionException(Throwable cause) {
     super(cause);
+  }
+
+  public IoTDBConnectionException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
@@ -34,9 +34,11 @@ public class RpcUtils {
    *
    * @param status -status
    */
-  public static void verifySuccess(TSStatus status) throws IoTDBRPCException {
+  public static void verifySuccess(TSStatus status) throws StatementExecutionException {
     if (status.getStatusType().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      throw new IoTDBRPCException(String.format("%d: %s", status.getStatusType().getCode(), status.getStatusType().getMessage()));
+      throw new StatementExecutionException(String.format("%d: %s",
+          status.getStatusType().getCode(),
+          status.getStatusType().getMessage()));
     }
   }
 

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/StatementExecutionException.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/StatementExecutionException.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,12 +18,17 @@
  */
 package org.apache.iotdb.rpc;
 
-public class IoTDBRPCException extends Exception{
+public class StatementExecutionException extends Exception{
 
-  private static final long serialVersionUID = -1268775292265203036L;
-
-  public IoTDBRPCException(String reason) {
+  public StatementExecutionException(String reason) {
     super(reason);
   }
 
+  public StatementExecutionException(Throwable cause) {
+    super(cause);
+  }
+
+  public StatementExecutionException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -26,8 +26,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import org.apache.iotdb.rpc.IoTDBRPCException;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.TSBatchInsertionReq;
 import org.apache.iotdb.service.rpc.thrift.TSCloseSessionReq;
@@ -100,12 +101,12 @@ public class Session {
     this.fetchSize = fetchSize;
   }
 
-  public synchronized void open() throws IoTDBSessionException {
+  public synchronized void open() throws IoTDBConnectionException {
     open(false, Config.DEFAULT_TIMEOUT_MS);
   }
 
   private synchronized void open(boolean enableRPCCompression, int connectionTimeoutInMs)
-      throws IoTDBSessionException {
+      throws IoTDBConnectionException {
     if (!isClosed) {
       return;
     }
@@ -114,7 +115,7 @@ public class Session {
       try {
         transport.open();
       } catch (TTransportException e) {
-        throw new IoTDBSessionException(e);
+        throw new IoTDBConnectionException(e);
       }
     }
 
@@ -153,10 +154,9 @@ public class Session {
         zoneId = ZoneId.of(getTimeZone());
       }
 
-    } catch (TException | IoTDBRPCException e) {
+    } catch (Exception e) {
       transport.close();
-      throw new IoTDBSessionException(String.format("Can not open session to %s:%s with user: %s.",
-          host, port, username), e);
+      throw new IoTDBConnectionException(e);
     }
     isClosed = false;
 
@@ -164,7 +164,7 @@ public class Session {
 
   }
 
-  public synchronized void close() throws IoTDBSessionException {
+  public synchronized void close() throws IoTDBConnectionException {
     if (isClosed) {
       return;
     }
@@ -172,7 +172,7 @@ public class Session {
     try {
       client.closeSession(req);
     } catch (TException e) {
-      throw new IoTDBSessionException(
+      throw new IoTDBConnectionException(
           "Error occurs when closing session at server. Maybe server is down.", e);
     } finally {
       isClosed = true;
@@ -201,7 +201,8 @@ public class Session {
    *
    * @param rowBatch data batch
    */
-  private TSExecuteBatchStatementResp insertSortedBatchIntern(RowBatch rowBatch) throws IoTDBSessionException{
+  private TSExecuteBatchStatementResp insertSortedBatchIntern(RowBatch rowBatch)
+      throws IoTDBConnectionException {
     TSBatchInsertionReq request = new TSBatchInsertionReq();
     request.setSessionId(sessionId);
     request.deviceId = rowBatch.deviceId;
@@ -216,7 +217,7 @@ public class Session {
     try {
       return checkAndReturn(client.insertBatch(request));
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
@@ -227,9 +228,9 @@ public class Session {
    * @param rowBatch data batch
    */
   public TSExecuteBatchStatementResp insertSortedBatch(RowBatch rowBatch)
-      throws IoTDBSessionException {
+      throws StatementExecutionException, IoTDBConnectionException {
     if(!checkSorted(rowBatch)){
-      throw new IoTDBSessionException("Row batch has't been sorted when calling insertSortedBatch");
+      throw new StatementExecutionException("Row batch has't been sorted when calling insertSortedBatch");
     }
     return insertSortedBatchIntern(rowBatch);
   }
@@ -239,8 +240,8 @@ public class Session {
    *
    * @param rowBatch data batch
    */
-  public TSExecuteBatchStatementResp insertBatch(RowBatch rowBatch)
-      throws IoTDBSessionException {
+  public TSExecuteBatchStatementResp insertBatch(RowBatch rowBatch) throws IoTDBConnectionException {
+
     sortRowBatch(rowBatch);
 
     return insertSortedBatchIntern(rowBatch);
@@ -329,9 +330,8 @@ public class Session {
    * @see Session#insertBatch(RowBatch)
    */
   public List<TSStatus> insertInBatch(List<String> deviceIds, List<Long> times,
-      List<List<String>> measurementsList,
-      List<List<String>> valuesList)
-      throws IoTDBSessionException {
+      List<List<String>> measurementsList, List<List<String>> valuesList)
+      throws IoTDBConnectionException {
     // check params size
     int len = deviceIds.size();
     if (len != times.size() || len != measurementsList.size() || len != valuesList.size()) {
@@ -353,7 +353,7 @@ public class Session {
       }
       return result;
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
@@ -365,8 +365,7 @@ public class Session {
    * @see Session#insertBatch(RowBatch)
    */
   public TSStatus insert(String deviceId, long time, List<String> measurements,
-      List<String> values)
-      throws IoTDBSessionException {
+      List<String> values) throws IoTDBConnectionException {
     TSInsertReq request = new TSInsertReq();
     request.setSessionId(sessionId);
     request.setDeviceId(deviceId);
@@ -377,7 +376,7 @@ public class Session {
     try {
       return checkAndReturn(client.insert(request));
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
@@ -386,7 +385,7 @@ public class Session {
    * this method should be used to test other time cost in client
    */
   public TSExecuteBatchStatementResp testInsertBatch(RowBatch rowBatch)
-      throws IoTDBSessionException {
+      throws IoTDBConnectionException {
     TSBatchInsertionReq request = new TSBatchInsertionReq();
     request.setSessionId(sessionId);
     request.deviceId = rowBatch.deviceId;
@@ -401,7 +400,7 @@ public class Session {
     try {
       return client.testInsertBatch(request);
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
@@ -410,9 +409,8 @@ public class Session {
    * this method should be used to test other time cost in client
    */
   public List<TSStatus> testInsertInBatch(List<String> deviceIds, List<Long> times,
-      List<List<String>> measurementsList,
-      List<List<String>> valuesList)
-      throws IoTDBSessionException {
+      List<List<String>> measurementsList, List<List<String>> valuesList)
+      throws IoTDBConnectionException {
     // check params size
     int len = deviceIds.size();
     if (len != times.size() || len != measurementsList.size() || len != valuesList.size()) {
@@ -431,7 +429,7 @@ public class Session {
       client.testInsertRowInBatch(request);
       return Collections.emptyList();
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
@@ -440,8 +438,7 @@ public class Session {
    * this method should be used to test other time cost in client
    */
   public TSStatus testInsert(String deviceId, long time, List<String> measurements,
-      List<String> values)
-      throws IoTDBSessionException {
+      List<String> values) throws IoTDBConnectionException {
     TSInsertReq request = new TSInsertReq();
     request.setSessionId(sessionId);
     request.setDeviceId(deviceId);
@@ -452,7 +449,7 @@ public class Session {
     try {
       return client.testInsertRow(request);
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
@@ -461,7 +458,7 @@ public class Session {
    *
    * @param path timeseries to delete, should be a whole path
    */
-  public TSStatus deleteTimeseries(String path) throws IoTDBSessionException {
+  public TSStatus deleteTimeseries(String path) throws IoTDBConnectionException {
     List<String> paths = new ArrayList<>();
     paths.add(path);
     return deleteTimeseries(paths);
@@ -472,11 +469,11 @@ public class Session {
    *
    * @param paths timeseries to delete, should be a whole path
    */
-  public TSStatus deleteTimeseries(List<String> paths) throws IoTDBSessionException {
+  public TSStatus deleteTimeseries(List<String> paths) throws IoTDBConnectionException {
     try {
       return checkAndReturn(client.deleteTimeseries(sessionId, paths));
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
@@ -486,7 +483,7 @@ public class Session {
    * @param path data in which time series to delete
    * @param time data with time stamp less than or equal to time will be deleted
    */
-  public TSStatus deleteData(String path, long time) throws IoTDBSessionException {
+  public TSStatus deleteData(String path, long time) throws IoTDBConnectionException {
     List<String> paths = new ArrayList<>();
     paths.add(path);
     return deleteData(paths, time);
@@ -498,8 +495,7 @@ public class Session {
    * @param paths data in which time series to delete
    * @param time  data with time stamp less than or equal to time will be deleted
    */
-  public TSStatus deleteData(List<String> paths, long time)
-      throws IoTDBSessionException {
+  public TSStatus deleteData(List<String> paths, long time) throws IoTDBConnectionException {
     TSDeleteDataReq request = new TSDeleteDataReq();
     request.setSessionId(sessionId);
     request.setPaths(paths);
@@ -508,38 +504,38 @@ public class Session {
     try {
       return checkAndReturn(client.deleteData(request));
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
-  public TSStatus setStorageGroup(String storageGroupId) throws IoTDBSessionException {
+  public TSStatus setStorageGroup(String storageGroupId)
+      throws IoTDBConnectionException, StatementExecutionException {
     checkPathValidity(storageGroupId);
     try {
       return checkAndReturn(client.setStorageGroup(sessionId, storageGroupId));
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
 
-  public TSStatus deleteStorageGroup(String storageGroup)
-      throws IoTDBSessionException {
+  public TSStatus deleteStorageGroup(String storageGroup) throws IoTDBConnectionException {
     List<String> groups = new ArrayList<>();
     groups.add(storageGroup);
     return deleteStorageGroups(groups);
   }
 
-  public TSStatus deleteStorageGroups(List<String> storageGroup)
-      throws IoTDBSessionException {
+  public TSStatus deleteStorageGroups(List<String> storageGroup) throws IoTDBConnectionException {
     try {
       return checkAndReturn(client.deleteStorageGroups(sessionId, storageGroup));
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
   public TSStatus createTimeseries(String path, TSDataType dataType,
-      TSEncoding encoding, CompressionType compressor) throws IoTDBSessionException {
+      TSEncoding encoding, CompressionType compressor)
+      throws IoTDBConnectionException, StatementExecutionException {
     checkPathValidity(path);
     TSCreateTimeseriesReq request = new TSCreateTimeseriesReq();
     request.setSessionId(sessionId);
@@ -551,16 +547,17 @@ public class Session {
     try {
       return checkAndReturn(client.createTimeseries(request));
     } catch (TException e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
-  public boolean checkTimeseriesExists(String path) throws IoTDBSessionException {
+  public boolean checkTimeseriesExists(String path)
+      throws StatementExecutionException, IoTDBConnectionException {
     checkPathValidity(path);
     try {
       return executeQueryStatement(String.format("SHOW TIMESERIES %s", path)).hasNext();
     } catch (Exception e) {
-      throw new IoTDBSessionException(e);
+      throw new IoTDBConnectionException(e);
     }
   }
 
@@ -578,19 +575,31 @@ public class Session {
     return resp;
   }
 
-  private synchronized String getTimeZone() throws TException, IoTDBRPCException {
+  private synchronized String getTimeZone()
+      throws StatementExecutionException, IoTDBConnectionException {
     if (zoneId != null) {
       return zoneId.toString();
     }
 
-    TSGetTimeZoneResp resp = client.getTimeZone(sessionId);
+    TSGetTimeZoneResp resp;
+    try {
+      resp = client.getTimeZone(sessionId);
+    } catch (TException e) {
+      throw new IoTDBConnectionException(e);
+    }
     RpcUtils.verifySuccess(resp.getStatus());
     return resp.getTimeZone();
   }
 
-  private synchronized void setTimeZone(String zoneId) throws TException, IoTDBRPCException {
+  private synchronized void setTimeZone(String zoneId)
+      throws StatementExecutionException, IoTDBConnectionException {
     TSSetTimeZoneReq req = new TSSetTimeZoneReq(sessionId, zoneId);
-    TSStatus resp = client.setTimeZone(req);
+    TSStatus resp;
+    try {
+      resp = client.setTimeZone(req);
+    } catch (TException e) {
+      throw new IoTDBConnectionException(e);
+    }
     RpcUtils.verifySuccess(resp);
     this.zoneId = ZoneId.of(zoneId);
   }
@@ -613,7 +622,7 @@ public class Session {
    * @return result set
    */
   public SessionDataSet executeQueryStatement(String sql)
-      throws TException, IoTDBRPCException {
+      throws StatementExecutionException, IoTDBConnectionException {
     if (!checkIsQuery(sql)) {
       throw new IllegalArgumentException("your sql \"" + sql
           + "\" is not a query statement, you should use executeNonQueryStatement method instead.");
@@ -621,7 +630,12 @@ public class Session {
 
     TSExecuteStatementReq execReq = new TSExecuteStatementReq(sessionId, sql, statementId);
     execReq.setFetchSize(fetchSize);
-    TSExecuteStatementResp execResp = client.executeQueryStatement(execReq);
+    TSExecuteStatementResp execResp;
+    try {
+      execResp = client.executeQueryStatement(execReq);
+    } catch (TException e) {
+      throw new IoTDBConnectionException(e);
+    }
 
     RpcUtils.verifySuccess(execResp.getStatus());
     return new SessionDataSet(sql, execResp.getColumns(), execResp.getDataTypeList(),
@@ -633,21 +647,25 @@ public class Session {
    *
    * @param sql non query statement
    */
-  public void executeNonQueryStatement(String sql) throws TException, IoTDBRPCException {
+  public void executeNonQueryStatement(String sql)
+      throws IoTDBConnectionException, StatementExecutionException {
     if (checkIsQuery(sql)) {
       throw new IllegalArgumentException("your sql \"" + sql
           + "\" is a query statement, you should use executeQueryStatement method instead.");
     }
 
     TSExecuteStatementReq execReq = new TSExecuteStatementReq(sessionId, sql, statementId);
-    TSExecuteStatementResp execResp = client.executeUpdateStatement(execReq);
-    RpcUtils.verifySuccess(execResp.getStatus());
+    try {
+      TSExecuteStatementResp execResp = client.executeUpdateStatement(execReq);
+      RpcUtils.verifySuccess(execResp.getStatus());
+    } catch (TException e) {
+      throw new IoTDBConnectionException(e);
+    }
   }
 
-  private void checkPathValidity(String path) throws IoTDBSessionException {
+  private void checkPathValidity(String path) throws StatementExecutionException {
     if (!PATH_PATTERN.matcher(path).matches()) {
-      throw new IoTDBSessionException(
-          String.format("Path [%s] is invalid", path));
+      throw new StatementExecutionException(String.format("Path [%s] is invalid", path));
     }
   }
 }

--- a/session/src/main/java/org/apache/iotdb/session/SessionDataSet.java
+++ b/session/src/main/java/org/apache/iotdb/session/SessionDataSet.java
@@ -24,8 +24,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.iotdb.rpc.IoTDBRPCException;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.TSCloseOperationReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsReq;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
@@ -100,7 +101,7 @@ public class SessionDataSet {
     this.batchSize = batchSize;
   }
 
-  public boolean hasNext() throws SQLException, IoTDBRPCException {
+  public boolean hasNext() throws IoTDBConnectionException, StatementExecutionException {
     if (hasCachedRecord) {
       return true;
     }
@@ -117,7 +118,7 @@ public class SessionDataSet {
           rowsIndex = 0;
         }
       } catch (TException e) {
-        throw new SQLException(
+        throw new IoTDBConnectionException(
             "Cannot fetch result from server, because of network connection: {} ", e);
       }
 
@@ -194,7 +195,6 @@ public class SessionDataSet {
    * judge whether the specified column value is null in the current position
    *
    * @param index column index
-   * @return
    */
   private boolean isNull(int index, int rowNum) {
     byte bitmap = currentBitmap[index];
@@ -202,7 +202,7 @@ public class SessionDataSet {
     return ((flag >>> shift) & bitmap) == 0;
   }
 
-  public RowRecord next() throws SQLException, IoTDBRPCException {
+  public RowRecord next() throws StatementExecutionException, IoTDBConnectionException {
     if (!hasCachedRecord) {
       if (!hasNext()) {
         return null;
@@ -213,16 +213,14 @@ public class SessionDataSet {
     return rowRecord;
   }
 
-  public void closeOperationHandle() throws SQLException {
+  public void closeOperationHandle() throws StatementExecutionException, IoTDBConnectionException {
     try {
       TSCloseOperationReq closeReq = new TSCloseOperationReq(sessionId);
       closeReq.setQueryId(queryId);
       TSStatus closeResp = client.closeOperation(closeReq);
       RpcUtils.verifySuccess(closeResp);
-    } catch (IoTDBRPCException e) {
-      throw new SQLException("Error occurs for close opeation in server side. The reason is " + e);
     } catch (TException e) {
-      throw new SQLException(
+      throw new IoTDBConnectionException(
           "Error occurs when connecting to server for close operation, because: " + e);
     }
   }

--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionIT.java
@@ -198,11 +198,14 @@ public class IoTDBSessionIT {
   }
 
   @Test
-  public void test()
-      throws ClassNotFoundException, SQLException, IoTDBSessionException,
+  public void test() throws ClassNotFoundException, SQLException,
       IoTDBConnectionException, StatementExecutionException {
     session = new Session("127.0.0.1", 6667, "root", "root");
-    session.open();
+    try {
+      session.open();
+    } catch (IoTDBConnectionException e) {
+      e.printStackTrace();
+    }
 
     session.setStorageGroup("root.sg1");
 

--- a/session/src/test/java/org/apache/iotdb/session/IoTDBSessionIT.java
+++ b/session/src/test/java/org/apache/iotdb/session/IoTDBSessionIT.java
@@ -34,7 +34,8 @@ import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.jdbc.Config;
-import org.apache.iotdb.rpc.IoTDBRPCException;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -42,7 +43,6 @@ import org.apache.iotdb.tsfile.read.common.Field;
 import org.apache.iotdb.tsfile.write.record.RowBatch;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.apache.iotdb.tsfile.write.schema.Schema;
-import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,7 +53,7 @@ public class IoTDBSessionIT {
   private Session session;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     System.setProperty(IoTDBConstant.IOTDB_CONF, "src/test/resources/");
     EnvironmentUtils.closeStatMonitor();
     EnvironmentUtils.envSetUp();
@@ -67,7 +67,7 @@ public class IoTDBSessionIT {
 
   @Test
   public void testAlignByDevice()
-      throws IoTDBSessionException, SQLException, ClassNotFoundException, TException, IoTDBRPCException {
+      throws SQLException, IoTDBConnectionException, StatementExecutionException {
     session = new Session("127.0.0.1", 6667, "root", "root");
     session.open();
 
@@ -82,8 +82,7 @@ public class IoTDBSessionIT {
   }
 
   // it's will output too much to travis, so ignore it
-  public void testTime()
-      throws IoTDBSessionException, SQLException, ClassNotFoundException, TException, IoTDBRPCException {
+  public void testTime() throws IoTDBConnectionException, StatementExecutionException {
     session = new Session("127.0.0.1", 6667, "root", "root");
     session.open();
 
@@ -96,7 +95,7 @@ public class IoTDBSessionIT {
 
   @Test
   public void testBatchInsertSeqAndUnseq()
-      throws IoTDBSessionException, SQLException, ClassNotFoundException, TException, IoTDBRPCException {
+      throws SQLException, ClassNotFoundException, IoTDBConnectionException, StatementExecutionException {
     session = new Session("127.0.0.1", 6667, "root", "root");
     session.open();
 
@@ -120,7 +119,7 @@ public class IoTDBSessionIT {
 
   @Test
   public void testBatchInsert()
-      throws IoTDBSessionException, SQLException, ClassNotFoundException, TException, IoTDBRPCException {
+      throws StatementExecutionException, SQLException, ClassNotFoundException, IoTDBConnectionException {
     session = new Session("127.0.0.1", 6667, "root", "root");
     session.open();
 
@@ -133,7 +132,7 @@ public class IoTDBSessionIT {
     queryForBatch();
   }
 
-  public void testTestMethod() throws IoTDBSessionException {
+  public void testTestMethod() throws StatementExecutionException, IoTDBConnectionException {
 
     session = new Session("127.0.0.1", 6667, "root", "root");
     session.open();
@@ -200,7 +199,8 @@ public class IoTDBSessionIT {
 
   @Test
   public void test()
-      throws ClassNotFoundException, SQLException, IoTDBSessionException, TException, IoTDBRPCException {
+      throws ClassNotFoundException, SQLException, IoTDBSessionException,
+      IoTDBConnectionException, StatementExecutionException {
     session = new Session("127.0.0.1", 6667, "root", "root");
     session.open();
 
@@ -273,7 +273,7 @@ public class IoTDBSessionIT {
   }
 
 
-  private void createTimeseriesForTime() throws IoTDBSessionException {
+  private void createTimeseriesForTime() throws StatementExecutionException, IoTDBConnectionException {
     session.createTimeseries("root.sg1.d1.s1", TSDataType.INT64, TSEncoding.RLE,
         CompressionType.SNAPPY);
     session.createTimeseries("root.sg1.d1.s2", TSDataType.INT64, TSEncoding.RLE,
@@ -294,7 +294,7 @@ public class IoTDBSessionIT {
         CompressionType.SNAPPY);
   }
 
-  private void createTimeseries() throws IoTDBSessionException {
+  private void createTimeseries() throws StatementExecutionException, IoTDBConnectionException {
     session.createTimeseries("root.sg1.d1.s1", TSDataType.INT64, TSEncoding.RLE,
         CompressionType.SNAPPY);
     session.createTimeseries("root.sg1.d1.s2", TSDataType.INT64, TSEncoding.RLE,
@@ -309,7 +309,7 @@ public class IoTDBSessionIT {
         CompressionType.SNAPPY);
   }
 
-  private void insertInBatch() throws IoTDBSessionException {
+  private void insertInBatch() throws IoTDBConnectionException {
     String deviceId = "root.sg1.d2";
     List<String> measurements = new ArrayList<>();
     measurements.add("s1");
@@ -342,7 +342,7 @@ public class IoTDBSessionIT {
     session.insertInBatch(deviceIds, timestamps, measurementsList, valuesList);
   }
 
-  private void insert() throws IoTDBSessionException {
+  private void insert() throws IoTDBConnectionException {
     String deviceId = "root.sg1.d1";
     List<String> measurements = new ArrayList<>();
     measurements.add("s1");
@@ -357,7 +357,7 @@ public class IoTDBSessionIT {
     }
   }
 
-  private void insertRowBatchTest1(String deviceId) throws IoTDBSessionException {
+  private void insertRowBatchTest1(String deviceId) throws IoTDBConnectionException {
     Schema schema = new Schema();
     schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.RLE));
     schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.RLE));
@@ -387,7 +387,7 @@ public class IoTDBSessionIT {
     }
   }
 
-  private void deleteData() throws IoTDBSessionException {
+  private void deleteData() throws IoTDBConnectionException {
     String path1 = "root.sg1.d1.s1";
     String path2 = "root.sg1.d1.s2";
     String path3 = "root.sg1.d1.s3";
@@ -400,7 +400,7 @@ public class IoTDBSessionIT {
     session.deleteData(paths, deleteTime);
   }
 
-  private void deleteTimeseries() throws IoTDBSessionException {
+  private void deleteTimeseries() throws IoTDBConnectionException {
     session.deleteTimeseries("root.sg1.d1.s1");
     session.deleteTimeseries("root.laptop.d1.1_2");
     session.deleteTimeseries("root.laptop.d1.\"1.2.3\"");
@@ -434,7 +434,7 @@ public class IoTDBSessionIT {
   }
 
   private void queryForAlignByDevice()
-      throws SQLException, TException, IoTDBRPCException {
+      throws SQLException, StatementExecutionException, IoTDBConnectionException {
     SessionDataSet sessionDataSet = session
         .executeQueryStatement("select '11', s1, '11' from root.sg1.d1 align by device");
     sessionDataSet.setBatchSize(1024);
@@ -453,7 +453,7 @@ public class IoTDBSessionIT {
   }
 
   private void queryForAlignByDevice2()
-      throws SQLException, TException, IoTDBRPCException {
+      throws SQLException, IoTDBConnectionException, StatementExecutionException {
     SessionDataSet sessionDataSet = session.executeQueryStatement(
         "select '11', s1, '11', s5, s1, s5 from root.sg1.d1 align by device");
     sessionDataSet.setBatchSize(1024);
@@ -497,11 +497,11 @@ public class IoTDBSessionIT {
     }
   }
 
-  public void deleteStorageGroupTest()
-      throws ClassNotFoundException, SQLException, IoTDBSessionException {
+  public void deleteStorageGroupTest() throws ClassNotFoundException, SQLException,
+      IoTDBConnectionException, StatementExecutionException {
     try {
       session.deleteStorageGroup("root.sg1.d1.s1");
-    } catch (IoTDBSessionException e) {
+    } catch (IoTDBConnectionException e) {
       assertEquals("The path root.sg1.d1.s1 is not a deletable storage group", e.getMessage());
     }
     session.deleteStorageGroup("root.sg1");
@@ -537,7 +537,7 @@ public class IoTDBSessionIT {
     }
   }
 
-  private void query4() throws TException, IoTDBRPCException, SQLException {
+  private void query4() throws IoTDBConnectionException, StatementExecutionException {
     SessionDataSet sessionDataSet = session.executeQueryStatement("select * from root.sg1.d2");
     sessionDataSet.setBatchSize(1024);
     int count = 0;
@@ -554,7 +554,7 @@ public class IoTDBSessionIT {
   }
 
 
-  private void query3() throws TException, IoTDBRPCException, SQLException {
+  private void query3() throws IoTDBConnectionException, StatementExecutionException {
     SessionDataSet sessionDataSet = session.executeQueryStatement("select * from root.sg1.d1");
     sessionDataSet.setBatchSize(1024);
     int count = 0;
@@ -571,13 +571,13 @@ public class IoTDBSessionIT {
   }
 
 
-  private void insert_via_sql() throws TException, IoTDBRPCException {
+  private void insert_via_sql() throws IoTDBConnectionException, StatementExecutionException {
     session.executeNonQueryStatement(
         "insert into root.sg1.d1(timestamp,s1, s2, s3) values(100, 1,2,3)");
   }
 
   @Test
-  public void checkPathTest() throws IoTDBSessionException {
+  public void checkPathTest() throws IoTDBConnectionException {
     session = new Session("127.0.0.1", 6667, "root", "root");
     session.open();
 
@@ -609,28 +609,30 @@ public class IoTDBSessionIT {
     session.close();
   }
 
-  private void checkSetSG(Session session, String sg, boolean correctStatus) {
+  private void checkSetSG(Session session, String sg, boolean correctStatus)
+      throws IoTDBConnectionException {
     boolean status = true;
     try {
       session.setStorageGroup(sg);
-    } catch (IoTDBSessionException e) {
+    } catch (StatementExecutionException e) {
       status = false;
     }
     assertEquals(correctStatus, status);
   }
 
-  private void checkCreateTimeseries(Session session, String timeseries, boolean correctStatus) {
+  private void checkCreateTimeseries(Session session, String timeseries, boolean correctStatus)
+      throws IoTDBConnectionException {
     boolean status = true;
     try {
       session.createTimeseries(timeseries, TSDataType.INT64, TSEncoding.RLE,
           CompressionType.SNAPPY);
-    } catch (IoTDBSessionException e) {
+    } catch (StatementExecutionException e) {
       status = false;
     }
     assertEquals(correctStatus, status);
   }
 
-  private void insertRowBatchTest2(String deviceId) throws IoTDBSessionException {
+  private void insertRowBatchTest2(String deviceId) throws IoTDBConnectionException {
     Schema schema = new Schema();
     schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.RLE));
     schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.RLE));
@@ -660,7 +662,7 @@ public class IoTDBSessionIT {
     }
   }
 
-  private void insertRowBatchTest3(String deviceId) throws IoTDBSessionException {
+  private void insertRowBatchTest3(String deviceId) throws IoTDBConnectionException {
     Schema schema = new Schema();
     schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.RLE));
     schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.RLE));
@@ -690,7 +692,7 @@ public class IoTDBSessionIT {
     }
   }
 
-  private void insertRowBatchTestForTime(String deviceId) throws IoTDBSessionException {
+  private void insertRowBatchTestForTime(String deviceId) throws IoTDBConnectionException {
     Schema schema = new Schema();
     schema.registerMeasurement(new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.RLE));
     schema.registerMeasurement(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.RLE));


### PR DESCRIPTION
Remove the IoTDBSessionException

Separate the error into IoTDBConnectionException and StatementExecutionException.