### PR TITLE
Remove disable align syntax within LAST query

### DIFF
--- a/docs/UserGuide/5-Operation Manual/4-SQL Reference.md
+++ b/docs/UserGuide/5-Operation Manual/4-SQL Reference.md
@@ -469,20 +469,19 @@ You could expect a table like:
 The LAST function returns the last time-value pair of the given timeseries. Currently filters are not supported in LAST queries.
 
 ```
-SELECT LAST <SelectClause> FROM <FromClause> <DisableAlignClause>
+SELECT LAST <SelectClause> FROM <FromClause>
 Select Clause : <Path> [COMMA <Path>]*
 FromClause : < PrefixPath > [COMMA < PrefixPath >]*
-DisableAlignClause : [DISABLE ALIGN]
 
-Eg. SELECT LAST s1 FROM root.sg.d1 disable align
-Eg. SELECT LAST s1, s2 FROM root.sg.d1 disable align
-Eg. SELECT LAST s1 FROM root.sg.d1, root.sg.d2 disable align
+Eg. SELECT LAST s1 FROM root.sg.d1
+Eg. SELECT LAST s1, s2 FROM root.sg.d1
+Eg. SELECT LAST s1 FROM root.sg.d1, root.sg.d2
 
 Rules:
 1. the statement needs to satisfy this constraint: <PrefixPath> + <Path> = <Timeseries>
 
-2. The result set of last query will always be displayed in a "disable-aligned" format showed below.
-For example, "select last s1, s2 from root.sg.d1, root.sg.d2 disable align", the query result would be:
+2. The result set of last query will always be displayed in a fixed three column table format.
+For example, "select last s1, s2 from root.sg.d1, root.sg.d2", the query result would be:
 
 | Time | Path         | Value |
 | ---  | ------------ | ----- |
@@ -491,9 +490,7 @@ For example, "select last s1, s2 from root.sg.d1, root.sg.d2 disable align", the
 |  4   | root.sg.d2.s1| 250   |
 |  9   | root.sg.d2.s2| 600   |
 
-3. LAST query syntax is expecting users to write a "diable align" keyword at the end of the query. 
-However, as it is a unique SQL syntax in IoTDB, IoTDB accepts LAST queries without "disable align" and treats them as "disable align" ones.
-Query like "select last s1 from root.sg.d1" will be parsed exactly the same as "select last s1 from root.sg.d1 disable align". 
+3. It is not supported to use "diable align" in LAST query. 
 
 ```
 

--- a/docs/zh/UserGuide/5-Operation Manual/4-SQL Reference.md
+++ b/docs/zh/UserGuide/5-Operation Manual/4-SQL Reference.md
@@ -457,22 +457,21 @@ root.sg1.d0.s0 is INT32 while root.sg2.d3.s0 is FLOAT.
 Last 语句返回所要查询时间序列的最近时间戳的一条数据
 
 ```
-SELECT LAST <SelectClause> FROM <FromClause> <DisableAlignClause>
+SELECT LAST <SelectClause> FROM <FromClause>
 Select Clause : <Path> [COMMA <Path>]*
 FromClause : < PrefixPath > [COMMA < PrefixPath >]*
-DisableAlignClause : [DISABLE ALIGN]
 
-Eg. SELECT LAST s1 FROM root.sg.d1 disable align
-Eg. SELECT LAST s1, s2 FROM root.sg.d1 disable align
-Eg. SELECT LAST s1 FROM root.sg.d1, root.sg.d2 disable align
+Eg. SELECT LAST s1 FROM root.sg.d1
+Eg. SELECT LAST s1, s2 FROM root.sg.d1
+Eg. SELECT LAST s1 FROM root.sg.d1, root.sg.d2
 
 规则:
 1. 需要满足PrefixPath.Path 为一条完整的时间序列，即 <PrefixPath> + <Path> = <Timeseries>
 
 2. SELECT LAST 语句不支持过滤条件.
 
-3. 结果集以"disable align"的形式返回，表现为总是包含三列的表格。
-例如 "select last s1, s2 from root.sg.d1, root.sg.d2 disable align", 结果集返回如下：
+3. 结果集以三列的表格的固定形式返回。
+例如 "select last s1, s2 from root.sg.d1, root.sg.d2", 结果集返回如下：
 
 | Time | Path         | Value |
 | ---  | ------------ | ----- |
@@ -481,8 +480,7 @@ Eg. SELECT LAST s1 FROM root.sg.d1, root.sg.d2 disable align
 |  4   | root.sg.d2.s1| 250   |
 |  9   | root.sg.d2.s2| 600   |
 
-4. SELECT LAST 查询语句要是总是和末尾的disable align在一起使用。如果用户不熟悉SELECT LAST的语法或者忘记在末尾添加"disable align"，IoTDB 也会接受不包含"disable align"的SQL语句并且仍以"disable align"的形式返回结果集。
-例如用户输入 "select last s1 from root.sg.d1" 所得到的查询结果与 "select last s1 from root.sg.d1 disable align". 的结果是完全相同的。
+4. 注意LAST语句不支持与"disable align"关键词一起使用。
 
 ```
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -206,7 +206,9 @@ public class PhysicalGenerator {
     }
     if (queryPlan instanceof LastQueryPlan) {
       // Last query result set will not be affected by alignment
-      queryPlan.setAlignByTime(true);
+      if (!queryOperator.isAlignByTime()) {
+        throw new QueryProcessException("Disable align cannot be applied to LAST query.");
+      }
       List<Path> paths = queryOperator.getSelectedPaths();
       queryPlan.setPaths(paths);
     } else if (queryOperator.isAlignByDevice()) {

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLastIT.java
@@ -121,7 +121,7 @@ public class IoTDBLastIT {
         Statement statement = connection.createStatement()) {
 
       boolean hasResultSet = statement.execute(
-              "select last temperature,status,id from root.ln.wf01.wt01 disable align");
+              "select last temperature,status,id from root.ln.wf01.wt01");
 
       Assert.assertTrue(hasResultSet);
       int cnt = 0;

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
@@ -610,7 +610,7 @@ public class PhysicalPlanTest {
   @Test
   public void testLastPlanPaths() throws QueryProcessException {
     String sqlStr1 = "SELECT last s1 FROM root.vehicle.d1";
-    String sqlStr2 = "SELECT last s1 FROM root.vehicle.d1, root.vehicle.d2 disable align";
+    String sqlStr2 = "SELECT last s1 FROM root.vehicle.d1, root.vehicle.d2";
     PhysicalPlan plan1 = processor.parseSQLToPhysicalPlan(sqlStr1);
     PhysicalPlan plan2 = processor.parseSQLToPhysicalPlan(sqlStr2);
     Path path1 = new Path("root.vehicle.d1.s1");


### PR DESCRIPTION
As discussed, the result set of **Last** query will always be displayed in a fixed three column table format and no longer support "**disable align**" syntax. 
Now the user will get an exception if adding a "**disable align**" at the end of a **Last** SQL.
