### PR TITLE
[IOTDB-678] LOCAL_IP and SEED_NODES should be consistent in the conf file

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -1131,7 +1131,6 @@ public class MetaGroupMember extends RaftMember implements TSMetaService.AsyncIf
 
   /**
    * Load the partition table from a local file if it can be found.
-   *
    */
   private void loadPartitionTable() {
     File partitionFile = new File(PARTITION_FILE_NAME);


### PR DESCRIPTION
If the LOCAL_IP and SEED_NODES in the configuration file have both a local ip(127.0.0.1) and a real ip, the iotdb service cannot be connected to other nodes, causing raft communication to fail, and the cluster is always in the election state.

I think the LOCAL_IP and SEED_NODES should be consistent in the conf file; for the pseudo distributed mode, it can be all local ip, for the distributed mode, it must be the real ip, otherwise it will report an error at startup.

please leave your options, thanks.