### PR TITLE
[IOTDB-476] Improve the ExpressionOptimizer

### DIFF
--- a/docs/Documentation-CHN/SystemDesign/1-TsFile/4-Read.md
+++ b/docs/Documentation-CHN/SystemDesign/1-TsFile/4-Read.md
@@ -384,8 +384,8 @@ IExpression 为查询过滤条件。一个 IExpression 可以是一个 SingleSer
 
     *情况二*：GlobalTimeExpression 和 IExpression 的关系为 OR。该情况下的合并步骤如下：
     1. 得到该查询所要投影的所有时间序列，其为一个 Path 的集合，以一个包含三个投影时间序列的查询为例，记所有要投影的列为 PathList{path1, path2, path3}。
-    2. 记 GlobalTimeExpression 的 Filter 为 tFilter，调用 pushGlobalTimeFilterToAllSeries() 方法为每个 Path 创建一个对应的 SingleSeriesExpression，且每个 SingleSeriesExpression 的 Filter 值均为 tFilter；将所有新创建的 SingleSeriesExpression 用 OR 运算符进行连接，得到一个 OrExpression，记其为 orExpression
-    3. 将步骤二得到的 orExpression 与 IExpression 按照关系 OR 进行合并，得到最终的结果。
+    2. 记 GlobalTimeExpression 的 Filter 为 tFilter，调用 pushGlobalTimeFilterToAllSeries() 方法为每个 Path 创建一个对应的 SingleSeriesExpression，且每个 SingleSeriesExpression 的 Filter 值均为 tFilter；将所有新创建的 SingleSeriesExpression 用 OR 运算符进行连接，得到一个 OrExpression，记其为 orExpression。
+    3. 调用 mergeSecondTreeToFirstTree 方法将 IExpression 中的节点与步骤二得到的 orExpression 中的节点进行合并，返回合并后的表达式。
 
 
     例如，将如下 GlobaLTimeFilter 和 IExpression 按照关系 OR 进行合并，设该查询的被投影列为 PathList{path1, path2, path3}

--- a/docs/Documentation/SystemDesign/1-TsFile/4-Read.md
+++ b/docs/Documentation/SystemDesign/1-TsFile/4-Read.md
@@ -384,11 +384,11 @@ Before the introducing the optimize() method in detail, we first show how to com
     *Case 2*: The relation between GlobalTimeExpression and IExpression is OR. In this case, the merge steps include: 
     1. Analyse the projected time series, which is a set of Path. To take a query with 3 projected time series as an example, denote that projected time series as a set, PathList{path1, path2, path3}。
     2. Denote the Filter in GlobalTimeExpression to be tFilter. The method calls pushGlobalTimeFilterToAllSeries() to generate a corresponding SingleSeriesExpression for each Path. Set the Filters of SingleSeriesExpressions to be tFilter. Join the generated SingleSeriesExpression with OR operator to get an OrExpression, which is denoted as orExpression.
-    3. Combine the result of step 2, the orExpression, and the IExpression with OR operation, to generate the final result.
+    3. Call mergeSecondTreeToFirstTree method to combine the nodes in IExpression with the nodes in the orExpression, which is generated from step 2. The combined structure is the result expression.
+    
+    For example, to combine the following GlobalTimeFilter and IExpression using OR relation, denote the projected time series as PathList{path1, path2, path3}
 
-    For example, to combine the following GlobaLTimeFilter and IExpression using OR relation, denote the projected time series as PathList{path1, path2, path3}
-
-        1. GlobaLTimeFilter(tFilter)
+        1. GlobalTimeFilter(tFilter)
         2. IExpression
                 AndExpression
                     SingleSeriesExpression("path1", filter1)

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/read/filter/IExpressionOptimizerTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/read/filter/IExpressionOptimizerTest.java
@@ -143,7 +143,7 @@ public class IExpressionOptimizerTest {
         .or(BinaryExpression.and(singleSeriesExp1, globalTimeFilter),
             globalTimeFilter2);
     try {
-      String rightRet = "[[[[[d1.s1:time > 1] || [d2.s1:time > 1]] || [d1.s2:time > 1]] || [d2.s2:time > 1]] || [d2.s1:((value > 100 || value < 50) && time < 14001234)]]";
+      String rightRet = "[[[[d1.s1:time > 1] || [d2.s1:(time > 1 || ((value > 100 || value < 50) && time < 14001234))]] || [d1.s2:time > 1]] || [d2.s2:time > 1]]";
       IExpression regularFilter = expressionOptimizer.optimize(expression, selectedSeries);
       Assert.assertEquals(rightRet, regularFilter.toString());
     } catch (QueryFilterOptimizationException e) {
@@ -189,8 +189,10 @@ public class IExpressionOptimizerTest {
 
     try {
       String rightRet =
-          "[[[[[d1.s1:time < 14001234] || [d2.s1:time < 14001234]] || [d1.s2:time < 14001234]] "
-              + "|| [d2.s2:time < 14001234]] || [[d2.s1:(value > 100 || value < 50)] || [d1.s2:(value > 100.5 || value < 50.6)]]]";
+          "[[[[d1.s1:time < 14001234] "
+              + "|| [d2.s1:(time < 14001234 || (value > 100 || value < 50))]] "
+              + "|| [d1.s2:(time < 14001234 || (value > 100.5 || value < 50.6))]] "
+              + "|| [d2.s2:time < 14001234]]";
       IExpression regularFilter = expressionOptimizer.optimize(expression, selectedSeries);
       Assert.assertEquals(rightRet, regularFilter.toString());
     } catch (QueryFilterOptimizationException e) {
@@ -216,9 +218,10 @@ public class IExpressionOptimizerTest {
 
     try {
       String rightRet =
-          "[[[[[d1.s1:(time < 14001234 && time > 14001000)] || [d2.s1:(time < 14001234 "
-              + "&& time > 14001000)]] || [d1.s2:(time < 14001234 && time > 14001000)]] || [d2.s2:(time < 14001234 "
-              + "&& time > 14001000)]] || [[d2.s1:(value > 100 || value < 50)] || [d1.s2:(value > 100.5 || value < 50.6)]]]";
+          "[[[[d1.s1:(time < 14001234 && time > 14001000)] "
+              + "|| [d2.s1:((time < 14001234 && time > 14001000) || (value > 100 || value < 50))]] "
+              + "|| [d1.s2:((time < 14001234 && time > 14001000) || (value > 100.5 || value < 50.6))]] "
+              + "|| [d2.s2:(time < 14001234 && time > 14001000)]]";
       IExpression regularFilter = expressionOptimizer.optimize(expression, selectedSeries);
       Assert.assertEquals(rightRet, regularFilter.toString());
     } catch (QueryFilterOptimizationException e) {


### PR DESCRIPTION
Accidentally, previous pull request failed to be merged into master branch. Here is the details of the pull request.

Some logic in ExpressionOptimizer is modified to make the optimizer generate more efficient expression. For example, before the modification, s1 > 10 or time < 1 will be tranformed to
`ORExpression ( SingleSeriesExpression(s1 , value >10) ORExpression( SingleSeriesExpression(s1 , time <10), SingleSeriesExpression(s2 , time <10) ) )`

With the new logic, the query will be transformed to
`ORExpression ( SingleSeriesExpression(s1 , value >10 or time <10) SingleSeriesExpression(s2 , time <10) )`

With less SingleSeriesExpressions, the query can be executed more efficiently. Experiments shows that, if we have 3 devices, each containing 3 sensors, and the query is t<4838 or d2.s2>0.5, the latency decreases around 10%.