### PR TITLE
[IOTDB-681] Fix bugs caused by batch manner displaying query results in CLI

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
+++ b/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
@@ -564,11 +564,12 @@ public abstract class AbstractCli {
               e.printStackTrace();
             }
           }
-          resetArgs();
         }
       }
     } catch (Exception e) {
       println("Msg: " + e.getMessage());
+    } finally {
+      resetArgs();
     }
   }
 
@@ -606,8 +607,8 @@ public abstract class AbstractCli {
       }
     }
     int j = 0;
-    isReachEnd = !resultSet.next();
     if (cursorBeforeFirst) {
+      isReachEnd = !resultSet.next();
       cursorBeforeFirst = false;
     }
     if (resultSet instanceof IoTDBJDBCResultSet) {


### PR DESCRIPTION
After entering and executing some wrong SQL statements, execute the correct statement.
At this time, the returned result is: empty set, which is unexpected.