### PR TITLE
Fix empty ChunkMetadata in LAST query gives wrong answer bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -128,15 +128,18 @@ public class LastQueryExecutor {
     TimeValuePair resultPair = new TimeValuePair(Long.MIN_VALUE, null);
 
     if (!seqFileResources.isEmpty()) {
-      List<ChunkMetaData> chunkMetadata =
-          FileLoaderUtils.loadChunkMetadataFromTsFileResource(
-              seqFileResources.get(seqFileResources.size() - 1), seriesPath, context);
-      if (!chunkMetadata.isEmpty()) {
-        ChunkMetaData lastChunkMetaData = chunkMetadata.get(chunkMetadata.size() - 1);
-        Statistics chunkStatistics = lastChunkMetaData.getStatistics();
-        resultPair =
-            constructLastPair(
-                chunkStatistics.getEndTime(), chunkStatistics.getLastValue(), tsDataType);
+      for (int i = seqFileResources.size() - 1; i >= 0; i--) {
+        List<ChunkMetaData> chunkMetadata =
+            FileLoaderUtils.loadChunkMetadataFromTsFileResource(
+                seqFileResources.get(i), seriesPath, context);
+        if (!chunkMetadata.isEmpty()) {
+          ChunkMetaData lastChunkMetaData = chunkMetadata.get(chunkMetadata.size() - 1);
+          Statistics chunkStatistics = lastChunkMetaData.getStatistics();
+          resultPair =
+              constructLastPair(
+                  chunkStatistics.getEndTime(), chunkStatistics.getLastValue(), tsDataType);
+          break;
+        }
       }
     }
 

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
@@ -72,6 +72,18 @@ public class IoTDBLastIT {
       "flush",
   };
 
+  private static String[] dataSet3 = new String[]{
+      "SET STORAGE GROUP TO root.ln.wf01.wt03",
+      "CREATE TIMESERIES root.ln.wf01.wt03.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
+      "CREATE TIMESERIES root.ln.wf01.wt03.temperature WITH DATATYPE=DOUBLE, ENCODING=PLAIN",
+      "CREATE TIMESERIES root.ln.wf01.wt03.id WITH DATATYPE=INT32, ENCODING=PLAIN",
+      "INSERT INTO root.ln.wf01.wt03(timestamp,temperature,status, id) "
+          + "values(100, 18.6, false, 7)",
+      "INSERT INTO root.ln.wf01.wt03(timestamp,temperature,status, id) "
+          + "values(300, 23.1, true, 8)",
+      "flush",
+  };
+
   private static final String TIMESTAMP_STR = "Time";
   private static final String TIMESEIRES_STR = "timeseries";
   private static final String VALUE_STR = "value";
@@ -235,6 +247,47 @@ public class IoTDBLastIT {
     }
   }
 
+  @Test
+  public void lastWithEmptyChunkMetadataTest() throws SQLException {
+    String[] retArray =
+        new String[] {
+            "300,root.ln.wf01.wt03.temperature,23.1",
+        };
+
+
+    try (Connection connection =
+        DriverManager.getConnection("jdbc:iotdb://127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      MNode node = MManager.getInstance()
+          .getDeviceNodeWithAutoCreateStorageGroup("root.ln.wf01.wt03.temperature");
+      ((LeafMNode) node).resetCache();
+
+      statement.execute("INSERT INTO root.ln.wf01.wt03(timestamp,status, id) values(500, false, 9)");
+      statement.execute("flush");
+      boolean hasResultSet = statement.execute(
+          "select last temperature from root.ln.wf01.wt03");
+
+      Assert.assertTrue(hasResultSet);
+      int cnt = 0;
+      try (ResultSet resultSet = statement.getResultSet()) {
+        while (resultSet.next()) {
+          String ans =
+              resultSet.getString(TIMESTAMP_STR) + ","
+                  + resultSet.getString(TIMESEIRES_STR) + ","
+                  + resultSet.getString(VALUE_STR);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+        Assert.assertEquals(cnt, 1);
+      }
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
   private void prepareData() {
     try (Connection connection = DriverManager
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root",
@@ -246,6 +299,9 @@ public class IoTDBLastIT {
         statement.execute(sql);
       }
       for (String sql : dataSet2) {
+        statement.execute(sql);
+      }
+      for (String sql : dataSet3) {
         statement.execute(sql);
       }
 


### PR DESCRIPTION
When processing *seqFileResources* in LAST query, we should make sure to find the last **non-empty** chunkMetadata to calculate the correct time-value pair.

Regression test added in server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java