### PR TITLE
fix concurrent auto create schema bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -101,11 +101,11 @@ public class MTree implements Serializable {
     if (cur instanceof LeafMNode) {
       throw new PathAlreadyExistException(cur.getFullPath());
     }
-    MNode leaf = new LeafMNode(cur, nodeNames[nodeNames.length - 1], dataType, encoding,
-        compressor, props);
-    if (cur.hasChild(leaf.getName())) {
-      throw new MetadataException(String.format("The timeseries %s has already existed.", path));
+    String leafName = nodeNames[nodeNames.length - 1];
+    if (cur.hasChild(leafName)) {
+      throw new PathAlreadyExistException(String.format("Path %s has already existed.", path));
     }
+    MNode leaf = new LeafMNode(cur, leafName, dataType, encoding, compressor, props);
     cur.addChild(leaf);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -103,7 +103,7 @@ public class MTree implements Serializable {
     }
     String leafName = nodeNames[nodeNames.length - 1];
     if (cur.hasChild(leafName)) {
-      throw new PathAlreadyExistException(String.format("Path %s has already existed.", path));
+      throw new PathAlreadyExistException(path);
     }
     MNode leaf = new LeafMNode(cur, leafName, dataType, encoding, compressor, props);
     cur.addChild(leaf);

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -713,17 +713,7 @@ public class PlanExecutor implements IPlanExecutor {
           }
           TSDataType dataType = TypeInferenceUtils.getPredictedDataType(strValues[i]);
           Path path = new Path(deviceId, measurement);
-
-          try {
-            mManager.createTimeseries(path.toString(), dataType, getDefaultEncoding(dataType),
-                TSFileDescriptor.getInstance().getConfig().getCompressor(),
-                Collections.emptyMap());
-          } catch (PathAlreadyExistException e) {
-            if (logger.isDebugEnabled()) {
-              logger.debug("Ignore PathAlreadyExistException when Concurrent inserting"
-                  + " a non-exist time series {}", path.getFullPath());
-            }
-          }
+          internalCreateTimeseries(path.toString(), dataType);
         }
         LeafMNode measurementNode = (LeafMNode) node.getChild(measurement);
         schemas[i] = measurementNode.getSchema();
@@ -732,6 +722,22 @@ public class PlanExecutor implements IPlanExecutor {
       StorageEngine.getInstance().insert(insertPlan);
     } catch (StorageEngineException | MetadataException e) {
       throw new QueryProcessException(e);
+    }
+  }
+
+  /**
+   * create timeseries with ignore PathAlreadyExistException
+   */
+  private void internalCreateTimeseries(String path, TSDataType dataType) throws MetadataException {
+    try {
+      mManager.createTimeseries(path, dataType, getDefaultEncoding(dataType),
+          TSFileDescriptor.getInstance().getConfig().getCompressor(),
+          Collections.emptyMap());
+    } catch (PathAlreadyExistException e) {
+      if (logger.isDebugEnabled()) {
+        logger.debug("Ignore PathAlreadyExistException when Concurrent inserting"
+            + " a non-exist time series {}", path);
+      }
     }
   }
 
@@ -779,16 +785,7 @@ public class PlanExecutor implements IPlanExecutor {
           }
           Path path = new Path(deviceId, measurementList[i]);
           TSDataType dataType = dataTypes[i];
-          try {
-            mManager.createTimeseries(path.getFullPath(), dataType, getDefaultEncoding(dataType),
-                TSFileDescriptor.getInstance().getConfig().getCompressor(),
-                Collections.emptyMap());
-          } catch (PathAlreadyExistException e) {
-            if (logger.isDebugEnabled()) {
-              logger.debug("Ignore PathAlreadyExistException when Concurrent inserting"
-                  + " a non-exist time series {}", path.getFullPath());
-            }
-          }
+          internalCreateTimeseries(path.getFullPath(), dataType);
         }
         LeafMNode measurementNode = (LeafMNode) node.getChild(measurementList[i]);
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -63,6 +63,7 @@ import org.apache.iotdb.db.engine.flush.pool.FlushTaskPoolManager;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
+import org.apache.iotdb.db.exception.metadata.PathAlreadyExistException;
 import org.apache.iotdb.db.exception.metadata.PathNotExistException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.MManager;
