### PR TITLE
[IOTDB-553] Return Empty ResultSet when queried series doesn't exist

### DIFF
--- a/client/src/main/java/org/apache/iotdb/client/AbstractClient.java
+++ b/client/src/main/java/org/apache/iotdb/client/AbstractClient.java
@@ -503,7 +503,7 @@ public abstract class AbstractClient {
       } else {
         blockLine.append("+");
       }
-      if (resultSetMetaData.getColumnName(2).equals(GROUPBY_DEVICE_COLUMN_NAME)) {
+      if (resultSetMetaData.getColumnCount() > 1 && resultSetMetaData.getColumnName(2).equals(GROUPBY_DEVICE_COLUMN_NAME)) {
         maxValueLength = measurementColumnLength;
       } else {
         int tmp = Integer.MIN_VALUE;

--- a/pom.xml
+++ b/pom.xml
@@ -533,7 +533,7 @@
                         <id>enforce-version-convergence</id>
                         <configuration>
                             <rules>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                         <goals>
@@ -579,7 +579,7 @@
                                 </requireJavaVersion>
                                 <!-- Disabled for now as it breaks the ability to build single modules -->
                                 <!--reactorModuleConvergence/-->
-                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies" />
+                                <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
                             </rules>
                         </configuration>
                     </execution>
@@ -727,7 +727,7 @@
                     <instrumentation>
                         <ignoreTrivial>true</ignoreTrivial>
                     </instrumentation>
-                    <check />
+                    <check/>
                 </configuration>
                 <executions>
                     <execution>
@@ -883,7 +883,7 @@
                     <plugin>
                         <groupId>com.googlecode.maven-download-plugin</groupId>
                         <artifactId>download-maven-plugin</artifactId>
-                        <version>1.4.0</version>
+                        <version>1.3.0</version>
                         <executions>
                             <execution>
                                 <id>get-thrift-executable</id>

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -279,10 +279,6 @@ public class PhysicalGenerator {
         measurementColumnList.addAll(measurementSetOfGivenSuffix);
       }
 
-      if (measurementColumnList.isEmpty()) {
-        throw new QueryProcessException("do not select any existing series");
-      }
-
       // slimit trim on the measurementColumnList
       if (queryOperator.hasSlimit()) {
         int seriesSlimit = queryOperator.getSeriesLimit();

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
@@ -302,10 +302,6 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
     for (int i = 0; i < paths.size(); i++) {
       try {
         List<String> actualPaths = executor.getAllPaths(paths.get(i).getFullPath());
-        if (actualPaths.isEmpty()) {
-          throw new LogicalOptimizeException(
-              "Path: \"" + paths.get(i) + "\" doesn't correspond to any known time series");
-        }
         for (String actualPath : actualPaths) {
           retPaths.add(new Path(actualPath));
           if (afterConcatAggregations != null && !afterConcatAggregations.isEmpty()) {

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -31,6 +31,7 @@ import java.sql.Statement;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -823,11 +824,6 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     List<Path> paths = plan.getPaths();
     List<String> respColumns = new ArrayList<>();
 
-    // check seriesPath exists
-    if (paths.isEmpty()) {
-      return getTSExecuteStatementResp(getStatus(TSStatusCode.TIMESERIES_NOT_EXIST_ERROR));
-    }
-
     // check file level set
     try {
       checkFileLevelSet(paths);
@@ -843,6 +839,12 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     }
 
     TSExecuteStatementResp resp = getTSExecuteStatementResp(getStatus(TSStatusCode.SUCCESS_STATUS));
+
+    // check seriesPath exists
+    if (paths.isEmpty()) {
+      resp.setColumns(Collections.emptyList());
+      return resp;
+    }
 
     if (((QueryPlan) plan).isGroupByDevice()) {
       // set columns in TSExecuteStatementResp. Note this is without deduplication.

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBGroupbyDeviceIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBGroupbyDeviceIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.integration;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.sql.Connection;
@@ -594,7 +595,7 @@ public class IoTDBGroupbyDeviceIT {
         Statement statement = connection.createStatement()) {
       boolean hasResultSet = statement.execute(
           "select s0 from root.nonexistent.noneixtsent group by device");
-      fail("No exception thrown.");
+      assertTrue(hasResultSet);
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("do not select any existing series"));
     }

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMultiSeriesIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBMultiSeriesIT.java
@@ -374,20 +374,6 @@ public class IoTDBMultiSeriesIT {
   }
 
   @Test
-  public void selectUnknownTimeSeries() throws ClassNotFoundException {
-    Class.forName(Config.JDBC_DRIVER_NAME);
-
-    try (Connection connection = DriverManager
-        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
-        Statement statement = connection.createStatement()) {
-      statement.execute("select s10 from root.vehicle.d0");
-      fail("not throw exception when select unknown time series");
-    } catch (SQLException e) {
-      assertEquals("Statement format is not right: Path: \"root.vehicle.d0.s10\" doesn't correspond to any known time series", e.getMessage());
-    }
-  }
-
-  @Test
   public void selectWhereUnknownTimeSeries() throws ClassNotFoundException {
     Class.forName(Config.JDBC_DRIVER_NAME);
 


### PR DESCRIPTION
This PR is a quick fix of version `0.9.x`: Return Empty ResultSet when queried series doesn't exist, instead of throwing an exception. And the issue is perfectly solved in the to-be-released version `0.10.0`.