### PR TITLE
[IOTDB-728]Disable “site” module by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ matrix:
       jdk: openjdk8
       script:
         # now, grafana has no tests; spark-* tests are written by scala
-        - mvn post-integration-test -Pcode-coverage -Pcoveralls -pl '!site','!distribution' -am
+        - mvn post-integration-test -Pcode-coverage -Pcoveralls -pl '!distribution' -am
       after_success:
         - mvn coveralls:report -DserviceName=travis_ci -pl tsfile,server,jdbc,client,session,hive-connector,flink-iotdb-connector,flink-tsfile-connector
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ matrix:
           token:
             secure: "a2n2+MFfuOb3hsrw5vjiIUZzjt6S0j4YmRVrms6NVKF+EpEAWU/zOjzfccLGRr3VFUAlkoM2p578c/0DMMGew2oj3Yl1iJe2n35BWIV6r/psUKRUMdgMAogdshQzZGMYmY1XL2xA3ATu8cf4F8WoRAafd/S58JGQdTfsQ5svh31BxK0iuh+nMIZb4dYxO717dSVD45D9hoF5ROxdtTRbyAaXFPs5djxWrdzKw0J3e6a8m82K9FGcpy4pY9ct3ttbyEzGqMnzE4fhd3KgopFJj+3QdAi/3Cmkf1voxorQdCSbktl4PtlzMY/nxF6XETI2E4T+GLUVMw4iHiXCabqwOiudGnEj5DjNz6X5MVCOyj7lrFBTlDirGzv9fNpvQ2I47WOL8DzBJPqFwQ0nRAlbvcWVtE4aAqj8YF1QwwLxEIi4abDfOwaxGG2TOixQf627pvhh1o0RdEf9R6aRyur7vbMt7H9+4tQaHGI2PY1KbCkjhppIrEsarI07uvfPic3By/yOWj6iqZ1QiVAgPTec/o1blNWlMeGwdcCPfCxMjy9iqzpzNIB9fld28CN1Yvzpg74iIKnMU5mL1wB5yT8Vo9Q28JNSEwKIBhuayZLloGbnl/PX8jvDDWSm7yYoZYEI42tgVOXAXX7R53rOcxJMEgCa5RsVDRmJn5n7o6hwhn8="
       script:
-        - mvn verify sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-iotdb -DskipTests -pl '!site','!distribution' -am
+        - mvn verify sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-iotdb -DskipTests -pl '!distribution' -am
     - os: linux
       if: fork = false #only fork=true (i.e., the committer has permission to write the repo)
       name: code-coverage
@@ -133,7 +133,7 @@ matrix:
       dist: xenial
       jdk: openjdk8
       script:
-        - mvn clean package -pl site
+        - mvn -P site clean package -pl site
     - os: windows
       name: windows-website checker
       language: c
@@ -152,7 +152,7 @@ matrix:
         - export "M2_HOME=/c/mvn363/apache-maven-3.6.3"
         - export "PATH=/c/mvn363/apache-maven-3.6.3/bin:$PATH"
       script:
-        - mvn clean package -pl site
+        - mvn -P site clean package -pl site
 cache:
   directories:
     - '$HOME/.m2/repository'
@@ -174,7 +174,7 @@ script:
     - mvn -B apache-rat:check
     # Output something every 10 minutes or Travis kills the job
     - while sleep 540; do echo "=====[ $SECONDS seconds still running ]====="; done &
-    - mvn -B clean test integration-test -pl '!site' -am
+    - mvn -B clean test integration-test
     # Killing background sleep loop
     - kill %1
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                     // Then run the analysis
                     // 'my-sonarcloud-token' needs to be defined for this job and contains the user token
                     withCredentials([string(credentialsId: 'xiangdong-iotdb-sonarcloud-token', variable: 'SONAR_TOKEN')]) {
-                        sh "mvn verify sonar:sonar -Dsonar.branch.name=master -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-iotdb -Dsonar.login=${SONAR_TOKEN} -DskipTests -pl '!site'"
+                        sh "mvn verify sonar:sonar -Dsonar.branch.name=master -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-iotdb -Dsonar.login=${SONAR_TOKEN} -DskipTests"
                     }
                 }
             }
@@ -136,26 +136,26 @@ pipeline {
         }
 
         //temporary disable this stage because VUEPRESS takes too much memory
-//        stage('Deploy site') {
-//            when {
-//                branch 'master'
-//            }
-//            // Only the nodes labeled 'git-websites' have the credentials to commit to the.
-//            agent {
-//                node {
-//                    label 'git-websites'
-//                }
-//            }
-//            steps {
-//                // Publish the site with the scm-publish plugin.
-//                sh 'mvn package scm-publish:publish-scm -pl site'
-//
-//                // Clean up the snapshots directory (freeing up more space after deploying).
-//                dir("target") {
-//                    deleteDir()
-//                }
-//            }
-//        }
+        stage('Deploy site') {
+            when {
+                branch 'master'
+            }
+            // Only the nodes labeled 'git-websites' have the credentials to commit to the.
+            agent {
+                node {
+                    label 'git-websites'
+                }
+            }
+            steps {
+                // Publish the site with the scm-publish plugin.
+                sh 'mvn -P site package scm-publish:publish-scm -pl site'
+
+                // Clean up the snapshots directory (freeing up more space after deploying).
+                dir("target") {
+                    deleteDir()
+                }
+            }
+        }
 
 
         stage('Cleanup') {

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@
         <module>flink-iotdb-connector</module>
         <module>distribution</module>
         <module>hive-connector</module>
-        <module>site</module>
     </modules>
     <!-- Properties Management -->
     <properties>
@@ -1223,5 +1222,12 @@
         <!-- upload code coverage report to coveralls.io-->
         <!-- to enable coveralls locally, you need to get the repoToken from https://coveralls.io/github/apache/incubator-iotdb.
              use `mvn post-integration-test -Pcode-coverage -DrepoToken=TOKEN`-->
+        <!-- enable site--><!-- use `mvn package -P site -pl site` to compile the site module only -->
+        <profile>
+            <id>site</id>
+            <modules>
+                <module>site</module>
+            </modules>
+        </profile>
     </profiles>
 </project>

--- a/site/src/main/package.json
+++ b/site/src/main/package.json
@@ -37,7 +37,7 @@
     "unified-engine": "^7.0.0",
     "vfile-reporter": "^6.0.1",
     "vue-tabs-component": "^1.5.0",
-    "vuepress": "^1.3.1",
+    "vuepress": "^1.5.0",
     "vuepress-plugin-tabs": "^0.3.0"
   }
 }


### PR DESCRIPTION
The website source code has been moved to iotdb repo from v0.10 on, named as module site.

 

However, normally guys who only care about the source code of IoTDB project may do not want to compile the website code (and the compiling is time consuming and memory consuming).

 

Now we can use `mvn package -pl '!site'` to disable the module.

 

However, I'd like to disable the module by default and if someone (e.g., the Jenkins server, the website developer) wants to run it, just run `mvn package -P site`.

 

Or, if we want to consider the module as a subproject in IDEAJ, just click the maven panel and click Profiles -> site.

 