### PR TITLE
[IOTDB-693]print more info if the sessionPool retry and fails more than RETRY times

### DIFF
--- a/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -222,7 +222,7 @@ public class SessionPool {
     }
   }
 
-  private void mayThrowConnectionException(Session session, int times, IoTDBConnectionException e) throws IoTDBConnectionException {
+  private void cleanSessionAndMayThrowConnectionException(Session session, int times, IoTDBConnectionException e) throws IoTDBConnectionException {
     closeSession(session);
     removeSession();
     if (times == FINAL_RETRY) {
@@ -278,7 +278,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
@@ -312,7 +312,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
@@ -338,7 +338,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
@@ -363,7 +363,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -385,7 +385,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
@@ -408,7 +408,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
@@ -430,7 +430,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -453,7 +453,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -476,7 +476,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -500,7 +500,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -524,7 +524,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -542,7 +542,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -560,7 +560,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -578,7 +578,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -596,7 +596,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -617,7 +617,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -639,7 +639,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
@@ -656,7 +656,7 @@ public class SessionPool {
         return resp;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       }
     }
     //never go here.
@@ -683,7 +683,7 @@ public class SessionPool {
         return wrapper;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
@@ -708,7 +708,7 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        mayThrowConnectionException(session, i, e);
+        cleanSessionAndMayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;

--- a/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -76,6 +76,7 @@ public class SessionPool {
 
   private long timeout; //ms
   private static int RETRY = 3;
+  private static int FINAL_RETRY = RETRY - 1;
   private boolean enableCompression = false;
 
   public SessionPool(String ip, int port, String user, String password, int maxSize) {
@@ -221,6 +222,16 @@ public class SessionPool {
     }
   }
 
+  private void mayThrowConnectionException(Session session, int times, IoTDBConnectionException e) throws IoTDBConnectionException {
+    closeSession(session);
+    removeSession();
+    if (times == FINAL_RETRY) {
+      throw new IoTDBConnectionException(
+          String.format("retry to execute statement on %s:%s failed %d times: %s", ip, port,
+              RETRY, e.getMessage()), e);
+    }
+  }
+
   /**
    * insert the data of a device. For each timestamp, the number of measurements is the same.
    *
@@ -267,15 +278,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
 
@@ -304,15 +312,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   /**
@@ -333,15 +338,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   /**
@@ -361,15 +363,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   /**
@@ -386,15 +385,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   /**
@@ -412,15 +408,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   /**
@@ -437,15 +430,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   /**
@@ -463,15 +453,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   /**
@@ -489,15 +476,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   /**
@@ -516,15 +500,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   /**
@@ -543,15 +524,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   public void setStorageGroup(String storageGroupId)
@@ -564,15 +542,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   public void deleteStorageGroup(String storageGroup)
@@ -585,15 +560,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   public void deleteStorageGroups(List<String> storageGroup)
@@ -606,15 +578,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   public void createTimeseries(String path, TSDataType dataType, TSEncoding encoding,
@@ -627,15 +596,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   public void createTimeseries(String path, TSDataType dataType, TSEncoding encoding,
@@ -651,15 +617,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   public void createMultiTimeseries(List<String> paths, List<TSDataType> dataTypes,
@@ -676,15 +639,12 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (BatchExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 
   public boolean checkTimeseriesExists(String path) throws IoTDBConnectionException {
@@ -696,12 +656,11 @@ public class SessionPool {
         return resp;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
+    //never go here.
+    return false;
   }
 
   /**
@@ -724,15 +683,14 @@ public class SessionPool {
         return wrapper;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
+    // never go here
+    return null;
   }
 
   /**
@@ -750,14 +708,11 @@ public class SessionPool {
         return;
       } catch (IoTDBConnectionException e) {
         // TException means the connection is broken, remove it and get a new one.
-        closeSession(session);
-        removeSession();
+        mayThrowConnectionException(session, i, e);
       } catch (StatementExecutionException e) {
         putBack(session);
         throw e;
       }
     }
-    throw new IoTDBConnectionException(
-        String.format("retry to execute statement on %s:%s failed %d times", ip, port, RETRY));
   }
 }


### PR DESCRIPTION
Now when a user uses SessionPool, and a command fails more than 3 times because the server returns IoTDBConnectionException, the user can only get message like 

"retry to execute statement on %s:%s failed %d times"


It is better to attach detailed info from the server, in case of there is more useful info.