### PR TITLE
Fix MLog recover

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -82,7 +82,7 @@ public class MManager {
   // tag key -> tag value -> LeafMNode
   private Map<String, Map<String, Set<LeafMNode>>> tagIndex = new HashMap<>();
 
-  private Map<String, Integer> seriesNumberInStorageGroups;
+  private Map<String, Integer> seriesNumberInStorageGroups = new HashMap<>();
   private long maxSeriesNumberAmongStorageGroup;
   private boolean initialized;
   private IoTDBConfig config;
@@ -142,7 +142,6 @@ public class MManager {
 
     try {
       tagLogFile = new TagLogFile(config.getSchemaDir(), MetadataConstant.TAG_LOG);
-      initFromLog(logFile);
 
       if (config.isEnableParameterAdapter()) {
         // storage group name -> the series number
@@ -223,7 +222,7 @@ public class MManager {
 
   public void operation(String cmd) throws IOException, MetadataException {
     //see createTimeseries() to get the detailed format of the cmd
-    String[] args = cmd.trim().split(",");
+    String[] args = cmd.trim().split(",", -1);
     switch (args[0]) {
       case MetadataOperationType.CREATE_TIMESERIES:
         Map<String, String> props = new HashMap<>();


### PR DESCRIPTION
The  split without -1 parameter will remove the empty splits, which cause error in restart.
Also, the redo log is duplicated