### PR TITLE
[IOTDB-661] Keep the alias column in result if it's used in query

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
+++ b/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
@@ -583,7 +583,7 @@ public abstract class AbstractCli {
   private static List<List<String>> cacheResult(ResultSet resultSet, List<Integer> maxSizeList,
       int columnCount, ResultSetMetaData resultSetMetaData, ZoneId zoneId) throws SQLException {
     List<List<String>> lists = new ArrayList<>(columnCount);
-    if( resultSet instanceof  IoTDBQueryResultSet) {
+    if (resultSet instanceof IoTDBQueryResultSet) {
       for (int i = 1; i <= columnCount; i++) {
         List<String> list = new ArrayList<>(maxPrintRowCount + 1);
         list.add(resultSetMetaData.getColumnLabel(i));
@@ -607,7 +607,7 @@ public abstract class AbstractCli {
       isReachEnd = !resultSet.next();
       cursorBeforeFirst = false;
     }
-    if(resultSet instanceof IoTDBQueryResultSet) {
+    if (resultSet instanceof IoTDBQueryResultSet) {
       boolean printTimestamp = !((IoTDBQueryResultSet) resultSet).isIgnoreTimeStamp();
       while (j < maxPrintRowCount && !isReachEnd) {
         for (int i = 1; i <= columnCount; i++) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -681,6 +681,20 @@ public class MManager {
     }
   }
 
+  /**
+   * Similar to method getAllTimeseriesName(), but return Path instead of String in order to include alias.
+   */
+  public List<Path> getAllTimeseriesPath(String prefixPath) throws MetadataException {
+    lock.readLock().lock();
+    try {
+      return mtree.getAllTimeseriesPath(prefixPath);
+    } catch (MetadataException e) {
+      throw new MetadataException(e);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
   public List<ShowTimeSeriesResult> getAllTimeseriesSchema(ShowTimeSeriesPlan plan)
       throws MetadataException {
     lock.readLock().lock();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -514,6 +514,26 @@ public class MTree implements Serializable {
   }
 
   /**
+   * Get all timeseries paths under the given path
+   *
+   * @param prefixPath a prefix path or a full path, may contain '*'.
+   */
+  List<Path> getAllTimeseriesPath(String prefixPath) throws MetadataException {
+    Path prePath = new Path(prefixPath);
+    ShowTimeSeriesPlan plan = new ShowTimeSeriesPlan(prePath);
+    List<String[]> res = getAllMeasurementSchema(plan);
+    List<Path> paths = new ArrayList<>();
+    for (String[] p : res) {
+      Path path = new Path(p[0]);
+      if (prePath.getMeasurement().equals(p[1])){
+        path.setAlias(p[1]);
+      }
+      paths.add(path);
+    }
+    return paths;
+  }
+
+  /**
    * Get all time series schema under the given path
    *
    * <p>result: [name, alias, storage group, dataType, encoding, compression, offset]

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -183,7 +183,7 @@ public class PhysicalGenerator {
             insert.getMeasurementList(),
             insert.getValueList());
       case MERGE:
-        if(operator.getTokenIntType() == SQLConstant.TOK_FULL_MERGE) {
+        if (operator.getTokenIntType() == SQLConstant.TOK_FULL_MERGE) {
           return new MergePlan(OperatorType.FULL_MERGE);
         } else {
           return new MergePlan();
@@ -398,16 +398,14 @@ public class PhysicalGenerator {
 
             String aggregation =
                 originAggregations != null && !originAggregations.isEmpty()
-                    ? originAggregations.get(i)
-                    : null;
+                    ? originAggregations.get(i) : null;
             List<TSDataType> dataTypes = getSeriesTypes(actualPaths, aggregation);
             for (int pathIdx = 0; pathIdx < actualPaths.size(); pathIdx++) {
               Path path = new Path(actualPaths.get(pathIdx));
 
               // check datatype consistency
-              // a example of inconsistency: select s0 from root.sg1.d1, root.sg2.d3 align by
-              // device,
-              // while root.sg1.d1.s0 is INT32 and root.sg2.d3.s0 is FLOAT.
+              // a example of inconsistency: select s0 from root.sg1.d1, root.sg1.d2 align by device,
+              // while root.sg1.d1.s0 is INT32 and root.sg1.d2.s0 is FLOAT.
               String measurementChecked;
               if (originAggregations != null && !originAggregations.isEmpty()) {
                 measurementChecked = originAggregations.get(i) + "(" + path.getMeasurement() + ")";
@@ -592,7 +590,12 @@ public class PhysicalGenerator {
     if (queryPlan instanceof LastQueryPlan) {
       for (int i = 0; i < paths.size(); i++) {
         Path path = paths.get(i);
-        String column = path.toString();
+        String column;
+        if (path.getAlias() != null) {
+          column = path.getFullPathWithAlias();
+        } else {
+          column = path.toString();
+        }
         if (!columnSet.contains(column)) {
           TSDataType seriesType = dataTypes.get(i);
           rawDataQueryPlan.addDeduplicatedPaths(path);
@@ -613,10 +616,13 @@ public class PhysicalGenerator {
     int index = 0;
     for (Pair<Path, Integer> indexedPath : indexedPaths) {
       String column;
-      if (queryPlan instanceof AggregationPlan) {
-        column = queryPlan.getAggregations().get(indexedPath.right) + "(" + indexedPath.left.toString() + ")";
+      if (indexedPath.left.getAlias() != null) {
+        column = indexedPath.left.getFullPathWithAlias();
       } else {
         column = indexedPath.left.toString();
+      }
+      if (queryPlan instanceof AggregationPlan) {
+        column = queryPlan.getAggregations().get(indexedPath.right) + "(" + column + ")";
       }
       if (!columnSet.contains(column)) {
         TSDataType seriesType = dataTypes.get(indexedPath.right);
@@ -624,7 +630,7 @@ public class PhysicalGenerator {
         rawDataQueryPlan.addDeduplicatedDataTypes(seriesType);
         columnSet.add(column);
         rawDataQueryPlan.addPathToIndex(column, index++);
-        if (queryPlan instanceof AggregationPlan){
+        if (queryPlan instanceof AggregationPlan) {
           ((AggregationPlan) queryPlan)
               .addDeduplicatedAggregations(queryPlan.getAggregations().get(indexedPath.right));
         }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
@@ -20,7 +20,6 @@ package org.apache.iotdb.db.qp.strategy.optimizer;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
@@ -279,18 +278,16 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
    */
   private List<Path> removeStarsInPathWithUnique(List<Path> paths) throws LogicalOptimizeException {
     List<Path> retPaths = new ArrayList<>();
-    LinkedHashMap<String, Integer> pathMap = new LinkedHashMap<>();
+    HashSet<String> pathSet = new HashSet<>();
     try {
       for (Path path : paths) {
-        List<String> all = removeWildcard(path.getFullPath());
-        for (String subPath : all) {
-          if (!pathMap.containsKey(subPath)) {
-            pathMap.put(subPath, 1);
+        List<Path> all = removeWildcard(path.getFullPath());
+        for (Path subPath : all) {
+          if (!pathSet.contains(subPath.getFullPath())) {
+            pathSet.add(subPath.getFullPath());
+            retPaths.add(path);
           }
         }
-      }
-      for (String pathStr : pathMap.keySet()) {
-        retPaths.add(new Path(pathStr));
       }
     } catch (MetadataException e) {
       throw new LogicalOptimizeException("error when remove star: " + e.getMessage());
@@ -304,9 +301,9 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
     List<String> newAggregations = new ArrayList<>();
     for (int i = 0; i < paths.size(); i++) {
       try {
-        List<String> actualPaths = removeWildcard(paths.get(i).getFullPath());
-        for (String actualPath : actualPaths) {
-          retPaths.add(new Path(actualPath));
+        List<Path> actualPaths = removeWildcard(paths.get(i).getFullPath());
+        for (Path actualPath : actualPaths) {
+          retPaths.add(actualPath);
           if (afterConcatAggregations != null && !afterConcatAggregations.isEmpty()) {
             newAggregations.add(afterConcatAggregations.get(i));
           }
@@ -319,7 +316,7 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
     selectOperator.setAggregations(newAggregations);
   }
 
-  protected List<String> removeWildcard(String path) throws MetadataException {
-    return MManager.getInstance().getAllTimeseriesName(path);
+  protected List<Path> removeWildcard(String path) throws MetadataException {
+    return MManager.getInstance().getAllTimeseriesPath(path);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/optimizer/ConcatPathOptimizer.java
@@ -285,7 +285,7 @@ public class ConcatPathOptimizer implements ILogicalOptimizer {
         for (Path subPath : all) {
           if (!pathSet.contains(subPath.getFullPath())) {
             pathSet.add(subPath.getFullPath());
-            retPaths.add(path);
+            retPaths.add(subPath);
           }
         }
       }

--- a/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/query/executor/LastQueryExecutor.java
@@ -50,9 +50,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_TIMESERIES;
-import static org.apache.iotdb.db.conf.IoTDBConstant.COLUMN_VALUE;
-
 public class LastQueryExecutor {
   private List<Path> selectedSeries;
   private List<TSDataType> dataTypes;
@@ -86,7 +83,11 @@ public class LastQueryExecutor {
       if (lastTimeValuePair.getValue() != null) {
         RowRecord resultRecord = new RowRecord(lastTimeValuePair.getTimestamp());
         Field pathField = new Field(TSDataType.TEXT);
-        pathField.setBinaryV(new Binary(selectedSeries.get(i).getFullPath()));
+        if (selectedSeries.get(i).getAlias() != null) {
+          pathField.setBinaryV(new Binary(selectedSeries.get(i).getFullPathWithAlias()));
+        } else {
+          pathField.setBinaryV(new Binary(selectedSeries.get(i).getFullPath()));
+        }
         resultRecord.addField(pathField);
 
         Field valueField = new Field(TSDataType.TEXT);

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -662,7 +662,11 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       case QUERY:
       case FILL:
         for (Path p : paths) {
-          respColumns.add(p.getFullPath());
+          if (p.getAlias() != null) {
+            respColumns.add(p.getFullPathWithAlias());
+          } else {
+            respColumns.add(p.getFullPath());
+          }
         }
         seriesTypes = getSeriesTypesByString(respColumns, null);
         break;
@@ -676,7 +680,11 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
           }
         }
         for (int i = 0; i < paths.size(); i++) {
-          respColumns.add(aggregations.get(i) + "(" + paths.get(i).getFullPath() + ")");
+          if (paths.get(i).getAlias() != null) {
+            respColumns.add(aggregations.get(i) + "(" + paths.get(i).getFullPathWithAlias() + ")");
+          } else {
+            respColumns.add(aggregations.get(i) + "(" + paths.get(i).getFullPath() + ")");
+          }
         }
         seriesTypes = getSeriesTypesByPath(paths, aggregations);
         break;

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBAliasIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBAliasIT.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.integration;
+
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IoTDBAliasIT {
+
+  private static String[] sqls = new String[]{
+      "SET STORAGE GROUP TO root.sg",
+      "CREATE TIMESERIES root.sg.d1.s1(speed) WITH DATATYPE=FLOAT, ENCODING=RLE",
+      "CREATE TIMESERIES root.sg.d1.s2(temperature) WITH DATATYPE=FLOAT, ENCODING=RLE",
+      "CREATE TIMESERIES root.sg.d2.s1(speed) WITH DATATYPE=FLOAT, ENCODING=RLE",
+      "CREATE TIMESERIES root.sg.d2.s2(temperature) WITH DATATYPE=FLOAT, ENCODING=RLE",
+
+      "INSERT INTO root.sg.d1(timestamp,speed,temperature) values(100, 10.1, 20.7)",
+      "INSERT INTO root.sg.d1(timestamp,speed,temperature) values(200, 15.2, 22.9)",
+      "INSERT INTO root.sg.d1(timestamp,speed,temperature) values(300, 30.3, 25.1)",
+      "INSERT INTO root.sg.d1(timestamp,speed,temperature) values(400, 50.4, 28.3)",
+
+      "INSERT INTO root.sg.d2(timestamp,speed,temperature) values(100, 11.1, 20.2)",
+      "INSERT INTO root.sg.d2(timestamp,speed,temperature) values(200, 20.2, 21.8)",
+      "INSERT INTO root.sg.d2(timestamp,speed,temperature) values(300, 45.3, 23.4)",
+      "INSERT INTO root.sg.d2(timestamp,speed,temperature) values(400, 73.4, 26.3)"
+  };
+
+  private static final String TIMESTAMP_STR = "Time";
+  private static final String TIMESEIRES_STR = "timeseries";
+  private static final String VALUE_STR = "value";
+
+  @Before
+  public void setUp() throws Exception {
+    EnvironmentUtils.closeStatMonitor();
+    EnvironmentUtils.envSetUp();
+
+    insertData();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    EnvironmentUtils.cleanEnv();
+  }
+
+  private static void insertData() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      for (String sql : sqls) {
+        statement.execute(sql);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void selectWithAliasTest() throws ClassNotFoundException {
+    String[] retArray = new String[]{
+        "100,10.1,20.7,",
+        "200,15.2,22.9,",
+        "300,30.3,25.1,",
+        "400,50.4,28.3,"
+    };
+
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      boolean hasResultSet = statement.execute("select speed, temperature from root.sg.d1");
+      Assert.assertTrue(hasResultSet);
+
+      try (ResultSet resultSet = statement.getResultSet()) {
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        StringBuilder header = new StringBuilder();
+        for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+          header.append(resultSetMetaData.getColumnName(i)).append(",");
+        }
+        Assert.assertEquals("Time,root.sg.d1.speed,root.sg.d1.temperature,", header.toString());
+
+        int cnt = 0;
+        while (resultSet.next()) {
+          StringBuilder builder = new StringBuilder();
+          for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+            builder.append(resultSet.getString(i)).append(",");
+          }
+          Assert.assertEquals(retArray[cnt], builder.toString());
+          cnt++;
+        }
+        Assert.assertEquals(retArray.length, cnt);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void lastSelectWithAliasTest() throws ClassNotFoundException {
+    String[] retArray = new String[]{
+        "400,root.sg.d1.speed,50.4",
+        "400,root.sg.d1.temperature,28.3"
+    };
+
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      boolean hasResultSet = statement.execute("select last speed, temperature from root.sg.d1");
+      Assert.assertTrue(hasResultSet);
+
+      try (ResultSet resultSet = statement.getResultSet()) {
+        int cnt = 0;
+        while (resultSet.next()) {
+          String ans = resultSet.getString(TIMESTAMP_STR) + ","
+              + resultSet.getString(TIMESEIRES_STR) + ","
+              + resultSet.getString(VALUE_STR);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+        Assert.assertEquals(retArray.length, cnt);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void selectDuplicatedPathsWithAliasTest() throws ClassNotFoundException {
+    String[] retArray = new String[]{
+        "100,10.1,10.1,20.7,",
+        "200,15.2,15.2,22.9,",
+        "300,30.3,30.3,25.1,",
+        "400,50.4,50.4,28.3,"
+    };
+
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      boolean hasResultSet = statement.execute("select speed, speed, s2 from root.sg.d1");
+      Assert.assertTrue(hasResultSet);
+
+      try (ResultSet resultSet = statement.getResultSet()) {
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        StringBuilder header = new StringBuilder();
+        for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+          header.append(resultSetMetaData.getColumnName(i)).append(",");
+        }
+        Assert.assertEquals("Time,root.sg.d1.speed,root.sg.d1.speed,root.sg.d1.s2,", header.toString());
+
+        int cnt = 0;
+        while (resultSet.next()) {
+          StringBuilder builder = new StringBuilder();
+          for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+            builder.append(resultSet.getString(i)).append(",");
+          }
+          Assert.assertEquals(retArray[cnt], builder.toString());
+          cnt++;
+        }
+        Assert.assertEquals(4, cnt);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void lastSelectDuplicatedPathsWithAliasTest() throws ClassNotFoundException {
+    String[] retArray = new String[]{
+        "400,root.sg.d1.speed,50.4",
+        "400,root.sg.d1.speed,50.4",
+        "400,root.sg.d1.s2,28.3"
+    };
+
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+      boolean hasResultSet = statement.execute("select last speed, speed, s2 from root.sg.d1");
+      Assert.assertTrue(hasResultSet);
+
+      try (ResultSet resultSet = statement.getResultSet()) {
+        int cnt = 0;
+        while (resultSet.next()) {
+          String ans = resultSet.getString(TIMESTAMP_STR) + ","
+              + resultSet.getString(TIMESEIRES_STR) + ","
+              + resultSet.getString(VALUE_STR);
+          Assert.assertEquals(retArray[cnt], ans);
+          cnt++;
+        }
+        Assert.assertEquals(retArray.length, cnt);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+
+}

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.common.Path;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -196,6 +197,19 @@ public class MTreeTest {
       assertEquals(2, result.size());
       assertEquals("root.a.d0.s0", result.get(0));
       assertEquals("root.a.d1.s0", result.get(1));
+
+
+      List<Path> result2 = root.getAllTimeseriesPath("root.a.*.s0");
+      assertEquals(2, result2.size());
+      assertEquals("root.a.d0.s0", result2.get(0).getFullPath());
+      assertEquals(null, result2.get(0).getAlias());
+      assertEquals("root.a.d1.s0", result2.get(1).getFullPath());
+      assertEquals(null, result2.get(1).getAlias());
+
+      result2 = root.getAllTimeseriesPath("root.a.*.temperature");
+      assertEquals(2, result2.size());
+      assertEquals("root.a.d0.temperature", result2.get(0).getFullPathWithAlias());
+      assertEquals("root.a.d1.temperature", result2.get(1).getFullPathWithAlias());
     } catch (MetadataException e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Path.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Path.java
@@ -19,7 +19,6 @@
 package org.apache.iotdb.tsfile.read.common;
 
 import java.io.Serializable;
-
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.utils.StringContainer;
 
@@ -33,6 +32,7 @@ public class Path implements Serializable, Comparable<Path> {
 
   private static final long serialVersionUID = 3405277066329298200L;
   private String measurement = null;
+  private String alias = null;
   private String device = null;
   private String fullPath;
   private static final String illegalPathArgument = "Path parameter is null";
@@ -177,6 +177,12 @@ public class Path implements Serializable, Comparable<Path> {
   public String getMeasurement() {
     return measurement;
   }
+
+  public String getAlias() { return alias; }
+
+  public void setAlias(String alias) { this.alias = alias; }
+
+  public String getFullPathWithAlias() { return device + TsFileConstant.PATH_SEPARATOR + alias; }
 
   @Override
   public int hashCode() {


### PR DESCRIPTION
SQL: SELECT speed FROM root.sg.d1; (speed is the alias of s1).

Which returns the result like | Time | root.sg.d1.s1 | now.

We need to support keeping the alias in result if it's used in query, returning the result like
 | Time | root.sg.d1.speed |.

This pr supports this function in rawDataQuery and lastQuery.