@@ -127,9 +128,12 @@ import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PlanExecutor implements IPlanExecutor {
 
+  private static final Logger logger = LoggerFactory.getLogger(PlanExecutor.class);
   // for data query
   protected IQueryRouter queryRouter;
   // for system schema
@@ -710,9 +714,16 @@ public class PlanExecutor implements IPlanExecutor {
           TSDataType dataType = TypeInferenceUtils.getPredictedDataType(strValues[i]);
           Path path = new Path(deviceId, measurement);
 
-          mManager.createTimeseries(path.toString(), dataType, getDefaultEncoding(dataType),
-                  TSFileDescriptor.getInstance().getConfig().getCompressor(),
-              Collections.emptyMap());
+          try {
+            mManager.createTimeseries(path.toString(), dataType, getDefaultEncoding(dataType),
+                TSFileDescriptor.getInstance().getConfig().getCompressor(),
+                Collections.emptyMap());
+          } catch (PathAlreadyExistException e) {
+            if (logger.isDebugEnabled()) {
+              logger.debug("Ignore PathAlreadyExistException when Concurrent inserting"
+                  + " a non-exist time series {}", path.getFullPath());
+            }
+          }
         }
         LeafMNode measurementNode = (LeafMNode) node.getChild(measurement);
         schemas[i] = measurementNode.getSchema();
@@ -768,9 +779,16 @@ public class PlanExecutor implements IPlanExecutor {
           }
           Path path = new Path(deviceId, measurementList[i]);
           TSDataType dataType = dataTypes[i];
-          mManager.createTimeseries(path.getFullPath(), dataType, getDefaultEncoding(dataType),
-                  TSFileDescriptor.getInstance().getConfig().getCompressor(),
-                  Collections.emptyMap());
+          try {
+            mManager.createTimeseries(path.getFullPath(), dataType, getDefaultEncoding(dataType),
+                TSFileDescriptor.getInstance().getConfig().getCompressor(),
+                Collections.emptyMap());
+          } catch (PathAlreadyExistException e) {
+            if (logger.isDebugEnabled()) {
+              logger.debug("Ignore PathAlreadyExistException when Concurrent inserting"
+                  + " a non-exist time series {}", path.getFullPath());
+            }
+          }
         }
         LeafMNode measurementNode = (LeafMNode) node.getChild(measurementList[i]);
 

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -1074,22 +1074,26 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
 
   @Override
   public TSStatus insert(TSInsertReq req) {
-    if (!checkLogin(req.getSessionId())) {
-      logger.info(INFO_NOT_LOGIN, IoTDBConstant.GLOBAL_DB_NAME);
-      return RpcUtils.getStatus(TSStatusCode.NOT_LOGIN_ERROR);
-    }
+    try {
+      if (!checkLogin(req.getSessionId())) {
+        logger.info(INFO_NOT_LOGIN, IoTDBConstant.GLOBAL_DB_NAME);
+        return RpcUtils.getStatus(TSStatusCode.NOT_LOGIN_ERROR);
+      }
 
-    InsertPlan plan = new InsertPlan();
-    plan.setDeviceId(req.getDeviceId());
-    plan.setTime(req.getTimestamp());
-    plan.setMeasurements(req.getMeasurements().toArray(new String[0]));
-    plan.setValues(req.getValues().toArray(new String[0]));
+      InsertPlan plan = new InsertPlan();
+      plan.setDeviceId(req.getDeviceId());
+      plan.setTime(req.getTimestamp());
+      plan.setMeasurements(req.getMeasurements().toArray(new String[0]));
+      plan.setValues(req.getValues().toArray(new String[0]));
 
-    TSStatus status = checkAuthority(plan, req.getSessionId());
-    if (status != null) {
-      return status;
+      TSStatus status = checkAuthority(plan, req.getSessionId());
+      if (status != null) {
+        return status;
+      }
+      return executePlan(plan);
+    } catch (Exception e) {
+      logger.error("meet error when insert", e);
     }
-    return executePlan(plan);
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -1094,6 +1094,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     } catch (Exception e) {
       logger.error("meet error when insert", e);
     }
+    return RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR);
   }
 
   @Override


### PR DESCRIPTION
In the PlanExecutor.insert or insertBatch. 

Multiple threads insert the same time series that does not exist. Then they will create schema automatically, cause a PathAlreadyExistException, we should ignore this exception.