### PR TITLE
fix meet incompatible file error in restart

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -375,7 +375,7 @@ public class StorageGroupProcessor {
       try {
         writer = recoverPerformer.recover();
       } catch (StorageGroupProcessorException e) {
-        logger.warn("skip InCompatible TsFile: {}", tsFileResource.getPath());
+        logger.warn("Skip TsFile: {} because of error in recover: ", tsFileResource.getPath(), e);
         continue;
       }
       if (i != tsFiles.size() - 1 || !writer.canWrite()) {
@@ -409,7 +409,7 @@ public class StorageGroupProcessor {
       try {
         writer = recoverPerformer.recover();
       } catch (StorageGroupProcessorException e) {
-        logger.warn("skip InCompatible TsFile: {}", tsFileResource.getPath());
+        logger.warn("Skip TsFile: {} because of error in recover: ", tsFileResource.getPath(), e);
         continue;
       }
       if (i != tsFiles.size() - 1 || !writer.canWrite()) {

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/RestorableTsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/RestorableTsFileIOWriter.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RestorableTsFileIOWriter extends TsFileIOWriter {
 
-  private static final Logger resourceLogger = LoggerFactory.getLogger("FileMonitor");
+  private static final Logger logger = LoggerFactory.getLogger("FileMonitor");
   private long truncatedPosition = -1;
   private Map<Path, MeasurementSchema> knownSchemas = new HashMap<>();
 
@@ -65,8 +65,8 @@ public class RestorableTsFileIOWriter extends TsFileIOWriter {
    * @throws IOException if write failed, or the file is broken but autoRepair==false.
    */
   public RestorableTsFileIOWriter(File file) throws IOException {
-    if (resourceLogger.isDebugEnabled()) {
-      resourceLogger.debug("{} is opened.", file.getName());
+    if (logger.isDebugEnabled()) {
+      logger.debug("{} is opened.", file.getName());
     }
     this.file = file;
     this.out = FSFactoryProducer.getFileOutputFactory().getTsFileOutput(file.getPath(), true);
@@ -93,8 +93,9 @@ public class RestorableTsFileIOWriter extends TsFileIOWriter {
         totalChunkNum = reader.getTotalChunkNum();
         if (truncatedPosition == TsFileCheckStatus.INCOMPATIBLE_FILE) {
           out.close();
-          throw new IOException(
-              String.format("%s is not in TsFile format.", file.getAbsolutePath()));
+          boolean result = file.delete();
+          logger.warn("TsFile {} is incompatible. Delete it successfully {}", file.getAbsolutePath(), result);
+          throw new IOException(String.format("%s is not in TsFile format.", file.getAbsolutePath()));
         } else if (truncatedPosition == TsFileCheckStatus.ONLY_MAGIC_HEAD) {
           crashed = true;
           out.truncate(


### PR DESCRIPTION
If an incompatible tsfile is met in the restart, the server will not start successfully. Just remove it and not to add into resource list.