### PR TITLE
Use a batched style to get series type

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/exception/query/LogicalOperatorException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/query/LogicalOperatorException.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.exception.query;
 
+import org.apache.iotdb.db.exception.IoTDBException;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 /**
@@ -43,5 +44,9 @@ public class LogicalOperatorException extends QueryProcessException {
   public LogicalOperatorException(String type, String message) {
     super(String.format("Unsupported type: [%s]. %s", type, message),
         TSStatusCode.LOGICAL_OPERATOR_ERROR.getStatusCode());
+  }
+
+  public LogicalOperatorException(IoTDBException e) {
+    super(e);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/exception/query/LogicalOptimizeException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/query/LogicalOptimizeException.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.exception.query;
 
+import org.apache.iotdb.db.exception.IoTDBException;
 import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.rpc.TSStatusCode;
 
@@ -35,5 +36,9 @@ public class LogicalOptimizeException extends LogicalOperatorException {
   public LogicalOptimizeException(String filterOperator, int tokenInt) {
     super(String.format("Unknown token in [%s]: [%s], [%s].", filterOperator, tokenInt,
         SQLConstant.tokenNames.get(tokenInt)), TSStatusCode.LOGICAL_OPTIMIZE_ERROR.getStatusCode());
+  }
+
+  public LogicalOptimizeException(IoTDBException e) {
+    super(e);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/Planner.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/Planner.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.qp;
 
 import java.time.ZoneId;
+import java.util.Set;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.query.LogicalOperatorException;
@@ -35,6 +36,7 @@ import org.apache.iotdb.db.qp.strategy.optimizer.DnfFilterOptimizer;
 import org.apache.iotdb.db.qp.strategy.optimizer.MergeSingleFilterOptimizer;
 import org.apache.iotdb.db.qp.strategy.optimizer.RemoveNotOptimizer;
 import org.apache.iotdb.db.utils.TestOnly;
+import org.apache.iotdb.tsfile.read.common.Path;
 
 /**
  * provide a integration method for other user.
@@ -117,6 +119,7 @@ public class Planner {
     if (filter == null) {
       return root;
     }
+    Set<Path> pathSet = filter.getPathSet();
     RemoveNotOptimizer removeNot = new RemoveNotOptimizer();
     filter = removeNot.optimize(filter);
     DnfFilterOptimizer dnf = new DnfFilterOptimizer();
@@ -124,6 +127,7 @@ public class Planner {
     MergeSingleFilterOptimizer merge = new MergeSingleFilterOptimizer();
     filter = merge.optimize(filter);
     root.setFilterOperator(filter);
+    filter.setPathSet(pathSet);
     return root;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/BasicFunctionOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/BasicFunctionOperator.java
@@ -18,11 +18,11 @@
  */
 package org.apache.iotdb.db.qp.logical.crud;
 
+import java.util.Map;
 import java.util.Objects;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.LogicalOperatorException;
 import org.apache.iotdb.db.exception.runtime.SQLParserException;
-import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -74,9 +74,10 @@ public class BasicFunctionOperator extends FunctionOperator {
   }
 
   @Override
