### PR TITLE
fix recover deadlock

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -127,7 +127,7 @@ public class MManager {
 
   //Because the writer will be used later and should not be closed here.
   @SuppressWarnings("squid:S2093")
-  public void init() {
+  public synchronized void init() {
     if (initialized) {
       return;
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -131,7 +131,6 @@ public class MManager {
     if (initialized) {
       return;
     }
-    lock.writeLock().lock();
     File logFile = SystemFileFactory.INSTANCE.getFile(logFilePath);
 
     try {
@@ -155,8 +154,6 @@ public class MManager {
     } catch (IOException | MetadataException e) {
       mtree = new MTree();
       logger.error("Cannot read MTree from file, using an empty new one", e);
-    } finally {
-      lock.writeLock().unlock();
     }
     initialized = true;
   }


### PR DESCRIPTION
create timeseries root.sg1.d1.s1
delete timeseries root.sg1.d1.s1

restart iotdb
Main thread: recover mmanager, lock a writelock for mmangaer
after delete the timeseries, the data is also need to be deleted because the sg is empty.
Then, the StorageEngine is init and recover each storage group in a recover thread.

recover thread:
In each storage group processor, it wants to recover schema from mManager and lock a readlock.
Then it hangs.

I removed the write lock in MManager init and use a synchronized field.
