### PR TITLE
[IOTDB-550] Fix TSMRWriteExample executes unsuccessfully

### DIFF
--- a/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSConfUtil.java
+++ b/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSConfUtil.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.hadoop.fileSystem;
 
-
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -27,6 +26,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.fileSystem.FSType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +36,9 @@ class HDFSConfUtil {
   private static final Logger logger = LoggerFactory.getLogger(HDFSConfUtil.class);
 
   static Configuration setConf(Configuration conf) {
+    if (!tsFileConfig.getTSFileStorageFs().equals(FSType.HDFS)) {
+      return conf;
+    }
     try {
       conf.addResource(new File(tsFileConfig.getCoreSitePath()).toURI().toURL());
       conf.addResource(new File(tsFileConfig.getHdfsSitePath()).toURI().toURL());


### PR DESCRIPTION
Add a judgement before setting HDFS configuration to `HDFSOutput`, to avoid unnecessary settings.