### PR TITLE
fix init MManager bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -134,11 +134,15 @@ public class MManager {
     File logFile = SystemFileFactory.INSTANCE.getFile(logFilePath);
 
     try {
-      initFromLog(logFile);
 
-      if (IoTDBDescriptor.getInstance().getConfig().isEnableParameterAdapter()) {
+      if (config.isEnableParameterAdapter()) {
         // storage group name -> the series number
         seriesNumberInStorageGroups = new HashMap<>();
+      }
+
+      initFromLog(logFile);
+
+      if (config.isEnableParameterAdapter()) {
         List<String> storageGroups = mtree.getAllStorageGroupNames();
         for (String sg : storageGroups) {
           MNode node = mtree.getNodeByPath(sg);
@@ -298,7 +302,7 @@ public class MManager {
       createTimeseriesWithMemoryCheckAndLog(path, dataType, encoding, compressor, props);
 
       // update statistics
-      if (IoTDBDescriptor.getInstance().getConfig().isEnableParameterAdapter()) {
+      if (config.isEnableParameterAdapter()) {
         int size = seriesNumberInStorageGroups.get(storageGroupName);
         seriesNumberInStorageGroups.put(storageGroupName, size + 1);
         if (size + 1 > maxSeriesNumberAmongStorageGroup) {
@@ -368,7 +372,7 @@ public class MManager {
     lock.writeLock().lock();
     if (isStorageGroup(prefixPath)) {
 
-      if (IoTDBDescriptor.getInstance().getConfig().isEnableParameterAdapter()) {
+      if (config.isEnableParameterAdapter()) {
         int size = seriesNumberInStorageGroups.get(prefixPath);
         seriesNumberInStorageGroups.put(prefixPath, 0);
         if (size == maxSeriesNumberAmongStorageGroup) {
@@ -423,7 +427,7 @@ public class MManager {
         throw new MetadataException(e);
       }
 
-      if (IoTDBDescriptor.getInstance().getConfig().isEnableParameterAdapter()) {
+      if (config.isEnableParameterAdapter()) {
         String storageGroup = getStorageGroupName(path);
         int size = seriesNumberInStorageGroups.get(storageGroup);
         seriesNumberInStorageGroups.put(storageGroup, size - 1);
@@ -454,7 +458,8 @@ public class MManager {
         writer.flush();
       }
       IoTDBConfigDynamicAdapter.getInstance().addOrDeleteStorageGroup(1);
-      if (IoTDBDescriptor.getInstance().getConfig().isEnableParameterAdapter()) {
+
+      if (config.isEnableParameterAdapter()) {
         ActiveTimeSeriesCounter.getInstance().init(storageGroup);
         seriesNumberInStorageGroups.put(storageGroup, 0);
       }
@@ -489,7 +494,7 @@ public class MManager {
         }
         mNodeCache.clear();
 
-        if (IoTDBDescriptor.getInstance().getConfig().isEnableParameterAdapter()) {
+        if (config.isEnableParameterAdapter()) {
           IoTDBConfigDynamicAdapter.getInstance().addOrDeleteStorageGroup(-1);
           int size = seriesNumberInStorageGroups.get(storageGroup);
           IoTDBConfigDynamicAdapter.getInstance().addOrDeleteTimeSeries(size * -1);


### PR DESCRIPTION
When enable parameter adapter, we first redo log, then init the seriesNumberInStorageGroups. It produces NullPointerException