### PR TITLE
[IOTDB-626] Fix UserGuide error of v0.9.x

### DIFF
--- a/docs/UserGuide/3-Server/4-Config Manual.md
+++ b/docs/UserGuide/3-Server/4-Config Manual.md
@@ -186,6 +186,18 @@ The permission definitions are in ${IOTDB\_CONF}/conf/jmx.access.
 |Default| The default is 2 digits. Note: The 32-bit floating point number has a decimal precision of 7 bits, and the 64-bit floating point number has a decimal precision of 15 bits. If the setting is out of the range, it will have no practical significance. |
 |Effective|Trigger|
 
+
+* bloomFilterErrorRate
+
+|Name| bloomFilterErrorRate |
+|:---:|:---|
+|Description| The false positive rate of bloom filter in each TsFile. Bloom filter checks whether a given time series is in the tsfile before loading metadata. This can improve the performance of loading metadata and skip the tsfile that doesn't contain specified time series. If you want to learn more about its mechanism, you can refer to: [wiki page of bloom filter](https://en.wikipedia.org/wiki/Bloom_filter).|
+|Type|float, (0, 1)|
+|Default| 0.05 |
+|Effective|After restart system|
+
+
+
 ### Engine Layer
 
 * rpc\_address

--- a/docs/UserGuide/4-Client/5-Programming - TsFile API.md
+++ b/docs/UserGuide/4-Client/5-Programming - TsFile API.md
@@ -557,17 +557,5 @@ TSFileConfig config = TSFileDescriptor.getInstance().getConfig();
 config.setXXX();
 ```
 
-## Bloom filter
 
-Bloom filter checks whether a given time series is in the tsfile before loading metadata. This can improve the performance of loading metadata and skip the tsfile that doesn't contain specified time series.
-If you want to learn more about its mechanism, you can refer to: [wiki page of bloom filter](https://en.wikipedia.org/wiki/Bloom_filter).
-
-#### configuration 
-
-you can control the false positive rate of bloom filter by the following parameter in the config
-
-```
-# The acceptable error rate of bloom filter, should be in [0.01, 0.1], default is 0.05
-bloomFilterErrorRate=0.05
-```
 

--- a/docs/zh/UserGuide/3-Server/4-Config Manual.md
+++ b/docs/zh/UserGuide/3-Server/4-Config Manual.md
@@ -157,6 +157,19 @@
 |默认值| 默认为2位。注意：32位浮点数的十进制精度为7位，64位浮点数的十进制精度为15位。如果设置超过机器精度将没有实际意义。|
 |改后生效方式|触发生效|
 
+
+* bloomFilterErrorRate
+
+|名字| bloomFilterErrorRate |
+|:---:|:---|
+|描述| bloom过滤器的误报率. 在加载元数据之前 Bloom filter 可以检查给定的时间序列是否在 TsFile 中。这可以优化加载元数据的性能，并跳过不包含指定时间序列的 TsFile。如果你想了解更多关于它的细节，你可以参考: [wiki page of bloom filter](https://en.wikipedia.org/wiki/Bloom_filter).|
+|类型|浮点数, 范围为(0, 1)|
+|默认值| 0.05 |
+|改后生效方式|重启生效|
+
+
+
+
 ### 引擎层配置
 
 * back\_loop\_period\_in\_second

--- a/docs/zh/UserGuide/4-Client/5-Programming - TsFile API.md
+++ b/docs/zh/UserGuide/4-Client/5-Programming - TsFile API.md
@@ -553,16 +553,3 @@ TSFileConfig config = TSFileDescriptor.getInstance().getConfig();
 config.setXXX();
 ```
 
-## Bloom filter
-
-在加载元数据之前 Bloom filter 可以检查给定的时间序列是否在 TsFile 中。这可以优化加载元数据的性能，并跳过不包含指定时间序列的 TsFile。
-如果你想了解更多关于它的细节，你可以参考: [wiki page of bloom filter](https://en.wikipedia.org/wiki/Bloom_filter).
-
-#### 配置 
-
-您可以通过修改 TsFileConfig 中的配置项来控制bloom过滤器的误报率：
-
-```
-# The acceptable error rate of bloom filter, should be in [0.01, 0.1], default is 0.05
-bloomFilterErrorRate=0.05
-```

--- a/site/src/main/.vuepress/config.js
+++ b/site/src/main/.vuepress/config.js
@@ -271,8 +271,7 @@ var config = {
 							['6-System Tools/4-Watermark Tool','Watermark Tool'],
 							['6-System Tools/5-Log Visualizer','Log Visualizer'],
 							['6-System Tools/6-Query History Visualization Tool','Query History Visualization Tool'],
-							['6-System Tools/7-Monitor and Log Tools','Monitor and Log Tools'],
-							['6-System Tools/8-Load External Tsfile','Load External Tsfile']
+							['6-System Tools/7-Monitor and Log Tools','Monitor and Log Tools']
 						]
 					},
 					{
@@ -686,8 +685,7 @@ var config = {
 							['6-System Tools/4-Watermark Tool','水印工具'],
 							['6-System Tools/5-Log Visualizer','日志可视化工具'],
 							['6-System Tools/6-Query History Visualization Tool','查询历史可视化工具'],
-							['6-System Tools/7-Monitor and Log Tools','监控与日志工具'],
-							['6-System Tools/8-Load External Tsfile','加载外部tsfile文件']
+							['6-System Tools/7-Monitor and Log Tools','监控与日志工具']
 						]
 					},
 					{


### PR DESCRIPTION
v0.9's docs have the following issue:

- In v0.9, there is no "load external tsfile" featuer, but the website shows it in the user guide doc.

-v0.9.2 added bloom fliter featuer but how to set it is in Programming.md, rather than Config Manual.md