### PR TITLE
add apache-rat for css files

### DIFF
--- a/site/src/main/.vuepress/public/css/index.css
+++ b/site/src/main/.vuepress/public/css/index.css
@@ -17,10 +17,6 @@
   under the License.
  */
 
-.red{
-    color:red;
-}
-
 /*滚动条的宽度*/
 
 ::-webkit-scrollbar {

--- a/site/src/main/.vuepress/public/css/index.css
+++ b/site/src/main/.vuepress/public/css/index.css
@@ -1,3 +1,22 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ */
+
 .red{
     color:red;
 }


### PR DESCRIPTION
A CSS file has no apache-rat.


see https://builds.apache.org/job/IoTDB-Pipeline/job/master/306/execution/node/67/log/

[INFO]  DONE  Success! Generated static files in src/.vuepress/dist.
[INFO] 
[INFO] 
[INFO] --- sitemapxml-maven-plugin:2.0.0:gen (default) @ iotdb-website ---
[INFO] Generate sitemap.xml - Start
[INFO] Generate sitemap.xml - OK
[INFO] 
[INFO] --- maven-surefire-plugin:2.22.0:test (integration-tests) @ iotdb-website ---
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.1:analyze-only (check-dependencies) @ iotdb-website ---
[WARNING] Unused declared dependencies found:
[WARNING]    junit:junit:jar:4.12:test
[WARNING]    org.mockito:mockito-all:jar:1.10.19:test
[INFO] 
[INFO] --- apache-rat-plugin:0.13:check (license-check) @ iotdb-website ---
[INFO] Enabled default license matchers.
[INFO] Will parse SCM ignores for exclusions...
[INFO] Finished adding exclusions from SCM ignore files.
[INFO] 62 implicit excludes (use -debug for more details).
[INFO] 23 explicit excludes (use -debug for more details).
[INFO] 31 resources included (use -debug for more details)
[INFO] Rat check: Summary over all files. Unapproved: 1, unknown: 1, generated: 0, approved: 12 licenses.
[INFO] Enabled default license matchers.
[INFO] Will parse SCM ignores for exclusions...
[INFO] Finished adding exclusions from SCM ignore files.
[INFO] 62 implicit excludes (use -debug for more details).
[INFO] 23 explicit excludes (use -debug for more details).
[INFO] 31 resources included (use -debug for more details)
[WARNING] Files with unapproved licenses:
  /home/jenkins/jenkins-slave/workspace/IoTDB-Pipeline_master/site/src/main/.vuepress/public/css/index.css