### PR TITLE
fix recover last file bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -530,6 +530,8 @@ public class StorageGroupProcessor {
         workSequenceTsFileProcessors
             .put(timePartitionId, tsFileProcessor);
         tsFileResource.setProcessor(tsFileProcessor);
+        tsFileResource.endTimeMap.clear();
+        tsFileResource.removeResourceFile();
         tsFileProcessor.setTimeRangeId(timePartitionId);
         writer.makeMetadataVisible();
       }
@@ -564,6 +566,7 @@ public class StorageGroupProcessor {
         workUnsequenceTsFileProcessors
             .put(timePartitionId, tsFileProcessor);
         tsFileResource.setProcessor(tsFileProcessor);
+        tsFileResource.removeResourceFile();
         tsFileProcessor.setTimeRangeId(timePartitionId);
         writer.makeMetadataVisible();
       }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -386,6 +386,10 @@ public class TsFileResource {
     fsFactory.getFile(file.getPath() + ModificationFile.FILE_SUFFIX).delete();
   }
 
+  public void removeResourceFile() {
+    fsFactory.getFile(file.getPath() + RESOURCE_SUFFIX).delete();
+  }
+
   void moveTo(File targetDir) {
     fsFactory.moveFile(file, fsFactory.getFile(targetDir, file.getName()));
     fsFactory.moveFile(fsFactory.getFile(file.getPath() + RESOURCE_SUFFIX),

--- a/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/recover/TsFileRecoverPerformer.java
@@ -209,7 +209,6 @@ public class TsFileRecoverPerformer {
       }
       // otherwise this file is not closed before crush, do nothing so we can continue writing
       // into it
-
       resource.serialize();
     } catch (IOException | InterruptedException | ExecutionException e) {
       throw new StorageGroupProcessorException(e);


### PR DESCRIPTION
When the last seq file is recovered, the endTimeMap is set and serialized. But this is not updated when inserting new data. Cause the file resource be filtered when adding a time filter.

insert into root.turbine1.d1(timestamp,s1) values(1,1);
insert into root.turbine1.d1(timestamp,s1) values(2,1);

restart iotdb

insert into root.turbine1.d1(timestamp,s1) values(12,1);
insert into root.turbine1.d1(timestamp,s1) values(13,1);

select s1 from root where time > 8