### PR TITLE
To Resolve grammar mistake in official website homepage

### DIFF
--- a/site/src/main/.vuepress/theme/global-components/IoTDB.vue
+++ b/site/src/main/.vuepress/theme/global-components/IoTDB.vue
@@ -181,7 +181,7 @@ export default {
         {
           src: "/img/home-Slide3.png",
           des:"Cloud Data Management",
-          detail:"In the scene of high-speed network (Internet of Vehicles, etc.), a car installed sensors on it can collect monitoring information(driving status, etc.) of itself at a certain frequency. Usually, these automotive devices have limited hardware configurations and are difficult to carry complex applications. Lightweight IoTDB(IoTDB Client) came into being. With JDBC API, it can make data sent by narrow-band IoT or 4G possible. In this way, devices and cloud are connected together."
+          detail:"In the scene of high-speed networks (Internet of Vehicles, etc.), a car installed of sensors, can collect monitoring information (driving status, etc.) of itself at a certain frequency. Usually, these automotive devices have limited hardware configurations and are difficult to carry complex applications. Here, lightweight IoTDB(IoTDB Client) came into being. IoTDB's JDBC API can make data that can be sent through narrow-band IoT networks or 4G whichever is possible. In this way, devices and cloud are connected together."
         },
       ],
       isHover: false


### PR DESCRIPTION
-- Change is on site module.
--Changing the description of 3rd slide in homepage (https://iotdb.apache.org/) carousal to resolve the grammar mistakes.