### PR TITLE
Fix bugs of add duplicated metadata

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -1537,8 +1537,9 @@ public class StorageGroupProcessor {
     writeLock();
     mergeLock.writeLock().lock();
     try {
-      loadTsFileByType(LoadTsFileType.LOAD_SEQUENCE, tsfileToBeInserted, newTsFileResource);
-      updateLatestTimeMap(newTsFileResource);
+      if (loadTsFileByType(LoadTsFileType.LOAD_SEQUENCE, tsfileToBeInserted, newTsFileResource)){
+        updateLatestTimeMap(newTsFileResource);
+      }
     } catch (DiskSpaceInsufficientException e) {
       logger.error(
           "Failed to append the tsfile {} to storage group processor {} because the disk space is insufficient.",
@@ -1780,8 +1781,9 @@ public class StorageGroupProcessor {
    * @param type load type
    * @param tsFileResource tsfile resource to be loaded
    * @UsedBy sync module, load external tsfile module.
+   * @return load the file successfully
    */
-  private void loadTsFileByType(LoadTsFileType type, File syncedTsFile,
+  private boolean loadTsFileByType(LoadTsFileType type, File syncedTsFile,
       TsFileResource tsFileResource)
       throws TsFileProcessorException, DiskSpaceInsufficientException {
     File targetFile;
@@ -1793,6 +1795,10 @@ public class StorageGroupProcessor {
             storageGroupName + File.separatorChar + timeRangeId + File.separator + tsFileResource
                 .getFile().getName());
         tsFileResource.setFile(targetFile);
+        if(unSequenceFileList.contains(tsFileResource)){
+          logger.error("The file {} has already been loaded in unsequence list", tsFileResource);
+          return false;
+        }
         unSequenceFileList.add(tsFileResource);
         logger.info("Load tsfile in unsequence list, move file from {} to {}",
             syncedTsFile.getAbsolutePath(), targetFile.getAbsolutePath());
@@ -1803,6 +1809,10 @@ public class StorageGroupProcessor {
                 storageGroupName + File.separatorChar + timeRangeId + File.separator
                     + tsFileResource.getFile().getName());
         tsFileResource.setFile(targetFile);
+        if(sequenceFileTreeSet.contains(tsFileResource)){
+          logger.error("The file {} has already been loaded in sequence list", tsFileResource);
+          return false;
+        }
         sequenceFileTreeSet.add(tsFileResource);
         logger.info("Load tsfile in sequence list, move file from {} to {}",
             syncedTsFile.getAbsolutePath(), targetFile.getAbsolutePath());
@@ -1840,6 +1850,7 @@ public class StorageGroupProcessor {
           syncedResourceFile.getAbsolutePath(), targetResourceFile.getAbsolutePath(),
           e.getMessage()));
     }
+    return true;
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -451,19 +451,15 @@ public class MManager {
    * @param storageGroup root.node.(node)*
    */
   public void setStorageGroup(String storageGroup) throws MetadataException {
-    if (mtree.checkStorageGroupByPath(storageGroup)) {
-      throw new MetadataException(
-          String.format("Storage group <%s> has already existed.", storageGroup));
-    }
     lock.writeLock().lock();
     try {
+      mtree.setStorageGroup(storageGroup);
       if (writeToLog) {
         BufferedWriter writer = getLogWriter();
         writer.write(MetadataOperationType.SET_STORAGE_GROUP + "," + storageGroup);
         writer.newLine();
         writer.flush();
       }
-      mtree.setStorageGroup(storageGroup);
       IoTDBConfigDynamicAdapter.getInstance().addOrDeleteStorageGroup(1);
       ActiveTimeSeriesCounter.getInstance().init(storageGroup);
       seriesNumberInStorageGroups.put(storageGroup, 0);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -451,6 +451,10 @@ public class MManager {
    * @param storageGroup root.node.(node)*
    */
   public void setStorageGroup(String storageGroup) throws MetadataException {
+    if (mtree.checkStorageGroupByPath(storageGroup)) {
+      throw new MetadataException(
+          String.format("Storage group <%s> has already existed.", storageGroup));
+    }
     lock.writeLock().lock();
     try {
       if (writeToLog) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -102,6 +102,9 @@ public class MTree implements Serializable {
     }
     MNode leaf = new LeafMNode(cur, nodeNames[nodeNames.length - 1], dataType, encoding,
         compressor, props);
+    if (cur.hasChild(leaf.getName())) {
+      throw new MetadataException(String.format("The timeseries %s has already existed.", path));
+    }
     cur.addChild(leaf);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/manage/SyncFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/manage/SyncFileManager.java
@@ -102,16 +102,6 @@ public class SyncFileManager implements ISyncFileManager {
           .equals(TsFileConstant.PATH_UPGRADE)) {
         continue;
       }
-      try {
-        if (!MManager.getInstance().getStorageGroupName(sgFolder.getName())
-            .equals(sgFolder.getName())) {
-          // the folder is not a sg folder
-          continue;
-        }
-      } catch (MetadataException e) {
-        // the folder is not a sg folder
-        continue;
-      }
       allSGs.putIfAbsent(sgFolder.getName(), new HashSet<>());
       currentAllLocalFiles.putIfAbsent(sgFolder.getName(), new HashMap<>());
       for (File timeRangeFolder : sgFolder.listFiles()) {

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/transfer/SyncClient.java
@@ -53,6 +53,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.iotdb.db.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.db.concurrent.ThreadName;
+import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.SyncConnectionException;
@@ -67,6 +68,7 @@ import org.apache.iotdb.db.sync.sender.recover.ISyncSenderLogger;
 import org.apache.iotdb.db.sync.sender.recover.SyncSenderLogAnalyzer;
 import org.apache.iotdb.db.sync.sender.recover.SyncSenderLogger;
 import org.apache.iotdb.db.utils.SyncUtils;
+import org.apache.iotdb.service.sync.thrift.ConfirmInfo;
 import org.apache.iotdb.service.sync.thrift.SyncService;
 import org.apache.iotdb.service.sync.thrift.SyncStatus;
 import org.apache.iotdb.tsfile.utils.BytesUtils;
@@ -286,9 +288,12 @@ public class SyncClient implements ISyncClient {
 
   @Override
   public void confirmIdentity() throws SyncConnectionException {
-    try (Socket socket = new Socket(config.getServerIp(), config.getServerPort())){
+    try (Socket socket = new Socket(config.getServerIp(), config.getServerPort())) {
+      ConfirmInfo info = new ConfirmInfo(socket.getLocalAddress().getHostAddress(),
+          getOrCreateUUID(getUuidFile()),
+          IoTDBDescriptor.getInstance().getConfig().getPartitionInterval(), IoTDBConstant.VERSION);
       SyncStatus status = serviceClient
-          .check(socket.getLocalAddress().getHostAddress(), getOrCreateUUID(getUuidFile()));
+          .check(info);
       if (status.code != SUCCESS_CODE) {
         throw new SyncConnectionException(
             "The receiver rejected the synchronization task because " + status.msg);

--- a/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
@@ -55,6 +55,7 @@ public class FileLoaderUtils {
     } else {
       tsFileResource.deserialize();
     }
+    tsFileResource.setClosed(true);
   }
 
   public static void updateTsFileResource(TsFileMetaData metaData, TsFileSequenceReader reader,

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -296,7 +296,7 @@ public class MTreeTest {
       root.setStorageGroup("root.laptop.d2");
       root.createTimeseries("root.laptop.d1.s1", TSDataType.INT32, TSEncoding.PLAIN,
           CompressionType.GZIP, null);
-      root.createTimeseries("root.laptop.d1.s1", TSDataType.INT32, TSEncoding.PLAIN,
+      root.createTimeseries("root.laptop.d1.s2", TSDataType.INT32, TSEncoding.PLAIN,
           CompressionType.GZIP, null);
 
       List<String> list = new ArrayList<>();

--- a/service-rpc/src/main/thrift/sync.thrift
+++ b/service-rpc/src/main/thrift/sync.thrift
@@ -18,15 +18,28 @@
  */
 namespace java org.apache.iotdb.service.sync.thrift
 
-typedef i32 int 
-
 struct SyncStatus{
-  required i32 code
-  required string msg
+  1:required i32 code
+  2:required string msg
+}
+
+// The sender and receiver need to check some info to confirm validity
+struct ConfirmInfo{
+  // check whether the ip of sender is in thw white list of receiver.
+  1:string address
+
+  // Sender needs to tell receiver its identity.
+  2:string uuid
+
+  // The partition interval of sender and receiver need to be the same.
+  3:i64 partitionInterval
+
+  // The version of sender and receiver need to be the same.
+  4:string version
 }
 
 service SyncService{
-	SyncStatus check(1:string address, 2:string uuid)
+	SyncStatus check(ConfirmInfo info)
 	SyncStatus startSync();
 	SyncStatus init(1:string storageGroupName)
 	SyncStatus syncDeletedFileName(1:string fileName)


### PR DESCRIPTION
When adding metadata which already exists in the engine. Previously, its result is as follow:
![image](https://user-images.githubusercontent.com/26211279/76854704-8d159980-688a-11ea-9c31-29bbcfb2e974.png)

It's caused by not checking existence when adding metadata.
In this case, when you restart the engine, you will query nothing from the engine:
![image](https://user-images.githubusercontent.com/26211279/76855729-b6372980-688c-11ea-80fa-d6d0d995dcea.png)

