### PR TITLE
[IOTDB-625] Change default storage group level number

### DIFF
--- a/server/src/assembly/resources/conf/iotdb-engine.properties
+++ b/server/src/assembly/resources/conf/iotdb-engine.properties
@@ -397,8 +397,8 @@ enable_auto_create_schema=true
 
 # Storage group level when creating schema automatically is enabled
 # e.g. root.sg0.d1.s2
-#      we will set root.sg0 as the storage group if storage group level is 2
-default_storage_group_level=2
+#      we will set root.sg0 as the storage group if storage group level is 1
+default_storage_group_level=1
 
 # BOOLEAN encoding when creating schema automatically is enabled
 default_boolean_encoding=RLE

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -365,7 +365,7 @@ public class IoTDBConfig {
   /**
    * Storage group level when creating schema automatically is enabled
    */
-  private int defaultStorageGroupLevel = 2;
+  private int defaultStorageGroupLevel = 1;
 
   /**
    * BOOLEAN encoding when creating schema automatically is enabled

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MetaUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MetaUtils.java
@@ -59,18 +59,18 @@ class MetaUtils {
   /**
    * Get storage group name when creating schema automatically is enable
    *
-   * e.g., path = root.a.b.c and level = 2, return root.a
+   * e.g., path = root.a.b.c and level = 1, return root.a
    *
    * @param path path
    * @param level level
    */
   public static String getStorageGroupNameByLevel(String path, int level) throws MetadataException {
     String[] nodeNames = MetaUtils.getNodeNames(path);
-    if (nodeNames.length < level || !nodeNames[0].equals(IoTDBConstant.PATH_ROOT)) {
+    if (nodeNames.length <= level || !nodeNames[0].equals(IoTDBConstant.PATH_ROOT)) {
       throw new IllegalPathException(path);
     }
     StringBuilder storageGroupName = new StringBuilder(nodeNames[0]);
-    for (int i = 1; i < level; i++) {
+    for (int i = 1; i <= level; i++) {
       storageGroupName.append(IoTDBConstant.PATH_SEPARATOR).append(nodeNames[i]);
     }
     return storageGroupName.toString();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsfileIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBLoadExternalTsfileIT.java
@@ -408,7 +408,7 @@ public class IoTDBLoadExternalTsfileIT {
       // test wrong statement
       boolean hasError = false;
       try {
-        statement.execute(String.format("load %s true1 2", tmpDir.getAbsolutePath()));
+        statement.execute(String.format("load %s true1 1", tmpDir.getAbsolutePath()));
       } catch (Exception e) {
         hasError = true;
         Assert.assertEquals(
@@ -420,7 +420,7 @@ public class IoTDBLoadExternalTsfileIT {
       // test not load metadata automatically, it will occur errors.
       hasError = false;
       try {
-        statement.execute(String.format("load %s false 2", tmpDir.getAbsolutePath()));
+        statement.execute(String.format("load %s false 1", tmpDir.getAbsolutePath()));
       } catch (Exception e) {
         hasError = true;
       }
@@ -428,7 +428,7 @@ public class IoTDBLoadExternalTsfileIT {
 
       // test load metadata automatically, it will succeed.
       tmpDir = tmpDir.getParentFile().getParentFile();
-      statement.execute(String.format("load %s true 2", tmpDir.getAbsolutePath()));
+      statement.execute(String.format("load %s true 1", tmpDir.getAbsolutePath()));
       resources = new ArrayList<>(
           StorageEngine.getInstance().getProcessor("root.vehicle")
               .getSequenceFileTreeSet());

--- a/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/plan/PhysicalPlanTest.java
@@ -699,21 +699,21 @@ public class PhysicalPlanTest {
     Planner processor = new Planner();
     OperateFilePlan plan = (OperateFilePlan) processor.parseSQLToPhysicalPlan(metadata);
     assertEquals(String.format(
-        "OperateFilePlan{file=%s, targetDir=null, autoCreateSchema=true, sgLevel=2, operatorType=LOAD_FILES}",
+        "OperateFilePlan{file=%s, targetDir=null, autoCreateSchema=true, sgLevel=1, operatorType=LOAD_FILES}",
         filePath), plan.toString());
 
     metadata = String.format("load %s true", filePath);
     processor = new Planner();
     plan = (OperateFilePlan) processor.parseSQLToPhysicalPlan(metadata);
     assertEquals(String.format(
-        "OperateFilePlan{file=%s, targetDir=null, autoCreateSchema=true, sgLevel=2, operatorType=LOAD_FILES}",
+        "OperateFilePlan{file=%s, targetDir=null, autoCreateSchema=true, sgLevel=1, operatorType=LOAD_FILES}",
         filePath), plan.toString());
 
     metadata = String.format("load %s false", filePath);
     processor = new Planner();
     plan = (OperateFilePlan) processor.parseSQLToPhysicalPlan(metadata);
     assertEquals(String.format(
-        "OperateFilePlan{file=%s, targetDir=null, autoCreateSchema=false, sgLevel=2, operatorType=LOAD_FILES}",
+        "OperateFilePlan{file=%s, targetDir=null, autoCreateSchema=false, sgLevel=1, operatorType=LOAD_FILES}",
         filePath), plan.toString());
 
     metadata = String.format("load %s true 3", filePath);


### PR DESCRIPTION
There is a configuration in iotdb-engine.properties

      # Storage group level when creating schema automatically is enabled

      # e.g. root.sg0.d1.s2

      # we will set root.sg0 as the storage group if storage group level is 2
          default_storage_group_level=2

That means the `root` is level 1. 
We should change default storage_group_level to 1 to keep `root` being level 0.
https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-625?filter=allopenissues