### PR TITLE
fix recover endTime set bug (affect 0.10.0-SNAPSHOT)

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/writelog/recover/LogReplayer.java
+++ b/server/src/main/java/org/apache/iotdb/db/writelog/recover/LogReplayer.java
@@ -82,26 +82,30 @@ public class LogReplayer {
    * finds the logNode of the TsFile given by insertFilePath and logNodePrefix, reads the WALs from
    * the logNode and redoes them into a given MemTable and ModificationFile.
    */
-  public void replayLogs() throws StorageGroupProcessorException {
+  public void replayLogs() {
     WriteLogNode logNode = MultiFileLogNodeManager.getInstance().getNode(
         logNodePrefix + FSFactoryProducer.getFSFactory().getFile(insertFilePath).getName());
 
     ILogReader logReader = logNode.getLogReader();
     try {
       while (logReader.hasNext()) {
-        PhysicalPlan plan = logReader.next();
-        if (plan instanceof InsertPlan) {
-          replayInsert((InsertPlan) plan);
-        } else if (plan instanceof DeletePlan) {
-          replayDelete((DeletePlan) plan);
-        } else if (plan instanceof UpdatePlan) {
-          replayUpdate((UpdatePlan) plan);
-        } else if (plan instanceof InsertTabletPlan) {
-          replayBatchInsert((InsertTabletPlan) plan);
+        try {
+          PhysicalPlan plan = logReader.next();
+          if (plan instanceof InsertPlan) {
+            replayInsert((InsertPlan) plan);
+          } else if (plan instanceof DeletePlan) {
+            replayDelete((DeletePlan) plan);
+          } else if (plan instanceof UpdatePlan) {
+            replayUpdate((UpdatePlan) plan);
+          } else if (plan instanceof InsertTabletPlan) {
+            replayBatchInsert((InsertTabletPlan) plan);
+          }
+        } catch (Exception e) {
+          logger.error("recover wal of {} failed", insertFilePath, e);
         }
       }
-    } catch (IOException | WriteProcessException | QueryProcessException e) {
-      throw new StorageGroupProcessorException(e);
+    } catch (IOException e) {
+      logger.error("meet error when redo wal of {}", insertFilePath, e);
     } finally {
       logReader.close();
       try {

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TTLTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TTLTest.java
@@ -170,7 +170,7 @@ public class TTLTest {
       insertPlan.setTime(initTime - 2000 + i);
       storageGroupProcessor.insert(insertPlan);
       if ((i + 1) % 300 == 0) {
-        storageGroupProcessor.asyncCloseAllWorkingTsFileProcessors();
+        storageGroupProcessor.syncCloseAllWorkingTsFileProcessors();
       }
     }
     // unsequence data
@@ -178,7 +178,7 @@ public class TTLTest {
       insertPlan.setTime(initTime - 2000 + i);
       storageGroupProcessor.insert(insertPlan);
       if ((i + 1) % 300 == 0) {
-        storageGroupProcessor.asyncCloseAllWorkingTsFileProcessors();
+        storageGroupProcessor.syncCloseAllWorkingTsFileProcessors();
       }
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TTLTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TTLTest.java
@@ -108,6 +108,7 @@ public class TTLTest {
   public void testSetMetaTTL() throws IOException, MetadataException {
     // exception is expected when setting ttl to a non-exist storage group
     boolean caught = false;
+
     try {
       MManager.getInstance().setTTL(sg1 + ".notExist", ttl);
     } catch (MetadataException e) {


### PR DESCRIPTION
When meet error when reading logs, we need to retain already recovered data in the tmp memtable.

When recover the last unclosed sequence file, we do not set the endtime. Then newly write data will all go into this new seq tsfile.

When recover, some overlapped chunk groups will be skipped.
