### PR TITLE
[IoTDB-575]add default jmx user and password; fix issues that jmx can not be accessed remotely

### DIFF
--- a/docs/UserGuide/3-Server/4-Config Manual.md
+++ b/docs/UserGuide/3-Server/4-Config Manual.md
@@ -70,7 +70,7 @@ The detail of each variables are as follows:
 |Name|JMX\_LOCAL|
 |:---:|:---|
 |Description|JMX monitoring mode, configured as yes to allow only local monitoring, no to allow remote monitoring|
-|Type|Enum String: "true", "true"|
+|Type|Enum String: "true", "false"|
 |Default|true|
 |Effective|After restart system|
 

--- a/docs/UserGuide/3-Server/4-Config Manual.md
+++ b/docs/UserGuide/3-Server/4-Config Manual.md
@@ -47,25 +47,6 @@ The environment configuration file is mainly used to configure the Java environm
 
 The detail of each variables are as follows:
 
-* LOCAL\_JMX
-
-|Name|LOCAL\_JMX|
-|:---:|:---|
-|Description|JMX monitoring mode, configured as yes to allow only local monitoring, no to allow remote monitoring|
-|Type|Enum String: "yes", "no"|
-|Default|yes|
-|Effective|After restart system|
-
-
-* JMX\_PORT
-
-|Name|JMX\_PORT|
-|:---:|:---|
-|Description|JMX listening port. Please confirm that the port is not a system reserved port and is not occupied|
-|Type|Short Int: [0,65535]|
-|Default|31999|
-|Effective|After restart system|
-
 * MAX\_HEAP\_SIZE
 
 |Name|MAX\_HEAP\_SIZE|
@@ -83,6 +64,42 @@ The detail of each variables are as follows:
 |Type|String|
 |Default| On Linux or MacOS, the default is min{cores * 100M, one quarter of MAX\_HEAP\_SIZE}. On Windows, the default value for 32-bit systems is 512M, and the default for 64-bit systems is 2G.|
 |Effective|After restart system|
+
+* JMX\_LOCAL
+
+|Name|JMX\_LOCAL|
+|:---:|:---|
+|Description|JMX monitoring mode, configured as yes to allow only local monitoring, no to allow remote monitoring|
+|Type|Enum String: "true", "true"|
+|Default|true|
+|Effective|After restart system|
+
+
+* JMX\_PORT
+
+|Name|JMX\_PORT|
+|:---:|:---|
+|Description|JMX listening port. Please confirm that the port is not a system reserved port and is not occupied|
+|Type|Short Int: [0,65535]|
+|Default|31999|
+|Effective|After restart system|
+
+* JMX\_IP
+
+|Name|JMX\_IP|
+|:---:|:---|
+|Description|JMX listening address. Only take effect if JMX\_LOCAL=false. 0.0.0.0 is never allowed|
+|Type|String|
+|Default|127.0.0.1|
+|Effective|After restart system|
+
+## JMX Authorization
+
+We **STRONGLY RECOMMENDED** you CHANGE the PASSWORD for the JMX remote connection.
+
+The user and passwords are in ${IOTDB\_CONF}/conf/jmx.password.
+
+The permission definitions are in ${IOTDB\_CONF}/conf/jmx.access.
 
 ## IoTDB System Configuration File
 

--- a/server/src/assembly/resources/conf/iotdb-env.bat
+++ b/server/src/assembly/resources/conf/iotdb-env.bat
@@ -27,7 +27,7 @@ set JMX_PORT="31999"
 # 0.0.0.0 is not allowed
 set JMX_IP="127.0.0.1"
 
-if [ ${JMX_LOCAL} = "false" ]; then
+if [ %JMX_LOCAL% = "false" ]; then
   echo "setting remote JMX..."
   #you may have no permission to run chmod. If so, contact your system administrator.
   set IOTDB_JMX_OPTS="%IOTDB_JMX_OPTS% -Dcom.sun.management.jmxremote"

--- a/server/src/assembly/resources/conf/iotdb-env.bat
+++ b/server/src/assembly/resources/conf/iotdb-env.bat
@@ -18,14 +18,30 @@
 @REM
 
 @echo off
-set LOCAL_JMX=no
-set JMX_PORT=31999
+#true or false
+#DO NOT FORGET TO MODIFY THE PASSWORD FOR SECURITY (%IOTDB_CONF%\jmx.password and %{IOTDB_CONF%\jmx.access)
+set JMX_LOCAL="true"
+set JMX_PORT="31999"
+#only take effect when the jmx_local=false
+#You need to change this IP as a public IP if you want to remotely connect IoTDB by JMX.
+# 0.0.0.0 is not allowed
+set JMX_IP="127.0.0.1"
 
