### PR TITLE
[IOTDB-563]fix pentaho can not be downloaded because of spring.io address

### DIFF
--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -147,4 +147,20 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <!-- as it is not good to upgrade the hive dependency version in a minor version of IoTDB,
+        we add the repo here. see IOTDB-563 -->
+        <repository>
+            <id>for_pentaho</id>
+            <name>spring.io</name>
+            <url>https://repo.spring.io/libs-milestone</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
 pentaho-aggdesigner-algorithm is not in the maven central-repo. It requires to access repo.sprint.io. However, the repo requires https while in some pom it is defined as http.

The dependency lib is depended by calcite and hive. Therefore, upgrading Hive from 2.3.4 to 3.1.2 is a solution.

 However, it is not suitable to upgrade hive version because rel/0.9 is just for fixing bugs..

Another solution is claim the correct repo address, by add the following content in hive-connector/pom.xml

```

<repositories>
<repository>
<id>for_pentaho</id>
<name>spring.io</name>
<url>https://repo.spring.io/libs-milestone</url>
<layout>default</layout>
<releases>
<enabled>true</enabled>
</releases>
<snapshots>
<enabled>false</enabled>
</snapshots>
</repository>
</repositories>

```