### PR TITLE
[IOTDB-636]Grafana connector does not use correct time unit

### DIFF
--- a/docs/UserGuide/7-Ecosystem Integration/1-Grafana.md
+++ b/docs/UserGuide/7-Ecosystem Integration/1-Grafana.md
@@ -153,7 +153,7 @@ isDownSampling=true
 # defaut sampling intervals
 interval=1m
 # aggregation function to use to downsampling the data
-# COUNT, FIRST_VALUE, LAST_VALUE, MAX_TIME, MAX_VALUE, AVG, MIN_TIME, MIN_VALUE, NOW, SUM
+# COUNT, FIRST, LAST, MAX_TIME, MAX_VALUE, AVG, MIN_TIME, MIN_VALUE, NOW, SUM
 function=avg
 ```
 

--- a/grafana/src/main/resources/application.properties
+++ b/grafana/src/main/resources/application.properties
@@ -32,4 +32,5 @@ isDownSampling=true
 interval=1m
 # aggregation function to use to downsampling the data
 # COUNT, FIRST_VALUE, LAST_VALUE, MAX_TIME, MAX_VALUE, AVG, MIN_TIME, MIN_VALUE, NOW, SUM
-function=avg
+# If it does fail (e.g. due to applying AVG to boolean) it will Fallback to LAST
+function=AVG

--- a/grafana/src/main/resources/application.properties
+++ b/grafana/src/main/resources/application.properties
@@ -31,6 +31,7 @@ isDownSampling=true
 # defaut sampling intervals
 interval=1m
 # aggregation function to use to downsampling the data
-# COUNT, FIRST_VALUE, LAST_VALUE, MAX_TIME, MAX_VALUE, AVG, MIN_TIME, MIN_VALUE, NOW, SUM
+# COUNT, FIRST, LAST, MAX_TIME, MAX_VALUE, AVG, MIN_TIME, MIN_VALUE, NOW, SUM
 # If it does fail (e.g. due to applying AVG to boolean) it will Fallback to LAST
+# notice that from v0.10 on, this parameter is deprecated
 function=AVG

--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -147,4 +147,20 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <!-- as it is not good to upgrade the hive dependency version in a minor version of IoTDB,
+        we add the repo here. see IOTDB-563 -->
+        <repository>
+            <id>for_pentaho</id>
+            <name>spring.io</name>
+            <url>https://repo.spring.io/libs-milestone</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
On rel/0.9, the grafana connector uses the time unit like this:

```
@Autowired
public BasicDaoImpl(JdbcTemplate jdbcTemplate) {
  this.jdbcTemplate = jdbcTemplate;
  Properties properties = new Properties();
  String tsPrecision = properties.getProperty("timestamp_precision", "ms");
  switch (tsPrecision) {
    case "us":
      TIMESTAMP_RADIX = 1000;
      break;
    case "ns":
      TIMESTAMP_RADIX = 1000_000;
      break;
    default:
      TIMESTAMP_RADIX = 1;
  }
  logger.info("Use timestamp precision {}", tsPrecision);
}

```
That is to say, it always is "ms"! No configuration file is read!

 

 