### PR TITLE
[IOTDB-563] fix downloading pentaho-aggdesigner-algorithm error from maven repo

### DIFF
--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -153,4 +153,20 @@
             </plugin>
         </plugins>
     </build>
+    <!-- org.pentaho:pentaho-aggdesigner-algorithm is in repo.spring.io and we have to claim
+    to use https-->
+    <repositories>
+        <repository>
+            <id>for_pentaho</id>
+            <name>spring.io</name>
+            <url>https://repo.spring.io/libs-milestone</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
when I run `mvn package` on a new PC, an error occurs:

 

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] hive-connector 0.10.0-SNAPSHOT ..................... FAILURE [ 36.612 s]
[INFO] cluster 0.10.0-SNAPSHOT ............................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 36.940 s
[INFO] Finished at: 2020-03-20T14:52:43+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process (process-resource-bundles) on project hive-connector: Error resolving project artifact: Could not transfer artifact org.pentaho:pentaho-aggdesigner-algorithm:pom:5.1.5-jhyde from/to spring-libs (http://repo.spring.io/libs-milestone/): Access denied to: http://repo.spring.io/libs-milestone/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom, ReasonPhrase: Forbidden. for project org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

 

It is because pentaho-aggdesigner-algorithm is not in the maven central-repo. It requires to access repo.sprint.io. However, the repo requires https while in some pom it is defined as http.

The dependency lib is depended by calcite and hive. Therefore, upgrading Hive from 2.3.4 to 3.1.2 is a solution.

 

Another solution is claim the correct repo address, by add the following content in hive-connector/pom.xml

```

<repositories>
<repository>
<id>for_pentaho</id>
<name>spring.io</name>
<url>https://repo.spring.io/libs-milestone</url>
<layout>default</layout>
<releases>
<enabled>true</enabled>
</releases>
<snapshots>
<enabled>false</enabled>
</snapshots>
</repository>
</repositories>

```

 This PR uses the latter solution.

 