### PR TITLE
[IOTDB-348] Add Author Plan

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
@@ -48,6 +48,7 @@ import org.apache.iotdb.db.metadata.mnode.StorageGroupMNode;
 import org.apache.iotdb.db.qp.executor.PlanExecutor;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.sys.AuthorPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.utils.SchemaUtils;
@@ -82,7 +83,9 @@ public class ClusterPlanExecutor extends PlanExecutor {
       return processDataQuery((QueryPlan) queryPlan, context);
     } else if (queryPlan instanceof ShowPlan) {
       return processShowQuery((ShowPlan) queryPlan);
-    } else {
+    } else if(queryPlan instanceof AuthorPlan){
+      return processAuthorQuery((AuthorPlan) queryPlan);
+    }else {
       //TODO-Cluster: support more queries
       throw new QueryProcessException(String.format("Unrecognized query plan %s", queryPlan));
     }

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -963,7 +963,7 @@ public class PlanExecutor implements IPlanExecutor {
     }
   }
 
-  private QueryDataSet processAuthorQuery(AuthorPlan plan)
+  protected QueryDataSet processAuthorQuery(AuthorPlan plan)
       throws QueryProcessException {
     AuthorType authorType = plan.getAuthorType();
     String userName = plan.getUserName();

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/PhysicalPlan.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
 import org.apache.iotdb.db.qp.physical.crud.BatchInsertPlan;
 import org.apache.iotdb.db.qp.physical.crud.DeletePlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
+import org.apache.iotdb.db.qp.physical.sys.AuthorPlan;
 import org.apache.iotdb.db.qp.physical.sys.CreateTimeSeriesPlan;
 import org.apache.iotdb.db.qp.physical.sys.DataAuthPlan;
 import org.apache.iotdb.db.qp.physical.sys.SetStorageGroupPlan;
@@ -192,6 +193,50 @@ public abstract class PhysicalPlan {
           plan = new DataAuthPlan(OperatorType.REVOKE_WATERMARK_EMBEDDING);
           plan.deserialize(buffer);
           break;
+        case CREATE_ROLE:
+          plan = new AuthorPlan(OperatorType.CREATE_ROLE);
+          plan.deserialize(buffer);
+          break;
+        case DELETE_ROLE:
+          plan = new AuthorPlan(OperatorType.DELETE_ROLE);
+          plan.deserialize(buffer);
+          break;
+        case CREATE_USER:
+          plan = new AuthorPlan(OperatorType.CREATE_USER);
+          plan.deserialize(buffer);
+          break;
+        case REVOKE_USER_ROLE:
+          plan = new AuthorPlan(OperatorType.REVOKE_USER_ROLE);
+          plan.deserialize(buffer);
+          break;
+        case REVOKE_ROLE_PRIVILEGE:
+          plan = new AuthorPlan(OperatorType.REVOKE_ROLE_PRIVILEGE);
+          plan.deserialize(buffer);
+          break;
+        case REVOKE_USER_PRIVILEGE:
+          plan = new AuthorPlan(OperatorType.REVOKE_USER_PRIVILEGE);
+          plan.deserialize(buffer);
+          break;
+        case GRANT_ROLE_PRIVILEGE:
+          plan = new AuthorPlan(OperatorType.GRANT_ROLE_PRIVILEGE);
+          plan.deserialize(buffer);
+          break;
+        case GRANT_USER_PRIVILEGE:
+          plan = new AuthorPlan(OperatorType.GRANT_USER_PRIVILEGE);
+          plan.deserialize(buffer);
+          break;
+        case GRANT_USER_ROLE:
+          plan = new AuthorPlan(OperatorType.GRANT_USER_ROLE);
+          plan.deserialize(buffer);
+          break;
+        case MODIFY_PASSWORD:
+          plan = new AuthorPlan(OperatorType.MODIFY_PASSWORD);
+          plan.deserialize(buffer);
+          break;
+        case DELETE_USER:
+          plan = new AuthorPlan(OperatorType.DELETE_USER);
+          plan.deserialize(buffer);
+          break;
         default:
           throw new IOException("unrecognized log type " + type);
       }
@@ -200,7 +245,8 @@ public abstract class PhysicalPlan {
   }
 
   public enum PhysicalPlanType {
-    INSERT, DELETE, BATCHINSERT, SET_STORAGE_GROUP, CREATE_TIMESERIES, TTL, GRANT_WATERMARK_EMBEDDING, REVOKE_WATERMARK_EMBEDDING
+    INSERT, DELETE, BATCHINSERT, SET_STORAGE_GROUP, CREATE_TIMESERIES, TTL, GRANT_WATERMARK_EMBEDDING, REVOKE_WATERMARK_EMBEDDING,
+    CREATE_ROLE, DELETE_ROLE, CREATE_USER, REVOKE_USER_ROLE, REVOKE_ROLE_PRIVILEGE, REVOKE_USER_PRIVILEGE, GRANT_ROLE_PRIVILEGE, GRANT_USER_PRIVILEGE, GRANT_USER_ROLE, MODIFY_PASSWORD, DELETE_USER
   }
 
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AuthorPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/AuthorPlan.java
@@ -302,7 +302,6 @@ public class AuthorPlan extends PhysicalPlan {
     } else {
       putString(stream, nodeName.getFullPath());
     }
-
   }
 
 


### PR DESCRIPTION
This pull request implement author plan, including nonquery plan (such as CREATE USER) and query plan (such as LIST USER). 

The following statements are tested in the cluster:

CREATE USER ln_write_user 'write_pwd';
CREATE USER sgcc_write_user 'write_pwd';
LIST USERr;