### PR TITLE
[IOTDB-675] Move MetadataIndexNodeType from entry to node

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexEntry.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexEntry.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.tsfile.file.metadata;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import org.apache.iotdb.tsfile.file.metadata.enums.MetadataIndexNodeType;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 public class MetadataIndexEntry {
@@ -30,18 +29,9 @@ public class MetadataIndexEntry {
   private String name;
   private long offset;
 
-  /**
-   * type of the child node at offset
-   */
-  private MetadataIndexNodeType childNodeType;
-
-  public MetadataIndexEntry() {
-  }
-
-  public MetadataIndexEntry(String name, long offset, MetadataIndexNodeType childNodeType) {
+  public MetadataIndexEntry(String name, long offset) {
     this.name = name;
     this.offset = offset;
-    this.childNodeType = childNodeType;
   }
 
   public String getName() {
@@ -52,10 +42,6 @@ public class MetadataIndexEntry {
     return offset;
   }
 
-  public MetadataIndexNodeType getChildNodeType() {
-    return childNodeType;
-  }
-
   public void setName(String name) {
     this.name = name;
   }
@@ -64,28 +50,20 @@ public class MetadataIndexEntry {
     this.offset = offset;
   }
 
-  public void setChildNodeType(MetadataIndexNodeType childNodeType) {
-    this.childNodeType = childNodeType;
-  }
-
   public String toString() {
-    return "<" + name + "," + offset + "," + childNodeType + ">";
+    return "<" + name + "," + offset + ">";
   }
 
   public int serializeTo(OutputStream outputStream) throws IOException {
     int byteLen = 0;
     byteLen += ReadWriteIOUtils.write(name, outputStream);
     byteLen += ReadWriteIOUtils.write(offset, outputStream);
-    byteLen += ReadWriteIOUtils.write(childNodeType.serialize(), outputStream);
     return byteLen;
   }
 
   public static MetadataIndexEntry deserializeFrom(ByteBuffer buffer) {
-    MetadataIndexEntry metadataIndex = new MetadataIndexEntry();
-    metadataIndex.setName(ReadWriteIOUtils.readString(buffer));
-    metadataIndex.setOffset(ReadWriteIOUtils.readLong(buffer));
-    metadataIndex
-        .setChildNodeType(MetadataIndexNodeType.deserialize(ReadWriteIOUtils.readByte(buffer)));
-    return metadataIndex;
+    String name = ReadWriteIOUtils.readString(buffer);
+    long offset = ReadWriteIOUtils.readLong(buffer);
+    return new MetadataIndexEntry(name, offset);
   }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexNode.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexNode.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
+import org.apache.iotdb.tsfile.file.metadata.enums.MetadataIndexNodeType;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
@@ -35,14 +36,22 @@ public class MetadataIndexNode {
   private List<MetadataIndexEntry> children;
   private long endOffset;
 
-  public MetadataIndexNode() {
+  /**
+   * type of the child node at offset
+   */
+  private MetadataIndexNodeType nodeType;
+
+  public MetadataIndexNode(MetadataIndexNodeType nodeType) {
     children = new ArrayList<>();
     endOffset = -1L;
+    this.nodeType = nodeType;
   }
 
-  public MetadataIndexNode(List<MetadataIndexEntry> children, long endOffset) {
+  public MetadataIndexNode(List<MetadataIndexEntry> children, long endOffset,
+      MetadataIndexNodeType nodeType) {
     this.children = children;
     this.endOffset = endOffset;
+    this.nodeType = nodeType;
   }
 
   public List<MetadataIndexEntry> getChildren() {
@@ -55,6 +64,10 @@ public class MetadataIndexNode {
 
   public void setEndOffset(long endOffset) {
     this.endOffset = endOffset;
+  }
+
+  public MetadataIndexNodeType getNodeType() {
+    return nodeType;
   }
 
   public void addEntry(MetadataIndexEntry metadataIndexEntry) {
@@ -79,6 +92,7 @@ public class MetadataIndexNode {
       byteLen += metadataIndexEntry.serializeTo(outputStream);
     }
     byteLen += ReadWriteIOUtils.write(endOffset, outputStream);
+    byteLen += ReadWriteIOUtils.write(nodeType.serialize(), outputStream);
     return byteLen;
   }
 
@@ -89,7 +103,8 @@ public class MetadataIndexNode {
       children.add(MetadataIndexEntry.deserializeFrom(buffer));
     }
     long offset = ReadWriteIOUtils.readLong(buffer);
-    return new MetadataIndexNode(children, offset);
+    MetadataIndexNodeType nodeType =  MetadataIndexNodeType.deserialize(ReadWriteIOUtils.readByte(buffer));
+    return new MetadataIndexNode(children, offset, nodeType);
   }
 
   public Pair<MetadataIndexEntry, Long> getChildIndexEntry(String key) {

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexNodeTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/file/metadata/MetadataIndexNodeTest.java
@@ -30,14 +30,14 @@ public class MetadataIndexNodeTest {
   @Test
   public void testBinarySearchInChildren() {
     List<MetadataIndexEntry> list = new ArrayList<>();
-    MetadataIndexNodeType type = MetadataIndexNodeType.LEAF_MEASUREMENT;
-    list.add(new MetadataIndexEntry("s0", -1L, type));
-    list.add(new MetadataIndexEntry("s5", -1L, type));
-    list.add(new MetadataIndexEntry("s10", -1L, type));
-    list.add(new MetadataIndexEntry("s15", -1L, type));
-    list.add(new MetadataIndexEntry("s20", -1L, type));
+    list.add(new MetadataIndexEntry("s0", -1L));
+    list.add(new MetadataIndexEntry("s5", -1L));
+    list.add(new MetadataIndexEntry("s10", -1L));
+    list.add(new MetadataIndexEntry("s15", -1L));
+    list.add(new MetadataIndexEntry("s20", -1L));
 
-    MetadataIndexNode metadataIndexNode = new MetadataIndexNode(list, -1L);
+    MetadataIndexNode metadataIndexNode = new MetadataIndexNode(list, -1L,
+        MetadataIndexNodeType.LEAF_MEASUREMENT);
     Assert.assertEquals(0, metadataIndexNode.binarySearchInChildren("s0"));
     Assert.assertEquals(2, metadataIndexNode.binarySearchInChildren("s10"));
     Assert.assertEquals(2, metadataIndexNode.binarySearchInChildren("s13"));

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/file/metadata/utils/TestHelper.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/file/metadata/utils/TestHelper.java
@@ -43,10 +43,9 @@ public class TestHelper {
   }
 
   private static MetadataIndexNode generateMetaDataIndex() {
-    MetadataIndexNode metaDataIndex = new MetadataIndexNode();
+    MetadataIndexNode metaDataIndex = new MetadataIndexNode(MetadataIndexNodeType.LEAF_MEASUREMENT);
     for (int i = 0; i < 5; i++) {
-      metaDataIndex.addEntry(new MetadataIndexEntry("d" + i, (long) i * 5,
-          MetadataIndexNodeType.LEAF_MEASUREMENT));
+      metaDataIndex.addEntry(new MetadataIndexEntry("d" + i, (long) i * 5));
     }
     return metaDataIndex;
   }


### PR DESCRIPTION
Maintaining a MetadataIndexNodeType field in every metadata index node entry is unnecessary in current implement. Therefore, move MetadataIndexNodeType field to metadata index node so that all entries in this node have the same type.