### PR TITLE
Upgrade mlog

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
@@ -126,15 +126,17 @@ public class IoTDBConfigCheck {
       }
       if (properties.getProperty("iotdb_version") == null) {
         logger.warn("Lower iotdb version detected, upgrading old mlog file... ");
-        MLogWriter.upgradeMLog(IoTDBDescriptor.getInstance().getConfig().getSchemaDir(), 
+        boolean upgradeSuccessful = MLogWriter.upgradeMLog(IoTDBDescriptor.getInstance().getConfig().getSchemaDir(), 
             MetadataConstant.METADATA_LOG);
-        logger.info("Old mlog file is upgraded.");
-        try (FileOutputStream outputStream = new FileOutputStream(file.toString())) {
-          properties.setProperty("timestamp_precision", timestampPrecision);
-          properties.setProperty("storage_group_time_range", String.valueOf(partitionInterval));
-          properties.setProperty("tsfile_storage_fs", tsfileFileSystem);
-          properties.setProperty("iotdb_version", iotdbVersion);
-          properties.store(outputStream, "System properties:");
+        if (upgradeSuccessful) {
+          logger.info("Old mlog file is upgraded.");
+          try (FileOutputStream outputStream = new FileOutputStream(file.toString())) {
+            properties.setProperty("timestamp_precision", timestampPrecision);
+            properties.setProperty("storage_group_time_range", String.valueOf(partitionInterval));
+            properties.setProperty("tsfile_storage_fs", tsfileFileSystem);
+            properties.setProperty("iotdb_version", iotdbVersion);
+            properties.store(outputStream, "System properties:");
+          }
         }
       }
     } catch (IOException e) {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
@@ -125,18 +125,16 @@ public class IoTDBConfigCheck {
         System.exit(-1);
       }
       if (properties.getProperty("iotdb_version") == null) {
-        logger.warn("Lower iotdb version detected, upgrading old mlog file... ");
-        boolean upgradeSuccessful = MLogWriter.upgradeMLog(IoTDBDescriptor.getInstance().getConfig().getSchemaDir(), 
+        logger.info("Lower iotdb version detected, upgrading old mlog file... ");
+        MLogWriter.upgradeMLog(IoTDBDescriptor.getInstance().getConfig().getSchemaDir(), 
             MetadataConstant.METADATA_LOG);
-        if (upgradeSuccessful) {
-          logger.info("Old mlog file is upgraded.");
-          try (FileOutputStream outputStream = new FileOutputStream(file.toString())) {
-            properties.setProperty("timestamp_precision", timestampPrecision);
-            properties.setProperty("storage_group_time_range", String.valueOf(partitionInterval));
-            properties.setProperty("tsfile_storage_fs", tsfileFileSystem);
-            properties.setProperty("iotdb_version", iotdbVersion);
-            properties.store(outputStream, "System properties:");
-          }
+        logger.info("Old mlog file is upgraded.");
+        try (FileOutputStream outputStream = new FileOutputStream(file.toString())) {
+          properties.setProperty("timestamp_precision", timestampPrecision);
+          properties.setProperty("storage_group_time_range", String.valueOf(partitionInterval));
+          properties.setProperty("tsfile_storage_fs", tsfileFileSystem);
+          properties.setProperty("iotdb_version", iotdbVersion);
+          properties.store(outputStream, "System properties:");
         }
       }
     } catch (IOException e) {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfigCheck.java
@@ -19,6 +19,8 @@
 package org.apache.iotdb.db.conf;
 
 import org.apache.iotdb.db.engine.fileSystem.SystemFileFactory;
+import org.apache.iotdb.db.metadata.MLogWriter;
+import org.apache.iotdb.db.metadata.MetadataConstant;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +41,7 @@ public class IoTDBConfigCheck {
   private static String timestampPrecision = "ms";
   private static long partitionInterval = 86400;
   private static String tsfileFileSystem = "LOCAL";
+  private static String iotdbVersion = "0.10.0";
   private Properties properties = new Properties();
 
   public static final IoTDBConfigCheck getInstance() {
@@ -93,6 +96,7 @@ public class IoTDBConfigCheck {
           properties.setProperty("timestamp_precision", timestampPrecision);
           properties.setProperty("storage_group_time_range", String.valueOf(partitionInterval));
           properties.setProperty("tsfile_storage_fs", tsfileFileSystem);
+          properties.setProperty("iotdb_version", iotdbVersion);
           properties.store(outputStream, "System properties:");
         }
       }
@@ -119,6 +123,19 @@ public class IoTDBConfigCheck {
         logger.error("Wrong tsfile file system, please set as: " + properties
             .getProperty("tsfile_storage_fs") + " !");
         System.exit(-1);
+      }
+      if (properties.getProperty("iotdb_version") == null) {
+        logger.warn("Lower iotdb version detected, upgrading old mlog file... ");
+        MLogWriter.upgradeMLog(IoTDBDescriptor.getInstance().getConfig().getSchemaDir(), 
+            MetadataConstant.METADATA_LOG);
+        logger.info("Old mlog file is upgraded.");
+        try (FileOutputStream outputStream = new FileOutputStream(file.toString())) {
+          properties.setProperty("timestamp_precision", timestampPrecision);
+          properties.setProperty("storage_group_time_range", String.valueOf(partitionInterval));
+          properties.setProperty("tsfile_storage_fs", tsfileFileSystem);
+          properties.setProperty("iotdb_version", iotdbVersion);
+          properties.store(outputStream, "System properties:");
+        }
       }
     } catch (IOException e) {
       logger.error("Load system.properties from {} failed.", file.getAbsolutePath(), e);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -137,15 +137,12 @@ public class MLogWriter {
     }
     // upgrading
     FileReader fileReader;
-    String line;
     fileReader = new FileReader(logFile);
-    BufferedReader reader = new BufferedReader(fileReader);
-
     FileWriter fileWriter;
     fileWriter = new FileWriter(tmpLogFile, true);
-    BufferedWriter writer = new BufferedWriter(fileWriter);
-
-    try {
+    try (BufferedReader reader = new BufferedReader(fileReader);
+        BufferedWriter writer = new BufferedWriter(fileWriter);) {
+      String line;
       while ((line = reader.readLine()) != null) {
         StringBuilder buf = new StringBuilder();
         buf.append(line);
@@ -155,10 +152,8 @@ public class MLogWriter {
         writer.write(buf.toString());
         writer.newLine();
         writer.flush();
+        
       }
-    } finally {
-      reader.close();
-      writer.close();
     }
 
     // upgrade finished, delete old mlog file

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -136,12 +136,8 @@ public class MLogWriter {
       }
     }
     // upgrading
-    FileReader fileReader;
-    fileReader = new FileReader(logFile);
-    FileWriter fileWriter;
-    fileWriter = new FileWriter(tmpLogFile, true);
-    try (BufferedReader reader = new BufferedReader(fileReader);
-        BufferedWriter writer = new BufferedWriter(fileWriter);) {
+    try (BufferedReader reader = new BufferedReader(new FileReader(logFile));
+        BufferedWriter writer = new BufferedWriter(new FileWriter(tmpLogFile, true));) {
       String line;
       while ((line = reader.readLine()) != null) {
         StringBuilder buf = new StringBuilder();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -122,25 +122,33 @@ public class MLogWriter {
     String line;
     fileReader = new FileReader(logFile);
     BufferedReader reader = new BufferedReader(fileReader);
-    StringBuffer bufAll = new StringBuffer();
-    while ((line = reader.readLine()) != null) {
-      StringBuffer buf = new StringBuffer();
-      if (line.startsWith(MetadataOperationType.CREATE_TIMESERIES)) {
-        line = line + ",,,,";
+    StringBuilder bufAll = new StringBuilder();
+    try {
+      while ((line = reader.readLine()) != null) {
+        StringBuilder buf = new StringBuilder();
+        buf.append(line);
+        if (line.startsWith(MetadataOperationType.CREATE_TIMESERIES)) {
+          buf.append(",,,,");
+        }
+        buf.append(System.getProperty("line.separator"));
+        bufAll.append(buf);
       }
-      buf.append(line);
-      buf.append(System.getProperty("line.separator"));
-      bufAll.append(buf);
+    } finally {
+      reader.close();
     }
-    reader.close();
-    logFile.delete();
+    if (!logFile.delete()) {
+      logger.error("MLog file does not exist.");
+    }
     File newFile = new File(logFile.getAbsolutePath());
     FileWriter fileWriter;
     fileWriter = new FileWriter(newFile, true);
     BufferedWriter writer = new BufferedWriter(fileWriter);
-    writer.write(bufAll.toString());
-    writer.flush();
-    writer.close();
+    try {
+      writer.write(bufAll.toString());
+      writer.flush();
+    } finally {
+      writer.close();
+    }
     return newFile;
   }
   

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -87,8 +87,6 @@ public class MLogWriter {
       writer.write(String.valueOf(offset));
     }
 
-    writer.write(",");
-
     writer.newLine();
     writer.flush();
   }
@@ -152,7 +150,7 @@ public class MLogWriter {
         StringBuilder buf = new StringBuilder();
         buf.append(line);
         if (line.startsWith(MetadataOperationType.CREATE_TIMESERIES)) {
-          buf.append(",,,,");
+          buf.append(",,,");
         }
         writer.write(buf.toString());
         writer.newLine();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MLogWriter.java
@@ -166,7 +166,7 @@ public class MLogWriter {
       writer.close();
     }
     if (!logFile.delete()) {
-      logger.error("Deleting old MLog file {} failed");
+      logger.error("Deleting old MLog file {} failed", logFile);
       return false;
     }
     FSFactoryProducer.getFSFactory().moveFile(tmpLogFile, logFile);


### PR DESCRIPTION
To upgrade old mlog, we add empty informations to all old `CREATE_TIMESERIES` records. 

We also add one more property `iotdbVersion` in system.properties for confirming whether we need to do upgrade. 