-  protected Pair<IUnaryExpression, String> transformToSingleQueryFilter()
+  protected Pair<IUnaryExpression, String> transformToSingleQueryFilter(
+      Map<Path, TSDataType> pathTSDataTypeHashMap)
       throws LogicalOperatorException, MetadataException {
-    TSDataType type = MManager.getInstance().getSeriesType(singlePath.toString());
+    TSDataType type = pathTSDataTypeHashMap.get(singlePath);
     if (type == null) {
       throw new MetadataException(
           "given seriesPath:{" + singlePath.getFullPath() + "} don't exist in metadata");
@@ -134,6 +135,7 @@ public class BasicFunctionOperator extends FunctionOperator {
     ret.tokenSymbol = tokenSymbol;
     ret.isLeaf = isLeaf;
     ret.isSingle = isSingle;
+    ret.pathSet = pathSet;
     return ret;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/InOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/crud/InOperator.java
@@ -22,11 +22,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.LogicalOperatorException;
-import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
@@ -75,9 +75,10 @@ public class InOperator extends FunctionOperator {
   }
 
   @Override
-  protected Pair<IUnaryExpression, String> transformToSingleQueryFilter()
+  protected Pair<IUnaryExpression, String> transformToSingleQueryFilter(
+      Map<Path, TSDataType> pathTSDataTypeHashMap)
       throws LogicalOperatorException, MetadataException {
-    TSDataType type = MManager.getInstance().getSeriesType(singlePath.toString());
+    TSDataType type = pathTSDataTypeHashMap.get(singlePath);
     if (type == null) {
       throw new MetadataException(
           "given seriesPath:{" + singlePath.getFullPath() + "} don't exist in metadata");
@@ -154,6 +155,7 @@ public class InOperator extends FunctionOperator {
     ret.tokenSymbol = tokenSymbol;
     ret.isLeaf = isLeaf;
     ret.isSingle = isSingle;
+    ret.pathSet = pathSet;
     return ret;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -212,8 +212,13 @@ public class PhysicalGenerator {
     }
   }
 
-  protected TSDataType getSeriesType(String path) throws MetadataException {
-    return SchemaUtils.getSeriesType(path);
+  protected List<TSDataType> getSeriesTypes(List<String> paths,
+      String aggregation) throws MetadataException {
+    return SchemaUtils.getSeriesTypesByString(paths, aggregation);
+  }
+
+  protected List<TSDataType> getSeriesTypes(List<Path> paths) throws MetadataException {
+    return SchemaUtils.getSeriesTypesByPath(paths);
   }
 
   private PhysicalPlan transformQuery(QueryOperator queryOperator)
@@ -304,22 +309,23 @@ public class PhysicalGenerator {
               }
             }
 
-            for (String pathStr : actualPaths) {
+            String aggregation = originAggregations != null && !originAggregations.isEmpty() ?
+                originAggregations.get(i) : null;
+            List<TSDataType> dataTypes = getSeriesTypes(actualPaths, aggregation);
+            for (int pathIdx = 0; pathIdx < actualPaths.size(); pathIdx++) {
+              String pathStr = actualPaths.get(pathIdx);
               Path path = new Path(pathStr);
 
               // check datatype consistency
               // a example of inconsistency: select s0 from root.sg1.d1, root.sg2.d3 align by device,
               // while root.sg1.d1.s0 is INT32 and root.sg2.d3.s0 is FLOAT.
-              String pathForDataType;
               String measurementChecked;
               if (originAggregations != null && !originAggregations.isEmpty()) {
-                pathForDataType = originAggregations.get(i) + "(" + path.getFullPath() + ")";
                 measurementChecked = originAggregations.get(i) + "(" + path.getMeasurement() + ")";
               } else {
-                pathForDataType = path.getFullPath();
                 measurementChecked = path.getMeasurement();
               }
-              TSDataType dataType = getSeriesType(pathForDataType);
+              TSDataType dataType = dataTypes.get(pathIdx);
               if (measurementDataTypeMap.containsKey(measurementChecked)) {
                 if (!dataType.equals(measurementDataTypeMap.get(measurementChecked))) {
                   throw new QueryProcessException(
@@ -392,8 +398,18 @@ public class PhysicalGenerator {
       FilterOperator filterOperator = queryOperator.getFilterOperator();
 
       if (filterOperator != null) {
-        IExpression expression = filterOperator.transformToExpression();
-        ((RawDataQueryPlan) queryPlan).setExpression(expression);
+        List<Path> filterPaths = new ArrayList<>(filterOperator.getPathSet());
+        try {
+          List<TSDataType> seriesTypes = getSeriesTypes(filterPaths);
+          HashMap<Path, TSDataType> pathTSDataTypeHashMap = new HashMap<>();
+          for (int i = 0; i < filterPaths.size(); i++) {
+            pathTSDataTypeHashMap.put(filterPaths.get(i), seriesTypes.get(i));
+          }
+          IExpression expression = filterOperator.transformToExpression(pathTSDataTypeHashMap);
+          ((RawDataQueryPlan) queryPlan).setExpression(expression);
+        } catch (MetadataException e) {
+          throw new LogicalOptimizeException(e);
+        }
       }
     }
     try {
@@ -416,11 +432,23 @@ public class PhysicalGenerator {
       FilterOperator operator)
       throws QueryProcessException {
     Map<String, IExpression> deviceToFilterMap = new HashMap<>();
+    Set<Path> filterPaths = new HashSet<>();
     for (String device : devices) {
       FilterOperator newOperator = operator.copy();
-      concatFilterPath(device, newOperator);
-
-      deviceToFilterMap.put(device, newOperator.transformToExpression());
+      concatFilterPath(device, newOperator, filterPaths);
+      // transform to a list so it can be indexed
+      List<Path> filterPathList = new ArrayList<>(filterPaths);
+      try {
+        List<TSDataType> seriesTypes = getSeriesTypes(filterPathList);
+        Map<Path, TSDataType> pathTSDataTypeHashMap = new HashMap<>();
+        for (int i = 0; i < filterPathList.size(); i++) {
+          pathTSDataTypeHashMap.put(filterPathList.get(i), seriesTypes.get(i));
+        }
+        deviceToFilterMap.put(device, newOperator.transformToExpression(pathTSDataTypeHashMap));
+        filterPaths.clear();
+      } catch (MetadataException e) {
+        throw new QueryProcessException(e);
+      }
     }
 
     return deviceToFilterMap;
@@ -442,10 +470,11 @@ public class PhysicalGenerator {
     return retDevices;
   }
 
-  private void concatFilterPath(String prefix, FilterOperator operator) {
+  private void concatFilterPath(String prefix, FilterOperator operator,
+      Set<Path> filterPaths) {
     if (!operator.isLeaf()) {
       for (FilterOperator child : operator.getChildren()) {
-        concatFilterPath(prefix, child);
+        concatFilterPath(prefix, child, filterPaths);
       }
       return;
     }
@@ -454,20 +483,22 @@ public class PhysicalGenerator {
 
     // do nothing in the cases of "where time > 5" or "where root.d1.s1 > 5"
     if (SQLConstant.isReservedPath(filterPath) || filterPath.startWith(SQLConstant.ROOT)) {
+      filterPaths.add(filterPath);
       return;
     }
 
     Path concatPath = Path.addPrefixPath(filterPath, prefix);
+    filterPaths.add(concatPath);
     basicOperator.setSinglePath(concatPath);
   }
 
   private void generateDataTypes(QueryPlan queryPlan) throws MetadataException {
     List<Path> paths = queryPlan.getPaths();
-    List<TSDataType> dataTypes = new ArrayList<>(paths.size());
-    for (Path path : paths) {
-      TSDataType seriesType = getSeriesType(path.toString());
-      dataTypes.add(seriesType);
-      queryPlan.addTypeMapping(path, seriesType);
+    List<TSDataType> dataTypes = getSeriesTypes(paths);
+    for (int i = 0; i < paths.size(); i++) {
+      Path path = paths.get(i);
+      TSDataType dataType = dataTypes.get(i);
+      queryPlan.addTypeMapping(path, dataType);
     }
     queryPlan.setDataTypes(dataTypes);
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -313,8 +313,7 @@ public class PhysicalGenerator {
                 originAggregations.get(i) : null;
             List<TSDataType> dataTypes = getSeriesTypes(actualPaths, aggregation);
             for (int pathIdx = 0; pathIdx < actualPaths.size(); pathIdx++) {
-              String pathStr = actualPaths.get(pathIdx);
-              Path path = new Path(pathStr);
+              Path path = new Path(actualPaths.get(pathIdx));
 
               // check datatype consistency
               // a example of inconsistency: select s0 from root.sg1.d1, root.sg2.d3 align by device,

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
@@ -19,8 +19,10 @@
 package org.apache.iotdb.db.qp.strategy.optimizer;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.runtime.SQLParserException;
@@ -110,12 +112,14 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
 
     // concat filter
     FilterOperator filter = sfwOperator.getFilterOperator();
+    Set<Path> filterPaths = new HashSet<>();
     if (filter == null) {
       return operator;
     }
     if(!isAlignByDevice){
-      sfwOperator.setFilterOperator(concatFilter(prefixPaths, filter));
+      sfwOperator.setFilterOperator(concatFilter(prefixPaths, filter, filterPaths));
     }
+    filter.setPathSet(filterPaths);
     // GROUP_BY_DEVICE leaves the concatFilter to PhysicalGenerator to optimize filter without prefix first
 
     return sfwOperator;
@@ -208,12 +212,13 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
     }
   }
 
-  private FilterOperator concatFilter(List<Path> fromPaths, FilterOperator operator)
+  private FilterOperator concatFilter(List<Path> fromPaths, FilterOperator operator,
+      Set<Path> filterPaths)
       throws LogicalOptimizeException {
     if (!operator.isLeaf()) {
       List<FilterOperator> newFilterList = new ArrayList<>();
       for (FilterOperator child : operator.getChildren()) {
-        newFilterList.add(concatFilter(fromPaths, child));
+        newFilterList.add(concatFilter(fromPaths, child, filterPaths));
       }
       operator.setChildren(newFilterList);
       return operator;
@@ -222,11 +227,13 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
     Path filterPath = functionOperator.getSinglePath();
     // do nothing in the cases of "where time > 5" or "where root.d1.s1 > 5"
     if (SQLConstant.isReservedPath(filterPath) || filterPath.startWith(SQLConstant.ROOT)) {
+      filterPaths.add(filterPath);
       return operator;
     }
     List<Path> concatPaths = new ArrayList<>();
     fromPaths.forEach(fromPath -> concatPaths.add(Path.addPrefixPath(filterPath, fromPath)));
     List<Path> noStarPaths = removeStarsInPathWithUnique(concatPaths);
+    filterPaths.addAll(noStarPaths);
     if (noStarPaths.size() == 1) {
       // Transform "select s1 from root.car.* where s1 > 10" to
       // "select s1 from root.car.* where root.car.*.s1 > 10"

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -334,9 +334,17 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     return new TSStatus(statusCodeAndMessage);
   }
 
-  protected TSDataType getSeriesType(String path) throws QueryProcessException, MetadataException {
+  protected List<TSDataType> getSeriesTypesByPath(List<Path> paths, List<String> aggregations) throws QueryProcessException {
     try {
-      return SchemaUtils.getSeriesType(path);
+      return SchemaUtils.getSeriesTypesByPath(paths, aggregations);
+    } catch (MetadataException e) {
+      throw new QueryProcessException(e);
+    }
+  }
+
+  protected List<TSDataType> getSeriesTypesByString(List<String> paths, String aggregation) throws QueryProcessException {
+    try {
+      return SchemaUtils.getSeriesTypesByString(paths, aggregation);
     } catch (MetadataException e) {
       throw new QueryProcessException(e);
     }
@@ -360,7 +368,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           status = getStatus(TSStatusCode.SUCCESS_STATUS);
           break;
         case "COLUMN":
-          resp.setDataType(getSeriesType(req.getColumnPath()).toString());
+          resp.setDataType(getSeriesTypesByString(Collections.singletonList(req.getColumnPath()), null).get(0).toString());
           status = getStatus(TSStatusCode.SUCCESS_STATUS);
           break;
         case "ALL_COLUMNS":
@@ -781,12 +789,14 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     // Restore column header of aggregate to func(column_name), only
     // support single aggregate function for now
     List<Path> paths = plan.getPaths();
+    List<TSDataType> seriesTypes;
     switch (plan.getOperatorType()) {
       case QUERY:
       case FILL:
         for (Path p : paths) {
           respColumns.add(p.getFullPath());
         }
+        seriesTypes = getSeriesTypesByString(respColumns, null);
         break;
       case AGGREGATION:
       case GROUPBY:
@@ -799,17 +809,14 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         for (int i = 0; i < paths.size(); i++) {
           respColumns.add(aggregations.get(i) + "(" + paths.get(i).getFullPath() + ")");
         }
+        seriesTypes = getSeriesTypesByPath(paths, aggregations);
         break;
       default:
         throw new TException("unsupported query type: " + plan.getOperatorType());
     }
 
-    for (String column : respColumns) {
-      try {
-        columnTypes.add(getSeriesType(column).toString());
-      } catch (MetadataException e) {
-        throw new QueryProcessException(e);
-      }
+    for (TSDataType seriesType : seriesTypes) {
+      columnTypes.add(seriesType.toString());
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
@@ -100,6 +100,12 @@ public class SchemaUtils {
     return dataTypes;
   }
 
+  /**
+   *
+   * @param paths time series paths
+   * @param aggregation aggregation function, may be null
+   * @return The data type of aggregation or (data type of paths if aggregation is null)
+   */
   public static List<TSDataType> getSeriesTypesByString(Collection<String> paths,
       String aggregation) throws MetadataException {
     TSDataType dataType = getAggregationType(aggregation);
@@ -142,8 +148,8 @@ public class SchemaUtils {
 
   /**
    *
-   * @param aggregation
-   * @return the data type of the aggregation or null if it cannot be determined
+   * @param aggregation aggregation function
+   * @return the data type of the aggregation or null if it aggregation is null
    */
   public static TSDataType getAggregationType(String aggregation) throws MetadataException {
     if (aggregation == null) {

--- a/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
@@ -18,12 +18,8 @@
  */
 package org.apache.iotdb.db.utils;
 
-import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_PRIVILEGE;
-import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_ROLE;
-import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_STORAGE_GROUP;
-import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TTL;
-import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_USER;
-
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.apache.iotdb.db.engine.StorageEngine;
@@ -96,46 +92,79 @@ public class SchemaUtils {
     }
 
   }
-
-  public static TSDataType getSeriesType(String path)
-      throws MetadataException {
-    switch (path.toLowerCase()) {
-      // authorization queries
-      case COLUMN_ROLE:
-      case COLUMN_USER:
-      case COLUMN_PRIVILEGE:
-      case COLUMN_STORAGE_GROUP:
-        return TSDataType.TEXT;
-      case SQLConstant.RESERVED_TIME:
-      case COLUMN_TTL:
-        return TSDataType.INT64;
-      default:
-        // do nothing
+  public static List<TSDataType> getSeriesTypesByPath(Collection<Path> paths) throws MetadataException {
+    List<TSDataType> dataTypes = new ArrayList<>();
+    for (Path path : paths) {
+      dataTypes.add(MManager.getInstance().getSeriesType(path.getFullPath()));
     }
+    return dataTypes;
+  }
 
-    if (path.contains("(") && !path.startsWith("(") && path.endsWith(")")) {
-      // aggregation
-      int leftBracketIndex = path.indexOf('(');
-      String aggrType = path.substring(0, leftBracketIndex);
-      String innerPath = path.substring(leftBracketIndex + 1, path.length() - 1);
-      switch (aggrType.toLowerCase()) {
-        case SQLConstant.MIN_TIME:
-        case SQLConstant.MAX_TIME:
-        case SQLConstant.COUNT:
-          return TSDataType.INT64;
-        case SQLConstant.LAST_VALUE:
-        case SQLConstant.FIRST_VALUE:
-        case SQLConstant.MIN_VALUE:
-        case SQLConstant.MAX_VALUE:
-          return getSeriesType(innerPath);
-        case SQLConstant.AVG:
-        case SQLConstant.SUM:
-          return TSDataType.DOUBLE;
-        default:
-          throw new MetadataException(
-              "aggregate does not support " + aggrType + " function.");
+  public static List<TSDataType> getSeriesTypesByString(Collection<String> paths,
+      String aggregation) throws MetadataException {
+    TSDataType dataType = getAggregationType(aggregation);
+    if (dataType != null) {
+      return Collections.nCopies(paths.size(), dataType);
+    }
+    List<TSDataType> dataTypes = new ArrayList<>();
+    for (String path : paths) {
+      dataTypes.add(MManager.getInstance().getSeriesType(path));
+    }
+    return dataTypes;
+  }
+
+  public static List<TSDataType> getSeriesTypesByPath(Collection<Path> paths,
+      String aggregation) throws MetadataException {
+    TSDataType dataType = getAggregationType(aggregation);
+    if (dataType != null) {
+      return Collections.nCopies(paths.size(), dataType);
+    }
+    List<TSDataType> dataTypes = new ArrayList<>();
+    for (Path path : paths) {
+      dataTypes.add(MManager.getInstance().getSeriesType(path.getFullPath()));
+    }
+    return dataTypes;
+  }
+
+  public static List<TSDataType> getSeriesTypesByPath(List<Path> paths,
+      List<String> aggregations) throws MetadataException {
+    List<TSDataType> tsDataTypes = new ArrayList<>();
+    for (int i = 0; i < paths.size(); i++) {
+      TSDataType dataType = getAggregationType(aggregations.get(i));
+      if (dataType != null) {
+        tsDataTypes.add(dataType);
+      } else {
+        tsDataTypes.add(MManager.getInstance().getSeriesType(paths.get(i).getFullPath()));
       }
     }
-    return MManager.getInstance().getSeriesType(path);
+    return tsDataTypes;
+  }
+
+  /**
+   *
+   * @param aggregation
+   * @return the data type of the aggregation or null if it cannot be determined
+   */
+  public static TSDataType getAggregationType(String aggregation) throws MetadataException {
+    if (aggregation == null) {
+      return null;
+    }
+    switch (aggregation.toLowerCase()) {
+      case SQLConstant.MIN_TIME:
+      case SQLConstant.MAX_TIME:
+      case SQLConstant.COUNT:
+        return TSDataType.INT64;
+      case SQLConstant.LAST_VALUE:
+      case SQLConstant.FIRST_VALUE:
+      case SQLConstant.MIN_VALUE:
+      case SQLConstant.MAX_VALUE:
+        return null;
+      case SQLConstant.AVG:
+      case SQLConstant.SUM:
+        return TSDataType.DOUBLE;
+      default:
+        throw new MetadataException(
+            "aggregate does not support " + aggregation + " function.");
+    }
   }
 }


### PR DESCRIPTION
Datatypes of timeseries are required during the query process to construct filters, readers, and datasets. They are currently determined in a one-by-one style and this PR will change it to a batched style which incurs the following benefits:
1. Reduced method calls and increased locality
2. Reduced communications in the distributed version
3. Possibly reduced datatype queries of the same series
The main affected classes are PhysicalGenerator, TSServiceImpl, and ConcatPathOptimizer.