### PR TITLE
[IOTDB-185]fix start-client failed on WinOS if there is blank space in the file path; let start-server.bat suport jdk12,13 etc

### DIFF
--- a/client/src/assembly/resources/sbin/start-client.bat
+++ b/client/src/assembly/resources/sbin/start-client.bat
@@ -37,17 +37,17 @@ if NOT DEFINED JAVA_HOME goto :err
 @REM -----------------------------------------------------------------------------
 @REM JVM Opts we'll use in legacy run or installation
 set JAVA_OPTS=-ea^
- -DIOTDB_CLI_HOME=%IOTDB_CLI_HOME%
+ -DIOTDB_CLI_HOME="%IOTDB_CLI_HOME%"
 
 REM For each jar in the IOTDB_CLI_HOME lib directory call append to build the CLASSPATH variable.
-set CLASSPATH=%IOTDB_CLI_HOME%\lib\*
+set CLASSPATH="%IOTDB_CLI_HOME%\lib\*"
 
 REM -----------------------------------------------------------------------------
 set PARAMETERS=%*
 
 if "%PARAMETERS%" == "" set PARAMETERS=-h 127.0.0.1 -p 6667 -u root -pw root
 
-"%JAVA_HOME%\bin\java" %JAVA_OPTS% -cp "%CLASSPATH%" %MAIN_CLASS% %PARAMETERS%
+"%JAVA_HOME%\bin\java" %JAVA_OPTS% -cp %CLASSPATH% %MAIN_CLASS% %PARAMETERS%
 
 goto finally
 

--- a/server/src/assembly/resources/sbin/start-server.bat
+++ b/server/src/assembly/resources/sbin/start-server.bat
@@ -42,11 +42,14 @@ for /f tokens^=2-5^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do (
 
 set JAVA_VERSION=%MAJOR_VERSION%
 
-IF NOT "%JAVA_VERSION%" == "8" (
-	IF NOT "%JAVA_VERSION%" == "11" (
-		echo IoTDB only supports jdk8 or jdk11, please check your java version.
+@REM we do not check jdk that version <1.6 because they are too stale...
+IF "%JAVA_VERSION%" == "6" (
+		echo IoTDB only supports jdk >= 8, please check your java version.
 		goto finally
-	)
+)
+IF "%JAVA_VERSION%" == "7" (
+		echo IoTDB only supports jdk >= 8, please check your java version.
+		goto finally
 )
 
 if "%OS%" == "Windows_NT" setlocal

--- a/server/src/assembly/resources/sbin/start-server.bat
+++ b/server/src/assembly/resources/sbin/start-server.bat
@@ -42,7 +42,7 @@ for /f tokens^=2-5^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do (
 
 set JAVA_VERSION=%MAJOR_VERSION%
 
-@REM we do not check jdk that version <1.6 because they are too stale...
+@REM we do not check jdk that version less than 1.6 because they are too stale...
 IF "%JAVA_VERSION%" == "6" (
 		echo IoTDB only supports jdk >= 8, please check your java version.
 		goto finally


### PR DESCRIPTION
I checked IoTDB-185 and it can be reproduced..

Sadly, the issue exists in v0.8.* and v0.9.*.

On winOS, if you put IoTDB in  some folder like D:\a b\iotdb, which has a blank space in the file path, then the start script will fail.

```
C:\Users\user\Downloads\a b> .\sbin\start-client.bat
````````````````````````
Starting IoTDB Client
````````````````````````
错误: 找不到或无法加载主类 b
原因: java.lang.ClassNotFoundException: b
```

Besides, start-server.bat only allows jdk8 and 11 to run IoTDB, which is not suitable because jdk12, 13 and 14 have released.