### PR TITLE
Revert "[IOTDB-578] Cluster module should use the same thrift version with io…"

### DIFF
--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -35,6 +35,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>0.12.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
             <version>0.10.0-SNAPSHOT</version>


### PR DESCRIPTION
Reverts apache/incubator-iotdb#986