### PR TITLE
[IOTDB-583] [to rel/0.9] Start JDBC service in the last

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -968,12 +968,12 @@ public class StorageGroupProcessor {
    */
   public int countUpgradeFiles() {
     int cntUpgradeFileNum = 0;
-    for (TsFileResource seqTsFileResource : new ArrayList<>(sequenceFileList)) {
+    for (TsFileResource seqTsFileResource : sequenceFileList) {
       if (UpgradeUtils.isNeedUpgrade(seqTsFileResource)) {
         cntUpgradeFileNum += 1;
       }
     }
-    for (TsFileResource unseqTsFileResource : new ArrayList<>(unSequenceFileList)) {
+    for (TsFileResource unseqTsFileResource : unSequenceFileList) {
       if (UpgradeUtils.isNeedUpgrade(unseqTsFileResource)) {
         cntUpgradeFileNum += 1;
       }
@@ -982,10 +982,10 @@ public class StorageGroupProcessor {
   }
 
   public void upgrade() {
-    for (TsFileResource seqTsFileResource : new ArrayList<>(sequenceFileList)) {
+    for (TsFileResource seqTsFileResource : sequenceFileList) {
       seqTsFileResource.doUpgrade();
     }
-    for (TsFileResource unseqTsFileResource : new ArrayList<>(unSequenceFileList)) {
+    for (TsFileResource unseqTsFileResource : unSequenceFileList) {
       unseqTsFileResource.doUpgrade();
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/IoTDB.java
@@ -93,7 +93,6 @@ public class IoTDB implements IoTDBMBean {
     registerManager.register(StorageEngine.getInstance());
     registerManager.register(MultiFileLogNodeManager.getInstance());
     registerManager.register(JMXService.getInstance());
-    registerManager.register(JDBCService.getInstance());
     registerManager.register(Monitor.getInstance());
     registerManager.register(StatMonitor.getInstance());
     registerManager.register(Measurement.INSTANCE);
@@ -106,7 +105,7 @@ public class IoTDB implements IoTDBMBean {
     registerManager.register(CacheHitRatioMonitor.getInstance());
     registerManager.register(MetricsService.getInstance());
     JMXService.registerMBean(getInstance(), mbeanName);
-
+    registerManager.register(JDBCService.getInstance());
     logger.info("IoTDB is set up.");
   }
 


### PR DESCRIPTION
When the server started, it first register the StorageEngine, JDBCService and UpgradeService. 
If the client write new data while the upgrade thread traverses the tsfile resource list, a ConcurrentModificationException will occur.

The upgrade traverse is in the startup. no need to copy resources. Just move the JDBCService start at last. 