### PR TITLE
[IOTDB-631] Using new TsFile MetadataIndex to optimize query and cache

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -19,6 +19,13 @@
 
 package org.apache.iotdb.db.engine.cache;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -30,22 +37,17 @@ import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.utils.BloomFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.IOException;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
- * This class is used to cache <code>TimeSeriesMetadata</code> in IoTDB. The caching
- * strategy is LRU.
+ * This class is used to cache <code>TimeSeriesMetadata</code> in IoTDB. The caching strategy is
+ * LRU.
  */
 public class TimeSeriesMetadataCache {
 
   private static final Logger logger = LoggerFactory.getLogger(TimeSeriesMetadataCache.class);
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
-  private static final long MEMORY_THRESHOLD_IN_TIME_SERIES_METADATA_CACHE = config.getAllocateMemoryForTimeSeriesMetaDataCache();
+  private static final long MEMORY_THRESHOLD_IN_TIME_SERIES_METADATA_CACHE = config
+      .getAllocateMemoryForTimeSeriesMetaDataCache();
   private static boolean cacheEnable = config.isMetaDataCacheEnable();
 
   private final LRULinkedHashMap<TimeSeriesMetadataCacheKey, TimeseriesMetadata> lruCache;
@@ -58,9 +60,11 @@ public class TimeSeriesMetadataCache {
 
   private TimeSeriesMetadataCache() {
     logger.info("TimeseriesMetadataCache size = " + MEMORY_THRESHOLD_IN_TIME_SERIES_METADATA_CACHE);
-    lruCache = new LRULinkedHashMap<TimeSeriesMetadataCacheKey, TimeseriesMetadata>(MEMORY_THRESHOLD_IN_TIME_SERIES_METADATA_CACHE, true) {
+    lruCache = new LRULinkedHashMap<TimeSeriesMetadataCacheKey, TimeseriesMetadata>(
+        MEMORY_THRESHOLD_IN_TIME_SERIES_METADATA_CACHE, true) {
       int count = 0;
       long averageSize = 0;
+
       @Override
       protected long calEntrySize(TimeSeriesMetadataCacheKey key, TimeseriesMetadata value) {
         if (count < 10) {
@@ -83,7 +87,8 @@ public class TimeSeriesMetadataCache {
     return TimeSeriesMetadataCache.TimeSeriesMetadataCacheHolder.INSTANCE;
   }
 
-  public TimeseriesMetadata get(TimeSeriesMetadataCacheKey key, Set<String> allSensors) throws IOException {
+  public TimeseriesMetadata get(TimeSeriesMetadataCacheKey key, Set<String> allSensors)
+      throws IOException {
     if (!cacheEnable) {
       // bloom filter part
       TsFileMetadata fileMetaData = TsFileMetaDataCache.getInstance().get(key.filePath);
@@ -125,9 +130,20 @@ public class TimeSeriesMetadataCache {
         return null;
       }
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-      TimeseriesMetadata timeseriesMetadata = reader.readTimeseriesMetadata(new Path(key.device, key.measurement));
-      lruCache.put(key, timeseriesMetadata);
-      return timeseriesMetadata;
+      TimeseriesMetadata resultTimeseriesMetadata = reader
+          .readTimeseriesMetadata(new Path(key.device, key.measurement));
+      lruCache.put(key, resultTimeseriesMetadata);
+
+      List<TimeseriesMetadata> timeSeriesMetadataList = reader
+          .readTimeseriesMetadata(key.device, allSensors);
+      if (!allSensors.isEmpty()) {
+        // put TimeSeriesMetadata of all sensors used in this query into cache
+        timeSeriesMetadataList.forEach(timeseriesMetadata -> {
+          lruCache.put(new TimeSeriesMetadataCacheKey(key.filePath, key.device,
+              timeseriesMetadata.getMeasurementId()), timeseriesMetadata);
+        });
+      }
+      return resultTimeseriesMetadata;
     } catch (IOException e) {
       logger.error("something wrong happened while reading {}", key.filePath);
       throw e;
@@ -143,9 +159,9 @@ public class TimeSeriesMetadataCache {
       return;
     }
     logger.debug(
-            "[TimeSeriesMetadata cache {}hit] The number of requests for cache is {}, hit rate is {}.",
-            isHit ? "" : "didn't ", cacheRequestNum.get(),
-            cacheHitNum.get() * 1.0 / cacheRequestNum.get());
+        "[TimeSeriesMetadata cache {}hit] The number of requests for cache is {}, hit rate is {}.",
+        isHit ? "" : "didn't ", cacheRequestNum.get(),
+        cacheHitNum.get() * 1.0 / cacheRequestNum.get());
   }
 
   public double calculateTimeSeriesMetadataHitRatio() {
@@ -177,6 +193,7 @@ public class TimeSeriesMetadataCache {
   }
 
   public static class TimeSeriesMetadataCacheKey {
+
     private String filePath;
     private String device;
     private String measurement;
@@ -189,12 +206,16 @@ public class TimeSeriesMetadataCache {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
       TimeSeriesMetadataCacheKey that = (TimeSeriesMetadataCacheKey) o;
       return Objects.equals(filePath, that.filePath) &&
-              Objects.equals(device, that.device) &&
-              Objects.equals(measurement, that.measurement);
+          Objects.equals(device, that.device) &&
+          Objects.equals(measurement, that.measurement);
     }
 
     @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.db.engine.cache;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -131,17 +130,12 @@ public class TimeSeriesMetadataCache {
         return null;
       }
       TsFileSequenceReader reader = FileReaderManager.getInstance().get(key.filePath, true);
-      Set<String> allSensorsIncludingKey = new HashSet<>(allSensors);
-      allSensorsIncludingKey.add(key.measurement);
       List<TimeseriesMetadata> timeSeriesMetadataList = reader
-          .readTimeseriesMetadata(key.device, allSensorsIncludingKey);
-      if (!allSensorsIncludingKey.isEmpty()) {
-        // put TimeSeriesMetadata of all sensors used in this query into cache
-        timeSeriesMetadataList.forEach(timeseriesMetadata -> {
+          .readTimeseriesMetadata(key.device, allSensors);
+      // put TimeSeriesMetadata of all sensors used in this query into cache
+      timeSeriesMetadataList.forEach(timeseriesMetadata ->
           lruCache.put(new TimeSeriesMetadataCacheKey(key.filePath, key.device,
-              timeseriesMetadata.getMeasurementId()), timeseriesMetadata);
-        });
-      }
+              timeseriesMetadata.getMeasurementId()), timeseriesMetadata));
       return lruCache.get(key);
     } catch (IOException e) {
       logger.error("something wrong happened while reading {}", key.filePath);

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/RawDataQueryPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/RawDataQueryPlan.java
@@ -18,11 +18,17 @@
  */
 package org.apache.iotdb.db.qp.physical.crud;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.expression.IExpression;
-import java.util.*;
 
 public class RawDataQueryPlan extends QueryPlan {
 
@@ -52,7 +58,8 @@ public class RawDataQueryPlan extends QueryPlan {
   }
 
   public void addDeduplicatedPaths(Path path) {
-    deviceToMeasurements.computeIfAbsent(path.getDevice(), key -> new HashSet<>()).add(path.getMeasurement());
+    deviceToMeasurements.computeIfAbsent(path.getDevice(), key -> new HashSet<>())
+        .add(path.getMeasurement());
     this.deduplicatedPaths.add(path);
   }
 
@@ -83,6 +90,11 @@ public class RawDataQueryPlan extends QueryPlan {
 
   public Set<String> getAllMeasurementsInDevice(String device) {
     return deviceToMeasurements.getOrDefault(device, Collections.emptySet());
+  }
+
+  public void addFilterPathInDeviceToMeasurements(Path path) {
+    deviceToMeasurements.computeIfAbsent(path.getDevice(), key -> new HashSet<>())
+        .add(path.getMeasurement());
   }
 
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -419,6 +419,7 @@ public class PhysicalGenerator {
 
       if (filterOperator != null) {
         List<Path> filterPaths = new ArrayList<>(filterOperator.getPathSet());
+        paths.addAll(filterPaths);
         try {
           List<TSDataType> seriesTypes = getSeriesTypes(filterPaths);
           HashMap<Path, TSDataType> pathTSDataTypeHashMap = new HashMap<>();

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -18,6 +18,14 @@
  */
 package org.apache.iotdb.db.qp.strategy;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.iotdb.db.auth.AuthException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.LogicalOperatorException;
@@ -27,22 +35,67 @@ import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
-import org.apache.iotdb.db.qp.logical.crud.*;
-import org.apache.iotdb.db.qp.logical.sys.*;
+import org.apache.iotdb.db.qp.logical.crud.BasicFunctionOperator;
+import org.apache.iotdb.db.qp.logical.crud.DeleteDataOperator;
+import org.apache.iotdb.db.qp.logical.crud.FilterOperator;
+import org.apache.iotdb.db.qp.logical.crud.InsertOperator;
+import org.apache.iotdb.db.qp.logical.crud.QueryOperator;
+import org.apache.iotdb.db.qp.logical.sys.AlterTimeSeriesOperator;
+import org.apache.iotdb.db.qp.logical.sys.AuthorOperator;
+import org.apache.iotdb.db.qp.logical.sys.CountOperator;
+import org.apache.iotdb.db.qp.logical.sys.CreateTimeSeriesOperator;
+import org.apache.iotdb.db.qp.logical.sys.DataAuthOperator;
+import org.apache.iotdb.db.qp.logical.sys.DeleteStorageGroupOperator;
+import org.apache.iotdb.db.qp.logical.sys.DeleteTimeSeriesOperator;
+import org.apache.iotdb.db.qp.logical.sys.LoadDataOperator;
+import org.apache.iotdb.db.qp.logical.sys.LoadFilesOperator;
+import org.apache.iotdb.db.qp.logical.sys.MoveFileOperator;
+import org.apache.iotdb.db.qp.logical.sys.RemoveFileOperator;
+import org.apache.iotdb.db.qp.logical.sys.SetStorageGroupOperator;
+import org.apache.iotdb.db.qp.logical.sys.SetTTLOperator;
+import org.apache.iotdb.db.qp.logical.sys.ShowChildPathsOperator;
+import org.apache.iotdb.db.qp.logical.sys.ShowDevicesOperator;
+import org.apache.iotdb.db.qp.logical.sys.ShowTTLOperator;
+import org.apache.iotdb.db.qp.logical.sys.ShowTimeSeriesOperator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
-import org.apache.iotdb.db.qp.physical.crud.*;
+import org.apache.iotdb.db.qp.physical.crud.AggregationPlan;
+import org.apache.iotdb.db.qp.physical.crud.AlignByDevicePlan;
 import org.apache.iotdb.db.qp.physical.crud.AlignByDevicePlan.MeasurementType;
-import org.apache.iotdb.db.qp.physical.sys.*;
+import org.apache.iotdb.db.qp.physical.crud.DeletePlan;
+import org.apache.iotdb.db.qp.physical.crud.FillQueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.GroupByFillPlan;
+import org.apache.iotdb.db.qp.physical.crud.GroupByPlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
+import org.apache.iotdb.db.qp.physical.crud.LastQueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.QueryPlan;
+import org.apache.iotdb.db.qp.physical.crud.RawDataQueryPlan;
+import org.apache.iotdb.db.qp.physical.sys.AlterTimeSeriesPlan;
+import org.apache.iotdb.db.qp.physical.sys.AuthorPlan;
+import org.apache.iotdb.db.qp.physical.sys.CountPlan;
+import org.apache.iotdb.db.qp.physical.sys.CreateTimeSeriesPlan;
+import org.apache.iotdb.db.qp.physical.sys.DataAuthPlan;
+import org.apache.iotdb.db.qp.physical.sys.DeleteStorageGroupPlan;
+import org.apache.iotdb.db.qp.physical.sys.DeleteTimeSeriesPlan;
+import org.apache.iotdb.db.qp.physical.sys.LoadConfigurationPlan;
+import org.apache.iotdb.db.qp.physical.sys.LoadDataPlan;
+import org.apache.iotdb.db.qp.physical.sys.OperateFilePlan;
+import org.apache.iotdb.db.qp.physical.sys.SetStorageGroupPlan;
+import org.apache.iotdb.db.qp.physical.sys.SetTTLPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowChildPathsPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowDevicesPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowPlan;
 import org.apache.iotdb.db.qp.physical.sys.ShowPlan.ShowContentType;
+import org.apache.iotdb.db.qp.physical.sys.ShowTTLPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowTimeSeriesPlan;
 import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.utils.Pair;
 
-import java.util.*;
-
-/** Used to convert logical operator to physical plan */
+/**
+ * Used to convert logical operator to physical plan
+ */
 public class PhysicalGenerator {
 
   public PhysicalPlan transformToPhysicalPlan(Operator operator) throws QueryProcessException {
@@ -373,7 +426,7 @@ public class PhysicalGenerator {
           } catch (MetadataException e) {
             throw new LogicalOptimizeException(
                 String.format(
-                        "Error when getting all paths of a full path: %s", fullPath.getFullPath())
+                    "Error when getting all paths of a full path: %s", fullPath.getFullPath())
                     + e.getMessage());
           }
         }
@@ -419,11 +472,11 @@ public class PhysicalGenerator {
 
       if (filterOperator != null) {
         List<Path> filterPaths = new ArrayList<>(filterOperator.getPathSet());
-        paths.addAll(filterPaths);
         try {
           List<TSDataType> seriesTypes = getSeriesTypes(filterPaths);
           HashMap<Path, TSDataType> pathTSDataTypeHashMap = new HashMap<>();
           for (int i = 0; i < filterPaths.size(); i++) {
+            ((RawDataQueryPlan) queryPlan).addFilterPathInDeviceToMeasurements(filterPaths.get(i));
             pathTSDataTypeHashMap.put(filterPaths.get(i), seriesTypes.get(i));
           }
           IExpression expression = filterOperator.transformToExpression(pathTSDataTypeHashMap);

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesRawDataBatchReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesRawDataBatchReader.java
@@ -19,7 +19,7 @@
 package org.apache.iotdb.db.query.reader.series;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
@@ -58,7 +58,9 @@ public class SeriesRawDataBatchReader implements ManagedSeriesReader {
   public SeriesRawDataBatchReader(Path seriesPath, TSDataType dataType, QueryContext context,
       List<TsFileResource> seqFileResource, List<TsFileResource> unseqFileResource,
       Filter timeFilter, Filter valueFilter) {
-    this.seriesReader = new SeriesReader(seriesPath, Collections.emptySet(), dataType, context,
+    Set<String> allSensors = new HashSet<>();
+    allSensors.add(seriesPath.getMeasurement());
+    this.seriesReader = new SeriesReader(seriesPath, allSensors, dataType, context,
         seqFileResource, unseqFileResource, timeFilter, valueFilter);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesRawDataBatchReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesRawDataBatchReader.java
@@ -18,6 +18,10 @@
  */
 package org.apache.iotdb.db.query.reader.series;
 
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.engine.storagegroup.TsFileResource;
 import org.apache.iotdb.db.query.context.QueryContext;
@@ -27,11 +31,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.BatchData;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
-
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 public class SeriesRawDataBatchReader implements ManagedSeriesReader {
 
@@ -58,7 +57,9 @@ public class SeriesRawDataBatchReader implements ManagedSeriesReader {
   public SeriesRawDataBatchReader(Path seriesPath, TSDataType dataType, QueryContext context,
       List<TsFileResource> seqFileResource, List<TsFileResource> unseqFileResource,
       Filter timeFilter, Filter valueFilter) {
-    this.seriesReader = new SeriesReader(seriesPath, new HashSet<>(), dataType, context, seqFileResource,
+    Set<String> allSensors = new HashSet<>();
+    allSensors.add(seriesPath.getMeasurement());
+    this.seriesReader = new SeriesReader(seriesPath, allSensors, dataType, context, seqFileResource,
         unseqFileResource, timeFilter, valueFilter);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesRawDataBatchReader.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/reader/series/SeriesRawDataBatchReader.java
@@ -19,7 +19,7 @@
 package org.apache.iotdb.db.query.reader.series;
 
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
@@ -47,20 +47,19 @@ public class SeriesRawDataBatchReader implements ManagedSeriesReader {
     this.seriesReader = seriesReader;
   }
 
-  public SeriesRawDataBatchReader(Path seriesPath, Set<String> allSensors, TSDataType dataType, QueryContext context,
-                                  QueryDataSource dataSource, Filter timeFilter, Filter valueFilter, TsFileFilter fileFilter) {
-    this.seriesReader = new SeriesReader(seriesPath, allSensors, dataType, context, dataSource, timeFilter,
-        valueFilter, fileFilter);
+  public SeriesRawDataBatchReader(Path seriesPath, Set<String> allSensors, TSDataType dataType,
+      QueryContext context, QueryDataSource dataSource, Filter timeFilter, Filter valueFilter,
+      TsFileFilter fileFilter) {
+    this.seriesReader = new SeriesReader(seriesPath, allSensors, dataType, context, dataSource,
+        timeFilter, valueFilter, fileFilter);
   }
 
   @TestOnly
   public SeriesRawDataBatchReader(Path seriesPath, TSDataType dataType, QueryContext context,
       List<TsFileResource> seqFileResource, List<TsFileResource> unseqFileResource,
       Filter timeFilter, Filter valueFilter) {
-    Set<String> allSensors = new HashSet<>();
-    allSensors.add(seriesPath.getMeasurement());
-    this.seriesReader = new SeriesReader(seriesPath, allSensors, dataType, context, seqFileResource,
-        unseqFileResource, timeFilter, valueFilter);
+    this.seriesReader = new SeriesReader(seriesPath, Collections.emptySet(), dataType, context,
+        seqFileResource, unseqFileResource, timeFilter, valueFilter);
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/query/timegenerator/ServerTimeGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/timegenerator/ServerTimeGenerator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.query.timegenerator;
 
+import java.io.IOException;
 import org.apache.iotdb.db.engine.querycontext.QueryDataSource;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.metadata.MManager;
@@ -33,10 +34,8 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.query.timegenerator.TimeGenerator;
 import org.apache.iotdb.tsfile.read.reader.IBatchReader;
 
-import java.io.IOException;
-
 /**
- * A timestamp generator for query with filter. e.g. For query clause "select s1, s2 form root where
+ * A timestamp generator for query with filter. e.g. For query clause "select s1, s2 from root where
  * s3 < 0 and time > 100", this class can iterate back to every timestamp of the query.
  */
 public class ServerTimeGenerator extends TimeGenerator {

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBEngineTimeGeneratorIT.java
@@ -18,6 +18,18 @@
  */
 package org.apache.iotdb.db.integration;
 
+import static org.apache.iotdb.db.utils.EnvironmentUtils.TEST_QUERY_CONTEXT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.constant.TestConstant;
 import org.apache.iotdb.db.exception.StorageEngineException;
@@ -37,15 +49,6 @@ import org.apache.iotdb.tsfile.read.filter.factory.FilterFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
-
-import static org.apache.iotdb.db.utils.EnvironmentUtils.TEST_QUERY_CONTEXT;
-import static org.junit.Assert.*;
 
 /**
  * Notice that, all test begins with "IoTDB" is integration test. All test which will start the
@@ -129,7 +132,7 @@ public class IoTDBEngineTimeGeneratorIT {
         }
       }
 
-      statement.execute("flush");
+      statement.execute("FLUSH");
 
       // insert data (time from 1200-1499)
       for (long time = 1200; time < 1500; time++) {
@@ -210,8 +213,13 @@ public class IoTDBEngineTimeGeneratorIT {
     ValueFilter.ValueGtEq valueGtEq = ValueFilter.gtEq(5);
 
     IExpression singleSeriesExpression = new SingleSeriesExpression(pd1s0, valueGtEq);
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
+    List<Path> paths = new ArrayList<>();
+    paths.add(pd1s0);
+    queryPlan.setDeduplicatedPaths(paths);
+
     ServerTimeGenerator timeGenerator = new ServerTimeGenerator(singleSeriesExpression,
-        TEST_QUERY_CONTEXT, new RawDataQueryPlan());
+        TEST_QUERY_CONTEXT, queryPlan);
 
     int cnt = 0;
     while (timeGenerator.hasNext()) {
@@ -243,8 +251,13 @@ public class IoTDBEngineTimeGeneratorIT {
     IExpression andExpression = BinaryExpression
         .and(singleSeriesExpression1, singleSeriesExpression2);
 
+    RawDataQueryPlan queryPlan = new RawDataQueryPlan();
+    List<Path> paths = new ArrayList<>();
+    paths.add(pd0s0);
+    paths.add(pd0s2);
+    queryPlan.setDeduplicatedPaths(paths);
     ServerTimeGenerator timeGenerator = new ServerTimeGenerator(andExpression,
-        TEST_QUERY_CONTEXT, new RawDataQueryPlan());
+        TEST_QUERY_CONTEXT, queryPlan);
     int cnt = 0;
     while (timeGenerator.hasNext()) {
       long time = timeGenerator.next();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexNode.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexNode.java
@@ -120,6 +120,6 @@ public class MetadataIndexNode {
         return mid; // key found
       }
     }
-    return low - 1;  // key not found
+    return low == 0 ? low : low - 1;  // key not found
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/MetadataIndexNodeType.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/enums/MetadataIndexNodeType.java
@@ -23,6 +23,15 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+
+/**
+ * The type of MetadataIndexNode
+ *
+ * INTERNAL_DEVICE: internal nodes of the index tree's device level
+ * LEAF_DEVICE: leaf nodes of the index tree's device level, points to measurement level
+ * INTERNAL_MEASUREMENT: internal nodes of the index tree's measurement level
+ * LEAF_MEASUREMENT: leaf nodes of the index tree's device level, points to TimeseriesMetadata
+ */
 public enum MetadataIndexNodeType {
   INTERNAL_DEVICE, LEAF_DEVICE, INTERNAL_MEASUREMENT, LEAF_MEASUREMENT;
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -338,7 +338,8 @@ public class TsFileSequenceReader implements AutoCloseable {
     Pair<MetadataIndexEntry, Long> metadataIndexPair = getMetadataAndEndOffset(
         deviceMetadataIndexNode, device, MetadataIndexNodeType.INTERNAL_DEVICE);
     List<TimeseriesMetadata> resultTimeseriesMetadataList = new ArrayList<>();
-    if (measurements.size() > config.getMaxDegreeOfIndexNode()) {
+    int maxDegreeOfIndexNode = config.getMaxDegreeOfIndexNode();
+    if (measurements.size() > maxDegreeOfIndexNode / Math.log(maxDegreeOfIndexNode)) {
       traverseAndReadTimeseriesMetadataInOneDevice(resultTimeseriesMetadataList, metadataIndexPair,
           measurements);
       return resultTimeseriesMetadataList;
@@ -584,6 +585,18 @@ public class TsFileSequenceReader implements AutoCloseable {
     return deviceTimeseriesMetadata;
   }
 
+  /**
+   * Get target MetadataIndexEntry and its end offset
+   *
+   * @param metadataIndex given MetadataIndexNode
+   * @param name target device / measurement name
+   * @param type target MetadataIndexNodeType, either INTERNAL_DEVICE or INTERNAL_MEASUREMENT. When
+   * searching for a device node,  return when it is not INTERNAL_DEVICE. Likewise, when searching
+   * for a measurement node, return when it is not INTERNAL_MEASUREMENT. This works for the
+   * situation when the index tree does NOT have the device level and ONLY has the measurement
+   * level.
+   * @return target MetadataIndexEntry, endOffset pair
+   */
   private Pair<MetadataIndexEntry, Long> getMetadataAndEndOffset(MetadataIndexNode metadataIndex,
       String name, MetadataIndexNodeType type) throws IOException {
     Pair<MetadataIndexEntry, Long> childIndexEntry = metadataIndex.getChildIndexEntry(name);

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/controller/MetadataQuerierByFileImpl.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/controller/MetadataQuerierByFileImpl.java
@@ -115,13 +115,11 @@ public class MetadataQuerierByFileImpl implements IMetadataQuerier {
         continue;
       }
 
-      Map<String, TimeseriesMetadata> timeseriesMetaDataInDevice = tsFileReader
-          .readDeviceMetadata(selectedDevice);
+      List<TimeseriesMetadata> timeseriesMetaDataList = tsFileReader
+          .readTimeseriesMetadata(selectedDevice, selectedMeasurements);
       List<ChunkMetadata> chunkMetadataList = new ArrayList<>();
-      for (Map.Entry<String, TimeseriesMetadata> entry : timeseriesMetaDataInDevice.entrySet()) {
-        if (selectedMeasurements.contains(entry.getKey())) {
-          chunkMetadataList.addAll(tsFileReader.readChunkMetaDataList(entry.getValue()));
-        }
+      for (TimeseriesMetadata timeseriesMetadata : timeseriesMetaDataList) {
+        chunkMetadataList.addAll(tsFileReader.readChunkMetaDataList(timeseriesMetadata));
       }
       // d1
       for (ChunkMetadata chunkMetaData : chunkMetadataList) {


### PR DESCRIPTION
As the new TsFile MetadataIndex is designed, we could do more optimization for querying process and TimeseriesMetadata Cache.
* provide a new interface `List<TimeseriesMetadata> readTimeseriesMetadata` to get more sensors' TimeseriesMetadata and reduce IO.
* use a new method `int binarySearchInTimeseriesMetadataList` for binary searching in TimeseriesMetadataList