-if "%LOCAL_JMX%" == "yes" (
-		set IOTDB_JMX_OPTS="-Diotdb.jmx.local.port=%JMX_PORT%" "-Dcom.sun.management.jmxremote.authenticate=true" "-Dcom.sun.management.jmxremote.ssl=false"
-	) else (
-		set IOTDB_JMX_OPTS="-Dcom.sun.management.jmxremote" "-Dcom.sun.management.jmxremote.authenticate=true"  "-Dcom.sun.management.jmxremote.ssl=false" "-Dcom.sun.management.jmxremote.port=%JMX_PORT%"
-	)
+if [ ${JMX_LOCAL} = "false" ]; then
+  echo "setting remote JMX..."
+  #you may have no permission to run chmod. If so, contact your system administrator.
+  set IOTDB_JMX_OPTS="%IOTDB_JMX_OPTS% -Dcom.sun.management.jmxremote"
+  set IOTDB_JMX_OPTS="%IOTDB_JMX_OPTS% -Dcom.sun.management.jmxremote.port=%JMX_PORT%"
+  set IOTDB_JMX_OPTS="%IOTDB_JMX_OPTS% -Djava.rmi.server.randomIDs=true"
+  set IOTDB_JMX_OPTS="%IOTDB_JMX_OPTS% -Dcom.sun.management.jmxremote.authenticate=true"
+  set IOTDB_JMX_OPTS="%IOTDB_JMX_OPTS% -Dcom.sun.management.jmxremote.ssl=false"
+  set IOTDB_JMX_OPTS="%IOTDB_JMX_OPTS% -Dcom.sun.management.jmxremote.authenticate=true"
+  set IOTDB_JMX_OPTS="%IOTDB_JMX_OPTS% -Dcom.sun.management.jmxremote.password.file=%IOTDB_CONF%\jmx.password"
+  set IOTDB_JMX_OPTS="%IOTDB_JMX_OPTS% -Dcom.sun.management.jmxremote.access.file=%IOTDB_CONF%\jmx.access"
+  set IOTDB_JMX_OPTS="%IOTDB_JMX_OPTS% -Djava.rmi.server.hostname=%JMX_IP%"
+else
+  echo "setting local JMX..."
+fi
 
 IF ["%IOTDB_HEAP_OPTS%"] EQU [""] (
 	rem detect Java 8 or 11

--- a/server/src/assembly/resources/conf/iotdb-env.sh
+++ b/server/src/assembly/resources/conf/iotdb-env.sh
@@ -164,16 +164,32 @@ calculate_heap_sizes
 # Minimum heap size
 #HEAP_NEWSIZE="2G"
 
-JMX_LOCAL=no
+#true or false
+#DO NOT FORGET TO MODIFY THE PASSWORD FOR SECURITY (${IOTDB_CONF}/jmx.password and ${IOTDB_CONF}/jmx.access)
+JMX_LOCAL="true"
 
 JMX_PORT="31999"
+#only take effect when the jmx_local=false
+#You need to change this IP as a public IP if you want to remotely connect IoTDB by JMX.
+# 0.0.0.0 is not allowed
+JMX_IP="127.0.0.1"
 
-if [ "JMX_LOCAL" = "yes" ]; then
-	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Diotdb.jmx.local.port=$JMX_PORT"
-	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.authenticate=true -Dcom.sun.management.jmxremote.ssl=false"
+if [ ${JMX_LOCAL} = "false" ]; then
+  echo "setting remote JMX..."
+  #you may have no permission to run chmod. If so, contact your system administrator.
+  chmod 600 ${IOTDB_CONF}/jmx.password
+  chmod 600 ${IOTDB_CONF}/jmx.access
+	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote"
+	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Djava.rmi.server.randomIDs=true"
+	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.authenticate=true"
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.authenticate=true"
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.password.file=${IOTDB_CONF}/jmx.password"
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.access.file=${IOTDB_CONF}/jmx.access"
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Djava.rmi.server.hostname=$JMX_IP"
 else
-	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=true  -Dcom.sun.management.jmxremote.ssl=false"
-	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
+  echo "setting local JMX..."
 fi
 
 

--- a/server/src/assembly/resources/conf/iotdb-env.sh
+++ b/server/src/assembly/resources/conf/iotdb-env.sh
@@ -179,10 +179,10 @@ if [ ${JMX_LOCAL} = "false" ]; then
   #you may have no permission to run chmod. If so, contact your system administrator.
   chmod 600 ${IOTDB_CONF}/jmx.password
   chmod 600 ${IOTDB_CONF}/jmx.access
-	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote"
-	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT"
-	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Djava.rmi.server.randomIDs=true"
-	IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.authenticate=true"
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote"
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Djava.rmi.server.randomIDs=true"
+  IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.authenticate=true"
   IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.ssl=false"
   IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.authenticate=true"
   IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Dcom.sun.management.jmxremote.password.file=${IOTDB_CONF}/jmx.password"

--- a/server/src/assembly/resources/conf/jmx.access
+++ b/server/src/assembly/resources/conf/jmx.access
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 # see https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html#gdeup
 iotdb readonly
 root readwrite

--- a/server/src/assembly/resources/conf/jmx.access
+++ b/server/src/assembly/resources/conf/jmx.access
@@ -1,0 +1,3 @@
+# see https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html#gdeup
+iotdb readonly
+root readwrite

--- a/server/src/assembly/resources/conf/jmx.password
+++ b/server/src/assembly/resources/conf/jmx.password
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 # see https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html#gdeup
 iotdb passw!d
 root  passw!d

--- a/server/src/assembly/resources/conf/jmx.password
+++ b/server/src/assembly/resources/conf/jmx.password
@@ -1,0 +1,3 @@
+# see https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html#gdeup
+iotdb passw!d
+root  passw!d

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConstant.java
@@ -27,13 +27,9 @@ public class IoTDBConstant {
   public static final String IOTDB_CONF = "IOTDB_CONF";
   public static final String GLOBAL_DB_NAME = "IoTDB";
   public static final String VERSION = "0.10.0-SNAPSHOT";
-  public static final String REMOTE_JMX_PORT_NAME = "com.sun.management.jmxremote.port";
-  public static final String IOTDB_LOCAL_JMX_PORT_NAME = "iotdb.jmx.local.port";
-  public static final String IOTDB_REMOTE_JMX_PORT_NAME = "iotdb.jmx.remote.port";
-  public static final String SERVER_RMI_ID = "java.rmi.server.randomIDs";
-  public static final String RMI_SERVER_HOST_NAME = "java.rmi.server.hostname";
-  public static final String JMX_REMOTE_RMI_PORT = "com.sun.management.jmxremote.rmi.port";
-  public static final String JMX_REMOTE_AUTHENTICATE = "com.sun.management.jmxremote.authenticate";
+
+  public static final String IOTDB_JMX_PORT = "iotdb.jmx.port";
+
   public static final String IOTDB_PACKAGE = "org.apache.iotdb.service";
   public static final String JMX_TYPE = "type";
 

--- a/server/src/main/java/org/apache/iotdb/db/service/JMXService.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/JMXService.java
@@ -18,11 +18,7 @@
  */
 package org.apache.iotdb.db.service;
 
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.net.InetAddress;
-import java.util.HashMap;
-import java.util.Map;
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanRegistrationException;
@@ -30,13 +26,7 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
-import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorServer;
-import javax.management.remote.JMXConnectorServerFactory;
-import javax.management.remote.JMXServiceURL;
-import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StartupException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +34,6 @@ import org.slf4j.LoggerFactory;
 public class JMXService implements IService {
 
   private static final Logger logger = LoggerFactory.getLogger(JMXService.class);
-
-  private JMXConnectorServer jmxConnectorServer;
 
   private JMXService() {
   }
@@ -97,14 +85,13 @@ public class JMXService implements IService {
   public void start() throws StartupException {
     String jmxPort = System.getProperty(IoTDBConstant.IOTDB_JMX_PORT);
     if (jmxPort == null) {
-      logger.warn("JMX port is undefined", this.getID().getName());
-      return;
+      logger.warn("{} JMX port is undefined", this.getID().getName());
     }
   }
 
   @Override
   public void stop() {
-
+    // do nothing.
   }
 
   private static class JMXServerHolder {

--- a/server/src/main/java/org/apache/iotdb/db/service/StartupChecks.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/StartupChecks.java
@@ -30,17 +30,12 @@ public class StartupChecks {
 
   private static final Logger logger = LoggerFactory.getLogger(StartupChecks.class);
   public static final StartupCheck checkJMXPort = () -> {
-    String jmxPort = System.getProperty(IoTDBConstant.REMOTE_JMX_PORT_NAME);
+    String jmxPort = System.getProperty(IoTDBConstant.IOTDB_JMX_PORT);
     if (jmxPort == null) {
-      logger.warn("JMX is not enabled to receive remote connection. "
-              + "Please check conf/{}.sh(Unix or OS X, if you use Windows, "
-              + "check conf/{}.bat) for more info",
-          IoTDBConstant.ENV_FILE_NAME, IoTDBConstant.ENV_FILE_NAME);
-      jmxPort = System.getProperty(IoTDBConstant.IOTDB_LOCAL_JMX_PORT_NAME, "31999");
       if (jmxPort == null) {
         logger.warn("{} missing from {}.sh(Unix or OS X, if you use Windows,"
                 + " check conf/{}.bat)",
-            IoTDBConstant.IOTDB_LOCAL_JMX_PORT_NAME, IoTDBConstant.ENV_FILE_NAME,
+            IoTDBConstant.IOTDB_JMX_PORT, IoTDBConstant.ENV_FILE_NAME,
             IoTDBConstant.ENV_FILE_NAME);
       }
     } else {

--- a/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/EnvironmentUtils.java
@@ -187,7 +187,6 @@ public class EnvironmentUtils {
    */
   public static void envSetUp() {
     logger.warn("EnvironmentUtil setup...");
-    System.setProperty(IoTDBConstant.REMOTE_JMX_PORT_NAME, "31999");
     IoTDBDescriptor.getInstance().getConfig().setThriftServerAwaitTimeForStopService(0);
     //we do not start 8181 port in test.
     IoTDBDescriptor.getInstance().getConfig().setEnableMetricService(false);


### PR DESCRIPTION
Though PR#979 has requires users to use JMX with authorization, it breaks our rule "make IoTDB available out of the box".
Users have to add files into their JDK HOME and then start IoTDB.

This PR fixes that and gives two default user/passwords for JMX.

Besides, I notice there are some unused codes in our JMXService module, so I simplify them.