### PR TITLE
[IOTDB-642] Data can't be inserted correctly by alias

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -871,7 +871,7 @@ public class PlanExecutor implements IPlanExecutor {
         }
         LeafMNode measurementNode = (LeafMNode) node.getChild(measurement);
         schemas[i] = measurementNode.getSchema();
-        if (measurement != measurementNode.getName()){
+        if (measurement != measurementNode.getName()) {
           measurementList[i] = measurementNode.getName();
         }
       }

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -871,8 +871,12 @@ public class PlanExecutor implements IPlanExecutor {
         }
         LeafMNode measurementNode = (LeafMNode) node.getChild(measurement);
         schemas[i] = measurementNode.getSchema();
+        if (measurement != measurementNode.getName()){
+          measurementList[i] = measurementNode.getName();
+        }
       }
 
+      insertPlan.setMeasurements(measurementList);
       insertPlan.setSchemas(schemas);
       StorageEngine.getInstance().insert(insertPlan);
     } catch (StorageEngineException | MetadataException e) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
@@ -105,7 +105,7 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
                             + " For more details please refer to the SQL document.");
           }
         }
-        // GROUP_BY_DEVICE leaves the 1) concat, 2) remove star, 3) slimit tasks to the next phase,
+        // ALIGN_BY_DEVICE leaves the 1) concat, 2) remove star, 3) slimit tasks to the next phase,
         // i.e., PhysicalGenerator.transformQuery
       }
     }


### PR DESCRIPTION
If data is inserted using alias, it will be stored by alias path which leads to the empty result in query.

set storage group to root.sg;
create timeseries root.sg.d1.s1(speed)with datatype=FLOAT, encoding=RLE;
insert into root.sg.d1(timestamp,speed) values(1,1);
select s1 from root.sg.d1;
select speed from root.sg.d1; 