### PR TITLE
Fix Travis issues about timeout and the socket problem in the Sync module 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,7 @@ matrix:
         - mvn -version
         # Output something every 10 minutes or Travis kills the job
         - while sleep 540; do echo "=====[ $SECONDS seconds still running ]====="; done &
-        - travis_wait 20 mvn -B clean integration-test
+        - travis_wait 40 mvn -B clean integration-test
         # Killing background sleep loop
         - kill %1
 

--- a/server/src/main/java/org/apache/iotdb/db/sync/thrift/SyncServiceEventHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/thrift/SyncServiceEventHandler.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.sync.thrift;
+
+import java.util.concurrent.CountDownLatch;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.server.ServerContext;
+import org.apache.thrift.server.TServerEventHandler;
+import org.apache.thrift.transport.TTransport;
+
+public class SyncServiceEventHandler  implements TServerEventHandler {
+
+  private CountDownLatch startLatch;
+
+  public SyncServiceEventHandler(CountDownLatch startLatch) {
+    this.startLatch = startLatch;
+  }
+
+  @Override
+  public void preServe() {
+    startLatch.countDown();
+  }
+
+  @Override
+  public ServerContext createContext(TProtocol input, TProtocol output) {
+    return null;
+  }
+
+  @Override
+  public void deleteContext(ServerContext serverContext, TProtocol input, TProtocol output) {
+
+  }
+
+  @Override
+  public void processContext(ServerContext serverContext, TTransport inputTransport,
+      TTransport outputTransport) {
+
+  }
+}


### PR DESCRIPTION
This PR fixes two issues:

1. As we have more and more UT/ITs, 20 minutes are not enough for tests on WinOS +Travis. So, I set the timeout time back to 40 minutes.

2. I notice some travis failures are caused because:
   a. An IT starts an IoTDB instance;
   b. the sync module is put into a startup thread;
   c. calling setting the timeout of the socket of the module. However, the startup thread for the sync module does not turn to run...

This PR will block the startup process until the socket is opened.
  