### PR TITLE
[IOTDB-665] validate physical plan before fowarding

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
@@ -42,6 +42,7 @@ import org.apache.iotdb.cluster.query.RemoteQueryContext;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.server.handlers.caller.GenericHandler;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
+import org.apache.iotdb.cluster.utils.StatusUtils;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
@@ -49,6 +50,7 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.service.TSServiceImpl;
+import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.TSIService.Processor;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -100,8 +102,8 @@ public class ClientServer extends TSServiceImpl {
   private TNonblockingServerSocket serverTransport;
 
   /**
-   * queryId -> queryContext map. When a query ends either normally or accidentally, the
-   * resources used by the query can be found in the context and then released.
+   * queryId -> queryContext map. When a query ends either normally or accidentally, the resources
+   * used by the query can be found in the context and then released.
    */
   private Map<Long, RemoteQueryContext> queryContextMap = new ConcurrentHashMap<>();
 
@@ -114,8 +116,8 @@ public class ClientServer extends TSServiceImpl {
 
   /**
    * Create a thrift server to listen to the client port and accept requests from clients. This
-   * server is run in a separate thread.
-   * Calling the method twice does not induce side effects.
+   * server is run in a separate thread. Calling the method twice does not induce side effects.
+   *
    * @throws TTransportException
    */
   public void start() throws TTransportException {
@@ -129,7 +131,7 @@ public class ClientServer extends TSServiceImpl {
 
     // this defines how thrift parse the requests bytes to a request
     TProtocolFactory protocolFactory;
-    if(ClusterDescriptor.getInstance().getConfig().isRpcThriftCompressionEnabled()) {
+    if (ClusterDescriptor.getInstance().getConfig().isRpcThriftCompressionEnabled()) {
       protocolFactory = new TCompactProtocol.Factory();
     } else {
       protocolFactory = new TBinaryProtocol.Factory();
@@ -140,11 +142,12 @@ public class ClientServer extends TSServiceImpl {
     // nonblocking server
     THsHaServer.Args poolArgs =
         new THsHaServer.Args(serverTransport).maxWorkerThreads(IoTDBDescriptor.
-        getInstance().getConfig().getRpcMaxConcurrentClientNum()).minWorkerThreads(1);
+            getInstance().getConfig().getRpcMaxConcurrentClientNum()).minWorkerThreads(1);
     poolArgs.executorService(new ThreadPoolExecutor(poolArgs.minWorkerThreads,
         poolArgs.maxWorkerThreads, poolArgs.getStopTimeoutVal(), poolArgs.getStopTimeoutUnit(),
         new SynchronousQueue<>(), new ThreadFactory() {
       private AtomicLong threadIndex = new AtomicLong(0);
+
       @Override
       public Thread newThread(Runnable r) {
         return new Thread(r, "ClusterClient" + threadIndex.incrementAndGet());
@@ -165,8 +168,8 @@ public class ClientServer extends TSServiceImpl {
   }
 
   /**
-   * Stop the thrift server, close the socket and shutdown the thread pool.
-   * Calling the method twice does not induce side effects.
+   * Stop the thrift server, close the socket and shutdown the thread pool. Calling the method twice
+   * does not induce side effects.
    */
   public void stop() {
     if (serverService == null) {
@@ -181,12 +184,15 @@ public class ClientServer extends TSServiceImpl {
 
   /**
    * Redirect the plan to the local MetaGroupMember so that it will be processed cluster-wide.
+   *
    * @param plan
    * @return
    */
   @Override
   protected TSStatus executePlan(PhysicalPlan plan) {
-    return metaGroupMember.executeNonQuery(plan);
+    TSStatus validateResult = metaGroupMember.validatePlan(plan);
+    return validateResult == StatusUtils.OK ? metaGroupMember.executeNonQuery(plan)
+        : validateResult;
   }
 
   /**
@@ -219,9 +225,10 @@ public class ClientServer extends TSServiceImpl {
 
   /**
    * Get the data types of each path in “paths”. If "aggregations" is not null, then it should be
-   * corresponding to "paths" one to one and the data type will be the type of the aggregation
-   * over the corresponding path.
-   * @param paths full timeseries paths
+   * corresponding to "paths" one to one and the data type will be the type of the aggregation over
+   * the corresponding path.
+   *
+   * @param paths        full timeseries paths
    * @param aggregations if not null, it should be the same size as "paths"
    * @return the data types of "paths" (using the aggregations)
    * @throws MetadataException
@@ -233,9 +240,10 @@ public class ClientServer extends TSServiceImpl {
   }
 
   /**
-   * Get the data types of each path in “paths”. If "aggregation" is not null, all "paths" will
-   * use this aggregation.
-   * @param paths full timeseries paths
+   * Get the data types of each path in “paths”. If "aggregation" is not null, all "paths" will use
+   * this aggregation.
+   *
+   * @param paths       full timeseries paths
    * @param aggregation if not null, it means "paths" all use this aggregation
    * @return the data types of "paths" (using the aggregation)
    * @throws MetadataException
@@ -246,8 +254,9 @@ public class ClientServer extends TSServiceImpl {
   }
 
   /**
-   * Generate and cache a QueryContext using "queryId". In the distributed version, the
-   * QueryContext is a RemoteQueryContext.
+   * Generate and cache a QueryContext using "queryId". In the distributed version, the QueryContext
+   * is a RemoteQueryContext.
+   *
    * @param queryId
    * @return a RemoteQueryContext using queryId
    */
@@ -260,6 +269,7 @@ public class ClientServer extends TSServiceImpl {
 
   /**
    * Release the local and remote resources used by a query.
+   *
    * @param queryId
    * @throws StorageEngineException
    */

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
@@ -19,8 +19,12 @@
 
 package org.apache.iotdb.cluster.server;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -36,6 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iotdb.cluster.client.async.DataClient;
 import org.apache.iotdb.cluster.config.ClusterConfig;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
+import org.apache.iotdb.cluster.partition.PartitionGroup;
 import org.apache.iotdb.cluster.query.ClusterPlanExecutor;
 import org.apache.iotdb.cluster.query.ClusterPlanner;
 import org.apache.iotdb.cluster.query.RemoteQueryContext;
@@ -48,6 +53,9 @@ import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
+import org.apache.iotdb.db.qp.physical.crud.InsertPlan;
+import org.apache.iotdb.db.qp.physical.sys.SetStorageGroupPlan;
+import org.apache.iotdb.db.qp.physical.sys.ShowTimeSeriesPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
 import org.apache.iotdb.db.service.TSServiceImpl;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -195,6 +203,8 @@ public class ClientServer extends TSServiceImpl {
         : validateResult;
   }
 
+
+
   /**
    * EventHandler handles the preprocess and postprocess of the thrift requests, but it currently
    * only release resources when a client disconnects.
@@ -297,4 +307,7 @@ public class ClientServer extends TSServiceImpl {
       }
     }
   }
+
+
+
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/DataClusterServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/DataClusterServer.java
@@ -53,6 +53,7 @@ import org.apache.iotdb.cluster.rpc.thrift.TSDataService.AsyncProcessor;
 import org.apache.iotdb.cluster.server.NodeReport.DataMemberReport;
 import org.apache.iotdb.cluster.server.member.DataGroupMember;
 import org.apache.iotdb.service.rpc.thrift.TSStatus;
+import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
 import org.apache.thrift.transport.TNonblockingServerSocket;
 import org.apache.thrift.transport.TTransportException;
@@ -361,6 +362,14 @@ public class DataClusterServer extends RaftServer implements TSDataService.Async
     DataGroupMember dataMember = getDataMember(header, resultHandler,
         "Get all measurement schema");
     dataMember.getAllMeasurementSchema(header, planBytes, resultHandler);
+  }
+
+  @Override
+  public void getSeriesDataType(Node header, String path,
+      AsyncMethodCallback<Integer> resultHandler) throws TException {
+    DataGroupMember dataMember = getDataMember(header, resultHandler,
+        "Get series data type");
+    dataMember.getSeriesDataType(header, path, resultHandler);
   }
 
   @Override

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
@@ -1499,6 +1499,20 @@ public class DataGroupMember extends RaftMember implements TSDataService.AsyncIf
     }
   }
 
+  @Override
+  public void getSeriesDataType(Node header, String path,
+      AsyncMethodCallback<Integer> resultHandler) throws TException {
+    if (!syncLeader()) {
+      resultHandler.onError(new LeaderUnknownException(getAllNodes()));
+      return;
+    }
+    try {
+      resultHandler.onComplete(MManager.getInstance().getSeriesType(path).ordinal());
+    } catch (MetadataException e) {
+      resultHandler.onError(e);
+    }
+  }
+
 
   /**
    * Execute aggregations over the given path and return the results to the requester.

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -1415,6 +1415,9 @@ public class MetaGroupMember extends RaftMember implements TSMetaService.AsyncIf
 
   private TSStatus validateSetStorageGroupPlan(SetStorageGroupPlan plan) {
     String path = plan.getPath().getFullPath();
+    if(path.trim().equals("root")){
+      return StatusUtils.PATH_ILLEGAL;
+    }
     if (getAllStorageGroupNames().contains(path)) {
       return StatusUtils.PATH_ALREADY_EXIST_ERROR;
     }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/MetaGroupMember.java
@@ -20,8 +20,11 @@
 package org.apache.iotdb.cluster.server.member;
 
 import static org.apache.iotdb.db.conf.IoTDBConstant.PATH_WILDCARD;
+import static org.apache.iotdb.db.qp.constant.SQLConstant.BOOLEAN_FALSE_NUM;
+import static org.apache.iotdb.db.qp.constant.SQLConstant.BOOLEAN_TRUE_NUM;
+import static org.apache.iotdb.db.qp.constant.SQLConstant.BOOLEAN_FALSE;
+import static org.apache.iotdb.db.qp.constant.SQLConstant.BOOLEAN_TRUE;
 import static org.apache.iotdb.db.utils.SchemaUtils.getAggregationType;
-import static org.apache.iotdb.tsfile.file.metadata.enums.TSDataType.*;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -126,7 +129,6 @@ import org.apache.iotdb.cluster.server.member.DataGroupMember.Factory;
 import org.apache.iotdb.cluster.utils.PartitionUtils;
 import org.apache.iotdb.cluster.utils.PartitionUtils.Intervals;
 import org.apache.iotdb.cluster.utils.StatusUtils;
-import org.apache.iotdb.cluster.utils.nodetool.function.Status;
 import org.apache.iotdb.db.auth.AuthException;
 import org.apache.iotdb.db.auth.authorizer.IAuthorizer;
 import org.apache.iotdb.db.auth.authorizer.LocalFileAuthorizer;
@@ -1480,6 +1482,7 @@ public class MetaGroupMember extends RaftMember implements TSMetaService.AsyncIf
 
 
   private void tryParse(String value, TSDataType type) {
+    value = value.trim();
     switch (type) {
       case INT32:
         Integer.parseInt(value);
@@ -1488,9 +1491,8 @@ public class MetaGroupMember extends RaftMember implements TSMetaService.AsyncIf
         Long.parseLong(value);
         break;
       case BOOLEAN:
-        if (!(value.equals("true") || value.equals("TRUE")
-            || value.equals("false") || value.equals("FALSE")
-            || value.equals("0") || value.equals("1"))) {
+        if (!(value.equalsIgnoreCase(BOOLEAN_TRUE) || value.equalsIgnoreCase(BOOLEAN_FALSE)
+            || value.equals(BOOLEAN_TRUE_NUM) || value.equals(BOOLEAN_FALSE_NUM))) {
           throw new IllegalArgumentException(
               "The BOOLEAN should be true/TRUE, false/FALSE or 0/1");
         }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/utils/StatusUtils.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/utils/StatusUtils.java
@@ -25,166 +25,170 @@ import org.apache.iotdb.service.rpc.thrift.TSStatus;
 public class StatusUtils {
 
 
-
   private StatusUtils() {
     // util class
   }
 
-  public static final TSStatus PARTITION_TABLE_NOT_READY = getStatus(TSStatusCode.PARTITION_NOT_READY);
+  public static final TSStatus PARTITION_TABLE_NOT_READY = getStatus(
+      TSStatusCode.PARTITION_NOT_READY);
   public static final TSStatus OK = getStatus(TSStatusCode.SUCCESS_STATUS);
   public static final TSStatus TIME_OUT = getStatus(TSStatusCode.TIME_OUT);
   public static final TSStatus NO_LEADER = getStatus(TSStatusCode.NO_LEADER);
   public static final TSStatus INTERNAL_ERROR = getStatus(TSStatusCode.INTERNAL_SERVER_ERROR);
   public static final TSStatus UNSUPPORTED_OPERATION =
-          getStatus(TSStatusCode.UNSUPPORTED_OPERATION);
+      getStatus(TSStatusCode.UNSUPPORTED_OPERATION);
   public static final TSStatus EXECUTE_STATEMENT_ERROR =
-          getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR);
+      getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR);
   public static final TSStatus NO_STORAGE_GROUP = getStatus(TSStatusCode.STORAGE_GROUP_ERROR);
   public static final TSStatus NODE_READ_ONLY = getStatus(TSStatusCode.NODE_READ_ONLY);
-  public static final TSStatus PATH_ALREADY_EXIST_ERROR = getStatus(TSStatusCode.PATH_ALREADY_EXIST_ERROR);
+  public static final TSStatus PATH_ALREADY_EXIST_ERROR = getStatus(
+      TSStatusCode.PATH_ALREADY_EXIST_ERROR);
+  public static final TSStatus WRITE_PROCESS_ERROR = getStatus(TSStatusCode.WRITE_PROCESS_ERROR);
+  public static final TSStatus PATH_NOT_EXIST_ERROR = getStatus(TSStatusCode.PATH_NOT_EXIST_ERROR);
 
   private static TSStatus getStatus(TSStatusCode statusCode) {
     TSStatus status = new TSStatus();
     status.setCode(statusCode.getStatusCode());
     switch (statusCode) {
       case TIME_OUT:
-        status.setMessage("Request timed out");
+        status.setMessage("Request timed out. ");
         break;
       case NO_LEADER:
-        status.setMessage("Leader cannot be found");
+        status.setMessage("Leader cannot be found. ");
         break;
       case PARTITION_NOT_READY:
-        status.setMessage("Partition table is not ready");
+        status.setMessage("Partition table is not ready. ");
         break;
       case NODE_READ_ONLY:
-        status.setMessage("Current node is read-only, please retry to find another available node");
+        status
+            .setMessage("Current node is read-only, please retry to find another available node. ");
         break;
 
       case INCOMPATIBLE_VERSION:
-        status.setMessage("Incompatible version.");
+        status.setMessage("Incompatible version. ");
         break;
       case NODE_DELETE_FAILED_ERROR:
-        status.setMessage("Failed while deleting node.");
+        status.setMessage("Failed while deleting node. ");
         break;
       case ALIAS_ALREADY_EXIST_ERROR:
-        status.setMessage("Alias already exists");
+        status.setMessage("Alias already exists. ");
         break;
       case PATH_ALREADY_EXIST_ERROR:
-        status.setMessage("Path already exist.");
+        status.setMessage("Path already exist. ");
         break;
       case PATH_NOT_EXIST_ERROR:
-        status.setMessage("Path does not exist.");
+        status.setMessage("Path does not exist. ");
         break;
       case UNSUPPORTED_FETCH_METADATA_OPERATION_ERROR:
-        status.setMessage("Unsupported fetch metadata operation.");
+        status.setMessage("Unsupported fetch metadata operation. ");
         break;
       case METADATA_ERROR:
-        status.setMessage("Meet error when dealing with metadata");
+        status.setMessage("Meet error when dealing with metadata. ");
         break;
       case OUT_OF_TTL_ERROR:
-        status.setMessage("Insertion time is less than TTL time bound.");
+        status.setMessage("Insertion time is less than TTL time bound. ");
         break;
       case CONFIG_ADJUSTER:
-        status.setMessage("IoTDB system load is too large.");
+        status.setMessage("IoTDB system load is too large. ");
         break;
       case MERGE_ERROR:
-        status.setMessage("Meet error while merging.");
+        status.setMessage("Meet error while merging. ");
         break;
       case SYSTEM_CHECK_ERROR:
-        status.setMessage("Meet error while system checking.");
+        status.setMessage("Meet error while system checking. ");
         break;
       case SYNC_DEVICE_OWNER_CONFLICT_ERROR:
-        status.setMessage("Sync device owners conflict.");
+        status.setMessage("Sync device owners conflict. ");
         break;
       case SYNC_CONNECTION_EXCEPTION:
-        status.setMessage("Meet error while sync connecting.");
+        status.setMessage("Meet error while sync connecting. ");
         break;
       case STORAGE_GROUP_PROCESSOR_ERROR:
-        status.setMessage("Storage group processor related error.");
+        status.setMessage("Storage group processor related error. ");
         break;
       case STORAGE_GROUP_ERROR:
-        status.setMessage("Storage group related error.");
+        status.setMessage("Storage group related error. ");
         break;
       case STORAGE_ENGINE_ERROR:
-        status.setMessage("Storage engine related error.");
+        status.setMessage("Storage engine related error. ");
         break;
       case TSFILE_PROCESSOR_ERROR:
-        status.setMessage("TsFile processor related error.");
+        status.setMessage("TsFile processor related error. ");
         break;
       case PATH_ILLEGAL:
-        status.setMessage("Illegal path.");
+        status.setMessage("Illegal path. ");
         break;
       case LOAD_FILE_ERROR:
-        status.setMessage("Meet error while loading file.");
+        status.setMessage("Meet error while loading file. ");
         break;
       case EXECUTE_STATEMENT_ERROR:
-        status.setMessage("Execute statement error.");
+        status.setMessage("Execute statement error. ");
         break;
       case SQL_PARSE_ERROR:
-        status.setMessage("Meet error while parsing SQL.");
+        status.setMessage("Meet error while parsing SQL. ");
         break;
       case GENERATE_TIME_ZONE_ERROR:
-        status.setMessage("Meet error while generating time zone.");
+        status.setMessage("Meet error while generating time zone. ");
         break;
       case SET_TIME_ZONE_ERROR:
-        status.setMessage("Meet error while setting time zone.");
+        status.setMessage("Meet error while setting time zone. ");
         break;
       case NOT_STORAGE_GROUP_ERROR:
-        status.setMessage("Operating object is not a storage group.");
+        status.setMessage("Operating object is not a storage group. ");
         break;
       case QUERY_NOT_ALLOWED:
-        status.setMessage("Query statements are not allowed error.");
+        status.setMessage("Query statements are not allowed error. ");
         break;
       case AST_FORMAT_ERROR:
-        status.setMessage("AST format related error.");
+        status.setMessage("AST format related error. ");
         break;
       case LOGICAL_OPERATOR_ERROR:
-        status.setMessage("Logical operator related error.");
+        status.setMessage("Logical operator related error. ");
         break;
       case LOGICAL_OPTIMIZE_ERROR:
-        status.setMessage("Logical optimize related error.");
+        status.setMessage("Logical optimize related error. ");
         break;
       case UNSUPPORTED_FILL_TYPE_ERROR:
-        status.setMessage("Unsupported fill type related error.");
+        status.setMessage("Unsupported fill type related error. ");
         break;
       case PATH_ERROR:
-        status.setMessage("Path related error.");
+        status.setMessage("Path related error. ");
         break;
       case QUERY_PROCESS_ERROR:
-        status.setMessage("Query process related error.");
+        status.setMessage("Query process related error. ");
         break;
       case WRITE_PROCESS_ERROR:
-        status.setMessage("Writing data related error.");
+        status.setMessage("Writing data related error. ");
         break;
       case INTERNAL_SERVER_ERROR:
-        status.setMessage("Internal server error.");
+        status.setMessage("Internal server error. ");
         break;
       case CLOSE_OPERATION_ERROR:
-        status.setMessage("Meet error in close operation.");
+        status.setMessage("Meet error in close operation. ");
         break;
       case READ_ONLY_SYSTEM_ERROR:
-        status.setMessage("Operating system is read only.");
+        status.setMessage("Operating system is read only. ");
         break;
       case DISK_SPACE_INSUFFICIENT_ERROR:
-        status.setMessage("Disk space is insufficient.");
+        status.setMessage("Disk space is insufficient. ");
         break;
       case START_UP_ERROR:
-        status.setMessage("Meet error while starting up.");
+        status.setMessage("Meet error while starting up. ");
         break;
       case WRONG_LOGIN_PASSWORD_ERROR:
-        status.setMessage("Username or password is wrong.");
+        status.setMessage("Username or password is wrong. ");
         break;
       case NOT_LOGIN_ERROR:
-        status.setMessage("Has not logged in.");
+        status.setMessage("Has not logged in. ");
         break;
       case NO_PERMISSION_ERROR:
-        status.setMessage("No permissions for this operation.");
+        status.setMessage("No permissions for this operation. ");
         break;
       case UNINITIALIZED_AUTH_ERROR:
-        status.setMessage("Uninitialized authorizer.");
+        status.setMessage("Uninitialized authorizer. ");
         break;
       case UNSUPPORTED_OPERATION:
-        status.setMessage("unsupported operation.");
+        status.setMessage("unsupported operation. ");
         break;
       default:
         status.setMessage("");

--- a/cluster/src/main/java/org/apache/iotdb/cluster/utils/StatusUtils.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/utils/StatusUtils.java
@@ -45,6 +45,8 @@ public class StatusUtils {
       TSStatusCode.PATH_ALREADY_EXIST_ERROR);
   public static final TSStatus WRITE_PROCESS_ERROR = getStatus(TSStatusCode.WRITE_PROCESS_ERROR);
   public static final TSStatus PATH_NOT_EXIST_ERROR = getStatus(TSStatusCode.PATH_NOT_EXIST_ERROR);
+  public static final TSStatus PATH_ILLEGAL = getStatus(TSStatusCode.PATH_ILLEGAL);
+
 
   private static TSStatus getStatus(TSStatusCode statusCode) {
     TSStatus status = new TSStatus();

--- a/cluster/src/main/java/org/apache/iotdb/cluster/utils/StatusUtils.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/utils/StatusUtils.java
@@ -24,6 +24,8 @@ import org.apache.iotdb.service.rpc.thrift.TSStatus;
 
 public class StatusUtils {
 
+
+
   private StatusUtils() {
     // util class
   }
@@ -39,6 +41,7 @@ public class StatusUtils {
           getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR);
   public static final TSStatus NO_STORAGE_GROUP = getStatus(TSStatusCode.STORAGE_GROUP_ERROR);
   public static final TSStatus NODE_READ_ONLY = getStatus(TSStatusCode.NODE_READ_ONLY);
+  public static final TSStatus PATH_ALREADY_EXIST_ERROR = getStatus(TSStatusCode.PATH_ALREADY_EXIST_ERROR);
 
   private static TSStatus getStatus(TSStatusCode statusCode) {
     TSStatus status = new TSStatus();

--- a/server/src/main/java/org/apache/iotdb/db/qp/constant/SQLConstant.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/constant/SQLConstant.java
@@ -45,8 +45,8 @@ public class SQLConstant {
   public static final String METADATA_PARAM_EQUAL = "=";
   public static final String QUOTE = "'";
   public static final String DQUOTE = "\"";
-  public static final String BOOLEN_TRUE = "true";
-  public static final String BOOLEN_FALSE = "false";
+  public static final String BOOLEAN_TRUE = "true";
+  public static final String BOOLEAN_FALSE = "false";
   public static final String BOOLEAN_TRUE_NUM = "1";
   public static final String BOOLEAN_FALSE_NUM = "0";
 

--- a/server/src/main/java/org/apache/iotdb/db/utils/CommonUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/CommonUtils.java
@@ -72,10 +72,10 @@ public class CommonUtils {
       switch (dataType) {
         case BOOLEAN:
           value = value.toLowerCase();
-          if (SQLConstant.BOOLEAN_FALSE_NUM.equals(value) || SQLConstant.BOOLEN_FALSE.equals(value)) {
+          if (SQLConstant.BOOLEAN_FALSE_NUM.equals(value) || SQLConstant.BOOLEAN_FALSE.equals(value)) {
             return false;
           }
-          if (SQLConstant.BOOLEAN_TRUE_NUM.equals(value) || SQLConstant.BOOLEN_TRUE.equals(value)) {
+          if (SQLConstant.BOOLEAN_TRUE_NUM.equals(value) || SQLConstant.BOOLEAN_TRUE.equals(value)) {
             return true;
           }
           throw new QueryProcessException("The BOOLEAN should be true/TRUE, false/FALSE or 0/1");

--- a/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
@@ -38,8 +38,8 @@ public class TypeInferenceUtils {
   }
 
   private static boolean isBoolean(String s) {
-    return s.equalsIgnoreCase(SQLConstant.BOOLEN_TRUE) || s
-        .equalsIgnoreCase(SQLConstant.BOOLEN_FALSE);
+    return s.equalsIgnoreCase(SQLConstant.BOOLEAN_TRUE) || s
+        .equalsIgnoreCase(SQLConstant.BOOLEAN_FALSE);
   }
 
   /**

--- a/service-rpc/src/main/thrift/cluster.thrift
+++ b/service-rpc/src/main/thrift/cluster.thrift
@@ -331,6 +331,7 @@ service TSDataService extends RaftService {
 
   binary getAllMeasurementSchema(1: Node header, 2: binary planBinary)
 
+  int getSeriesDataType(1: Node header, 2: string path)
 
   list<binary> getAggrResult(1:GetAggrResultRequest request)
 


### PR DESCRIPTION
This pull request implements physical plan validation before fowarding. The client connects and sends requests to a node in the cluster, which should response some messages if the statement is invalid.

The validation is implemented in `MetaGroupMember` class, `validatePlan()` method.

```
Currently implemented:
    - SetStorageGroupPlan: 
        + path should not exist
    - InsertPlan:
        + path should exist
        + the value can be parsed into the data type of the path
```
