### PR TITLE
[IOTDB-591]enlarge memory for vue compiling

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -328,8 +328,8 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <nodeVersion>v11.5.0</nodeVersion>
-                            <npmVersion>6.4.1</npmVersion>
+                            <nodeVersion>v12.16.2</nodeVersion>
+                            <npmVersion>6.14.4</npmVersion>
                         </configuration>
                     </execution>
                     <!-- Install all project dependencies -->

--- a/site/src/main/package.json
+++ b/site/src/main/package.json
@@ -4,9 +4,9 @@
   "description": "Apache IoTDB (incubating) Website",
   "main": "index.js",
   "scripts": {
-    "dev": "vuepress dev src",
-    "build": "vuepress build src",
-    "deploy": "node deploy.js"
+    "dev": "node --max_old_space_size=1500 ./node_modules/vuepress/cli.js dev src",
+    "build": "node --max_old_space_size=1500 ./node_modules/vuepress/cli.js build src",
+    "deploy": "node --max_old_space_size=1500 deploy.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Nodejs uses 512MB memory by default. However, when we upgrade vuepress from v0.x to v1.x, the memory is not enough, which causes the following errors:

[INFO] <--- Last few GCs --->
[INFO]
[INFO] FATAL ERROR: MarkCompactCollector: semi-space copy, fallback in old gen Allocation failed - JavaScript heap out of memory
[INFO] [17802:0x305e750] 310024 ms: Scavenge 1052.0 (1438.9) -> 1051.3 (1454.9) MB, 8.9 / 0.0 ms (average mu = 0.635, current mu = 0.566) allocation failure
[INFO] [17802:0x305e750] 310346 ms: Mark-sweep 1066.9 (1454.9) -> 1066.9 (1438.9) MB, 302.6 / 0.0 ms (average mu = 0.472, current mu = 0.282) allocation failure scavenge might not succeed
[INFO] [17802:0x305e750] 310356 ms: Scavenge 1066.9 (1438.9) -> 1066.2 (1454.9) MB, 9.2 / 0.0 ms (average mu = 0.472, current mu = 0.282) allocation failure


set the max memory to 1.5G can solve the problem, by using `node --max_old_space_size=1500`
