### PR TITLE
[IOTDB-738] Fix measurements has blank

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -19,14 +19,17 @@
 package org.apache.iotdb;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Random;
+import java.util.Map;
 import org.apache.iotdb.rpc.BatchExecutionException;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.session.Session;
-import org.apache.iotdb.session.pool.SessionDataSetWrapper;
-import org.apache.iotdb.session.pool.SessionPool;
+import org.apache.iotdb.session.SessionDataSet;
+import org.apache.iotdb.session.SessionDataSet.DataIterator;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.write.record.Tablet;
@@ -34,274 +37,365 @@ import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 public class SessionExample {
 
-  static SessionPool sessionPool = new SessionPool("127.0.0.1", 6667, "root", "root", 10);
+  private static Session session;
 
-  public static void main(String[] args) {
+  public static void main(String[] args)
+      throws IoTDBConnectionException, StatementExecutionException, BatchExecutionException {
+    session = new Session("127.0.0.1", 6667, "root", "root");
+    session.open(false);
 
-    for (int i = 0; i < 6; i++) {
-      new Thread(new WriteThread(1)).start();
+    try {
+      session.setStorageGroup("root.sg1");
+    } catch (StatementExecutionException e) {
+      if (e.getStatusCode() != TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode())
+        throw e;
     }
 
-//    try {
-//      Thread.sleep(10000);
-//    } catch (InterruptedException e) {
-//      e.printStackTrace();
-//    }
-//
-//    for (int i = 0; i < 6; i++) {
-//      new Thread(new ReadLastThread(i)).start();
-//      new Thread(new ReadRawDataThread(i)).start();
-//      new Thread(new ReadGroupByThread(i)).start();
-//    }
-//
-//    try {
-//      Thread.sleep(10000);
-//    } catch (InterruptedException e) {
-//      e.printStackTrace();
-//    }
-//
-//    new Thread(new WriteHistThread(1)).start();
-
+    createTimeseries();
+    createMultiTimeseries();
+    insertRecord();
+    insertTablet();
+    insertTablets();
+    insertRecords();
+    nonQuery();
+    query();
+    queryByIterator();
+    deleteData();
+    deleteTimeseries();
+    session.close();
   }
 
-  static class WriteThread implements Runnable{
-    int device;
+  private static void createTimeseries()
+      throws IoTDBConnectionException, StatementExecutionException {
 
-    WriteThread(int device) {
-      this.device = device;
+    if (!session.checkTimeseriesExists("root.sg1.d1.s1")) {
+      session.createTimeseries("root.sg1.d1.s1", TSDataType.INT64, TSEncoding.RLE,
+          CompressionType.SNAPPY);
+    }
+    if (!session.checkTimeseriesExists("root.sg1.d1.s2")) {
+      session.createTimeseries("root.sg1.d1.s2", TSDataType.INT64, TSEncoding.RLE,
+          CompressionType.SNAPPY);
+    }
+    if (!session.checkTimeseriesExists("root.sg1.d1.s3")) {
+      session.createTimeseries("root.sg1.d1.s3", TSDataType.INT64, TSEncoding.RLE,
+          CompressionType.SNAPPY);
     }
 
-    @Override
-    public void run() {
-      Session session = new Session("127.0.0.1", 6667, "root", "root");
-      try {
-        session.open();
-      } catch (IoTDBConnectionException e) {
-        e.printStackTrace();
-      }
-      long time = 1;
-      Random random = new Random();
-      while (true) {
-        try {
-          Thread.sleep(10);
-        } catch (InterruptedException e) {
-          e.printStackTrace();
-        }
-        long start = System.currentTimeMillis();
-
-        time += 100;
-        String deviceId = "root.sg1.d" + time;
-        List<String> measurements = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
-          measurements.add("s" + (time + i));
-        }
-
-        List<String> values = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
-          values.add(random.nextInt() + "");
-        }
-
-        try {
-          session.insertRecord(deviceId, time, measurements, values);
-        } catch (IoTDBConnectionException | StatementExecutionException e) {
-          e.printStackTrace();
-        }
-        System.out.println(
-            Thread.currentThread().getName() + " write 1 cost: " + (System.currentTimeMillis() - start));
-      }
+    // create timeseries with tags and attributes
+    if (!session.checkTimeseriesExists("root.sg1.d1.s4")) {
+      Map<String, String> tags = new HashMap<>();
+      tags.put("tag1", "v1");
+      Map<String, String> attributes = new HashMap<>();
+      tags.put("description", "v1");
+      session.createTimeseries("root.sg1.d1.s4", TSDataType.INT64, TSEncoding.RLE,
+          CompressionType.SNAPPY, null, tags, attributes, "temperature");
     }
   }
 
-  static class WriteHistThread implements Runnable{
-    int device;
+  private static void createMultiTimeseries()
+      throws IoTDBConnectionException, BatchExecutionException, StatementExecutionException {
 
-    WriteHistThread(int device) {
-      this.device = device;
-    }
+    if (!session.checkTimeseriesExists("root.sg1.d2.s1") && !session
+        .checkTimeseriesExists("root.sg1.d2.s2")) {
+      List<String> paths = new ArrayList<>();
+      paths.add("root.sg1.d2.s1");
+      paths.add("root.sg1.d2.s2");
+      List<TSDataType> tsDataTypes = new ArrayList<>();
+      tsDataTypes.add(TSDataType.INT64);
+      tsDataTypes.add(TSDataType.INT64);
+      List<TSEncoding> tsEncodings = new ArrayList<>();
+      tsEncodings.add(TSEncoding.RLE);
+      tsEncodings.add(TSEncoding.RLE);
+      List<CompressionType> compressionTypes = new ArrayList<>();
+      compressionTypes.add(CompressionType.SNAPPY);
+      compressionTypes.add(CompressionType.SNAPPY);
 
-    @Override
-    public void run() {
-      long time = 86400000000L;
-      Random random = new Random();
-      while (true) {
-        try {
-          Thread.sleep(5000);
-        } catch (InterruptedException e) {
-          e.printStackTrace();
-        }
-        long start = System.currentTimeMillis();
+      List<Map<String, String>> tagsList = new ArrayList<>();
+      Map<String, String> tags = new HashMap<>();
+      tags.put("unit", "kg");
+      tagsList.add(tags);
+      tagsList.add(tags);
 
-        int index = random.nextInt(250000);
+      List<Map<String, String>> attributesList = new ArrayList<>();
+      Map<String, String> attributes = new HashMap<>();
+      attributes.put("minValue", "1");
+      attributes.put("maxValue", "100");
+      attributesList.add(attributes);
+      attributesList.add(attributes);
 
-        List<MeasurementSchema> schemaList = new ArrayList<>();
-        schemaList.add(new MeasurementSchema("s" + index, TSDataType.FLOAT, TSEncoding.RLE));
-        schemaList.add(new MeasurementSchema("s" + (index+1), TSDataType.FLOAT, TSEncoding.RLE));
-        schemaList.add(new MeasurementSchema("s" + (index+2), TSDataType.FLOAT, TSEncoding.RLE));
-        schemaList.add(new MeasurementSchema("s" + (index+3), TSDataType.FLOAT, TSEncoding.RLE));
-        schemaList.add(new MeasurementSchema("s" + (index+4), TSDataType.FLOAT, TSEncoding.RLE));
-        schemaList.add(new MeasurementSchema("s" + (index+5), TSDataType.FLOAT, TSEncoding.RLE));
-        schemaList.add(new MeasurementSchema("s" + (index+6), TSDataType.FLOAT, TSEncoding.RLE));
-        schemaList.add(new MeasurementSchema("s" + (index+7), TSDataType.FLOAT, TSEncoding.RLE));
-        schemaList.add(new MeasurementSchema("s" + (index+8), TSDataType.FLOAT, TSEncoding.RLE));
-        schemaList.add(new MeasurementSchema("s" + (index+9), TSDataType.FLOAT, TSEncoding.RLE));
+      List<String> alias = new ArrayList<>();
+      alias.add("weight1");
+      alias.add("weight2");
 
-
-        Tablet tablet = new Tablet("root.sg1.d1", schemaList, 50000);
-
-        long[] timestamps = tablet.timestamps;
-        Object[] values = tablet.values;
-
-        for (int num = 0; num < 50000; num++) {
-          int row = tablet.rowSize++;
-          timestamps[row] = time;
-          time += 5000;
-          for (int i = 0; i < 10; i++) {
-            float[] sensor = (float[]) values[i];
-            sensor[row] = random.nextFloat();
-          }
-          if (tablet.rowSize == tablet.getMaxRowNumber()) {
-            try {
-              sessionPool.insertTablet(tablet, true);
-            } catch (IoTDBConnectionException | BatchExecutionException e) {
-              e.printStackTrace();
-            }
-            tablet.reset();
-          }
-        }
-
-        if (tablet.rowSize != 0) {
-          try {
-            sessionPool.insertTablet(tablet);
-          } catch (IoTDBConnectionException | BatchExecutionException e) {
-            e.printStackTrace();
-          }
-          tablet.reset();
-        }
-        System.out.println(
-            Thread.currentThread().getName() + " write 500000 future point cost: " + (System.currentTimeMillis() - start) + "to s" + index);
-      }
+      session
+          .createMultiTimeseries(paths, tsDataTypes, tsEncodings, compressionTypes, null, tagsList,
+              attributesList, alias);
     }
   }
 
-  static class ReadLastThread implements Runnable {
-    int device;
+  private static void insertRecord() throws IoTDBConnectionException, StatementExecutionException {
+    String deviceId = "root.sg1.d1";
+    List<String> measurements = new ArrayList<>();
+    List<TSDataType> types = new ArrayList<>();
+    measurements.add("s1");
+    measurements.add("s2");
+    measurements.add("s3");
+    types.add(TSDataType.INT64);
+    types.add(TSDataType.INT64);
+    types.add(TSDataType.INT64);
 
-    ReadLastThread(int device) {
-      this.device = device;
-    }
-
-    @Override
-    public void run() {
-      SessionDataSetWrapper dataSet = null;
-
-      try {
-        while (true) {
-          Thread.sleep(5000);
-          long start = System.currentTimeMillis();
-
-          StringBuilder builder = new StringBuilder("select last ");
-          for (int c = 50000*device; c < 50000*device + 49999; c++) {
-            builder.append("s").append(c).append(",");
-          }
-
-          builder.append("s" + ((device+1)*50000-1));
-          builder.append(" from root.sg1.d1");
-
-          dataSet = sessionPool.executeQueryStatement(builder.toString());
-          int a = 0;
-          while (dataSet.hasNext()) {
-            a++;
-            dataSet.next();
-          }
-          System.out.println(Thread.currentThread().getName() + " last query: " + a + " cost: " + (System.currentTimeMillis() - start));
-          sessionPool.closeResultSet(dataSet);
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-
+    for (long time = 0; time < 100; time++) {
+      List<Object> values = new ArrayList<>();
+      values.add(1L);
+      values.add(2L);
+      values.add(3L);
+      session.insertRecord(deviceId, time, measurements, types, values);
     }
   }
 
-  static class ReadRawDataThread implements Runnable {
-    int device;
+  private static void insertStrRecord() throws IoTDBConnectionException, StatementExecutionException {
+    String deviceId = "root.sg1.d1";
+    List<String> measurements = new ArrayList<>();
+    measurements.add("s1");
+    measurements.add("s2");
+    measurements.add("s3");
 
-    ReadRawDataThread(int device) {
-      this.device = device;
-    }
-
-    @Override
-    public void run() {
-      SessionDataSetWrapper dataSet = null;
-
-      Random random = new Random();
-      long time = 86400000;
-      try {
-        while (true) {
-          Thread.sleep(5000);
-          long start = System.currentTimeMillis();
-
-          StringBuilder builder = new StringBuilder("select ");
-
-          time += 5000;
-          builder.append("s" + random.nextInt(300000));
-          builder.append(" from root.sg1.d1 where time >= " + (time-86400000) + " and time <= " + time);
-
-          dataSet = sessionPool.executeQueryStatement(builder.toString());
-          int a = 0;
-          while (dataSet.hasNext()) {
-            a++;
-            dataSet.next();
-          }
-          System.out.println(Thread.currentThread().getName() + " raw data query: " + a + " cost: " + (System.currentTimeMillis() - start));
-          sessionPool.closeResultSet(dataSet);
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-
+    for (long time = 0; time < 10; time++) {
+      List<String> values = new ArrayList<>();
+      values.add("1");
+      values.add("2");
+      values.add("3");
+      session.insertRecord(deviceId, time, measurements, values);
     }
   }
 
-  static class ReadGroupByThread implements Runnable {
-    int device;
+  private static void insertRecordInObject()
+      throws IoTDBConnectionException, StatementExecutionException {
+    String deviceId = "root.sg1.d1";
+    List<String> measurements = new ArrayList<>();
+    List<TSDataType> types = new ArrayList<>();
+    measurements.add("s1");
+    measurements.add("s2");
+    measurements.add("s3");
+    types.add(TSDataType.INT64);
+    types.add(TSDataType.INT64);
+    types.add(TSDataType.INT64);
 
-    ReadGroupByThread(int device) {
-      this.device = device;
+    for (long time = 0; time < 100; time++) {
+      session.insertRecord(deviceId, time, measurements, types, 1L, 1L, 1L);
+    }
+  }
+
+  private static void insertRecords() throws IoTDBConnectionException, BatchExecutionException {
+    String deviceId = "root.sg1.d1";
+    List<String> measurements = new ArrayList<>();
+    measurements.add("s1");
+    measurements.add("s2");
+    measurements.add("s3");
+    List<String> deviceIds = new ArrayList<>();
+    List<List<String>> measurementsList = new ArrayList<>();
+    List<List<Object>> valuesList = new ArrayList<>();
+    List<Long> timestamps = new ArrayList<>();
+    List<List<TSDataType>> typesList = new ArrayList<>();
+
+    for (long time = 0; time < 500; time++) {
+      List<Object> values = new ArrayList<>();
+      List<TSDataType> types = new ArrayList<>();
+      values.add(1L);
+      values.add(2L);
+      values.add(3L);
+      types.add(TSDataType.INT64);
+      types.add(TSDataType.INT64);
+      types.add(TSDataType.INT64);
+
+      deviceIds.add(deviceId);
+      measurementsList.add(measurements);
+      valuesList.add(values);
+      typesList.add(types);
+      timestamps.add(time);
+      if (time != 0 && time % 100 == 0) {
+        session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
+        deviceIds.clear();
+        measurementsList.clear();
+        valuesList.clear();
+        timestamps.clear();
+      }
     }
 
-    @Override
-    public void run() {
-      SessionDataSetWrapper dataSet = null;
+    session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
+  }
+  /**
+   * insert the data of a device. For each timestamp, the number of measurements is the same.
+   *
+   * a Tablet example:
+   *
+   *      device1
+   * time s1, s2, s3
+   * 1,   1,  1,  1
+   * 2,   2,  2,  2
+   * 3,   3,  3,  3
+   *
+   * Users need to control the count of Tablet and write a batch when it reaches the maxBatchSize
+   */
+  private static void insertTablet() throws IoTDBConnectionException, BatchExecutionException {
+    // The schema of sensors of one device
+    List<MeasurementSchema> schemaList = new ArrayList<>();
+    schemaList.add(new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.RLE));
+    schemaList.add(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.RLE));
+    schemaList.add(new MeasurementSchema("s3", TSDataType.INT64, TSEncoding.RLE));
 
-      Random random = new Random();
-      long time = 86400000;
-      try {
-        while (true) {
-          Thread.sleep(5000);
-          long start = System.currentTimeMillis();
+    Tablet tablet = new Tablet("root.sg1.d1", schemaList, 100);
 
-          time += 5000;
+    long[] timestamps = tablet.timestamps;
+    Object[] values = tablet.values;
 
-          StringBuilder builder = new StringBuilder("select ");
+    for (long time = 0; time < 100; time++) {
+      int row = tablet.rowSize++;
+      timestamps[row] = time;
+      for (int i = 0; i < 3; i++) {
+        long[] sensor = (long[]) values[i];
+        sensor[row] = i;
+      }
+      if (tablet.rowSize == tablet.getMaxRowNumber()) {
+        session.insertTablet(tablet, true);
+        tablet.reset();
+      }
+    }
 
-          builder.append("last_value(s" + random.nextInt(300000) + ")");
-          builder.append(" from root.sg1.d1 group by ([" + (time-86400000) + "," + time + "), 5m) fill(int64[PREVIOUSUNTILLAST])");
+    if (tablet.rowSize != 0) {
+      session.insertTablet(tablet);
+      tablet.reset();
+    }
+  }
 
-          dataSet = sessionPool.executeQueryStatement(builder.toString());
+  private static void insertTablets() throws IoTDBConnectionException, BatchExecutionException {
+    // The schema of sensors of one device
+    List<MeasurementSchema> schemaList = new ArrayList<>();
+    schemaList.add(new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.RLE));
+    schemaList.add(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.RLE));
+    schemaList.add(new MeasurementSchema("s3", TSDataType.INT64, TSEncoding.RLE));
 
-          int a = 0;
-          while (dataSet.hasNext()) {
-            a++;
-            dataSet.next();
-          }
-          System.out.println(Thread.currentThread().getName() + " down sampling query:  " + a + " cost: " + (System.currentTimeMillis() - start));
-          sessionPool.closeResultSet(dataSet);
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
+    Tablet tablet1 = new Tablet("root.sg1.d1", schemaList, 100);
+    Tablet tablet2 = new Tablet("root.sg1.d2", schemaList, 100);
+    Tablet tablet3 = new Tablet("root.sg1.d3", schemaList, 100);
+
+    Map<String, Tablet> tabletMap = new HashMap<>();
+    tabletMap.put("root.sg1.d1", tablet1);
+    tabletMap.put("root.sg1.d2", tablet2);
+    tabletMap.put("root.sg1.d3", tablet3);
+
+    long[] timestamps1 = tablet1.timestamps;
+    Object[] values1 = tablet1.values;
+    long[] timestamps2 = tablet2.timestamps;
+    Object[] values2 = tablet2.values;
+    long[] timestamps3 = tablet3.timestamps;
+    Object[] values3 = tablet3.values;
+
+    for (long time = 0; time < 100; time++) {
+      int row1 = tablet1.rowSize++;
+      int row2 = tablet2.rowSize++;
+      int row3 = tablet3.rowSize++;
+      timestamps1[row1] = time;
+      timestamps2[row2] = time;
+      timestamps3[row3] = time;
+      for (int i = 0; i < 3; i++) {
+        long[] sensor1 = (long[]) values1[i];
+        sensor1[row1] = i;
+        long[] sensor2 = (long[]) values2[i];
+        sensor2[row2] = i;
+        long[] sensor3 = (long[]) values3[i];
+        sensor3[row3] = i;
+      }
+      if (tablet1.rowSize == tablet1.getMaxRowNumber()) {
+        session.insertTablets(tabletMap, true);
+
+        tablet1.reset();
+        tablet2.reset();
+        tablet3.reset();
+      }
+    }
+
+    if (tablet1.rowSize != 0) {
+      session.insertTablets(tabletMap, true);
+      tablet1.reset();
+      tablet2.reset();
+      tablet3.reset();
+    }
+  }
+
+  private static void deleteData() throws IoTDBConnectionException, StatementExecutionException {
+    String path = "root.sg1.d1.s1";
+    long deleteTime = 99;
+    session.deleteData(path, deleteTime);
+  }
+
+  private static void deleteTimeseries()
+      throws IoTDBConnectionException, StatementExecutionException {
+    List<String> paths = new ArrayList<>();
+    paths.add("root.sg1.d1.s1");
+    paths.add("root.sg1.d1.s2");
+    paths.add("root.sg1.d1.s3");
+    session.deleteTimeseries(paths);
+  }
+
+  private static void query() throws IoTDBConnectionException, StatementExecutionException {
+    SessionDataSet dataSet;
+    dataSet = session.executeQueryStatement("select * from root.sg1.d1");
+    System.out.println(dataSet.getColumnNames());
+    dataSet.setFetchSize(1024); // default is 512
+    while (dataSet.hasNext()) {
+      System.out.println(dataSet.next());
+    }
+
+    dataSet.closeOperationHandle();
+  }
+
+  private static void queryByIterator()
+      throws IoTDBConnectionException, StatementExecutionException {
+    SessionDataSet dataSet;
+    dataSet = session.executeQueryStatement("select * from root.sg1.d1");
+    DataIterator iterator = dataSet.iterator();
+    System.out.println(dataSet.getColumnNames());
+    dataSet.setFetchSize(1024); // default is 512
+    while (iterator.next()) {
+      StringBuilder builder = new StringBuilder();
+      // get time
+      builder.append(iterator.getLong(1)).append(",");
+      // get second column
+      if (!iterator.isNull(2)) {
+        builder.append(iterator.getLong(2)).append(",");
+      } else {
+        builder.append("null").append(",");
       }
 
+      // get third column
+      if (!iterator.isNull("root.sg1.d1.s2")) {
+        builder.append(iterator.getLong("root.sg1.d1.s2")).append(",");
+      } else {
+        builder.append("null").append(",");
+      }
+
+      // get forth column
+      if (!iterator.isNull(4)) {
+        builder.append(iterator.getLong(4)).append(",");
+      } else {
+        builder.append("null").append(",");
+      }
+
+      // get fifth column
+      if (!iterator.isNull("root.sg1.d1.s4")) {
+        builder.append(iterator.getObject("root.sg1.d1.s4"));
+      } else {
+        builder.append("null");
+      }
+
+      System.out.println(builder.toString());
     }
+
+    dataSet.closeOperationHandle();
+  }
+
+  private static void nonQuery() throws IoTDBConnectionException, StatementExecutionException {
+    session.executeNonQueryStatement("insert into root.sg1.d1(timestamp,s1) values(200, 1);");
   }
 }

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -19,17 +19,14 @@
 package org.apache.iotdb;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Random;
 import org.apache.iotdb.rpc.BatchExecutionException;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
-import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.session.Session;
-import org.apache.iotdb.session.SessionDataSet;
-import org.apache.iotdb.session.SessionDataSet.DataIterator;
-import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
+import org.apache.iotdb.session.pool.SessionDataSetWrapper;
+import org.apache.iotdb.session.pool.SessionPool;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.write.record.Tablet;
@@ -37,365 +34,274 @@ import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 public class SessionExample {
 
-  private static Session session;
+  static SessionPool sessionPool = new SessionPool("127.0.0.1", 6667, "root", "root", 10);
 
-  public static void main(String[] args)
-      throws IoTDBConnectionException, StatementExecutionException, BatchExecutionException {
-    session = new Session("127.0.0.1", 6667, "root", "root");
-    session.open(false);
+  public static void main(String[] args) {
 
-    try {
-      session.setStorageGroup("root.sg1");
-    } catch (StatementExecutionException e) {
-      if (e.getStatusCode() != TSStatusCode.PATH_ALREADY_EXIST_ERROR.getStatusCode())
-        throw e;
+    for (int i = 0; i < 6; i++) {
+      new Thread(new WriteThread(1)).start();
     }
 
-    createTimeseries();
-    createMultiTimeseries();
-    insertRecord();
-    insertTablet();
-    insertTablets();
-    insertRecords();
-    nonQuery();
-    query();
-    queryByIterator();
-    deleteData();
-    deleteTimeseries();
-    session.close();
+//    try {
+//      Thread.sleep(10000);
+//    } catch (InterruptedException e) {
+//      e.printStackTrace();
+//    }
+//
+//    for (int i = 0; i < 6; i++) {
+//      new Thread(new ReadLastThread(i)).start();
+//      new Thread(new ReadRawDataThread(i)).start();
+//      new Thread(new ReadGroupByThread(i)).start();
+//    }
+//
+//    try {
+//      Thread.sleep(10000);
+//    } catch (InterruptedException e) {
+//      e.printStackTrace();
+//    }
+//
+//    new Thread(new WriteHistThread(1)).start();
+
   }
 
-  private static void createTimeseries()
-      throws IoTDBConnectionException, StatementExecutionException {
+  static class WriteThread implements Runnable{
+    int device;
 
-    if (!session.checkTimeseriesExists("root.sg1.d1.s1")) {
-      session.createTimeseries("root.sg1.d1.s1", TSDataType.INT64, TSEncoding.RLE,
-          CompressionType.SNAPPY);
-    }
-    if (!session.checkTimeseriesExists("root.sg1.d1.s2")) {
-      session.createTimeseries("root.sg1.d1.s2", TSDataType.INT64, TSEncoding.RLE,
-          CompressionType.SNAPPY);
-    }
-    if (!session.checkTimeseriesExists("root.sg1.d1.s3")) {
-      session.createTimeseries("root.sg1.d1.s3", TSDataType.INT64, TSEncoding.RLE,
-          CompressionType.SNAPPY);
+    WriteThread(int device) {
+      this.device = device;
     }
 
-    // create timeseries with tags and attributes
-    if (!session.checkTimeseriesExists("root.sg1.d1.s4")) {
-      Map<String, String> tags = new HashMap<>();
-      tags.put("tag1", "v1");
-      Map<String, String> attributes = new HashMap<>();
-      tags.put("description", "v1");
-      session.createTimeseries("root.sg1.d1.s4", TSDataType.INT64, TSEncoding.RLE,
-          CompressionType.SNAPPY, null, tags, attributes, "temperature");
-    }
-  }
+    @Override
+    public void run() {
+      Session session = new Session("127.0.0.1", 6667, "root", "root");
+      try {
+        session.open();
+      } catch (IoTDBConnectionException e) {
+        e.printStackTrace();
+      }
+      long time = 1;
+      Random random = new Random();
+      while (true) {
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+        long start = System.currentTimeMillis();
 
-  private static void createMultiTimeseries()
-      throws IoTDBConnectionException, BatchExecutionException, StatementExecutionException {
+        time += 100;
+        String deviceId = "root.sg1.d" + time;
+        List<String> measurements = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+          measurements.add("s" + (time + i));
+        }
 
-    if (!session.checkTimeseriesExists("root.sg1.d2.s1") && !session
-        .checkTimeseriesExists("root.sg1.d2.s2")) {
-      List<String> paths = new ArrayList<>();
-      paths.add("root.sg1.d2.s1");
-      paths.add("root.sg1.d2.s2");
-      List<TSDataType> tsDataTypes = new ArrayList<>();
-      tsDataTypes.add(TSDataType.INT64);
-      tsDataTypes.add(TSDataType.INT64);
-      List<TSEncoding> tsEncodings = new ArrayList<>();
-      tsEncodings.add(TSEncoding.RLE);
-      tsEncodings.add(TSEncoding.RLE);
-      List<CompressionType> compressionTypes = new ArrayList<>();
-      compressionTypes.add(CompressionType.SNAPPY);
-      compressionTypes.add(CompressionType.SNAPPY);
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+          values.add(random.nextInt() + "");
+        }
 
-      List<Map<String, String>> tagsList = new ArrayList<>();
-      Map<String, String> tags = new HashMap<>();
-      tags.put("unit", "kg");
-      tagsList.add(tags);
-      tagsList.add(tags);
-
-      List<Map<String, String>> attributesList = new ArrayList<>();
-      Map<String, String> attributes = new HashMap<>();
-      attributes.put("minValue", "1");
-      attributes.put("maxValue", "100");
-      attributesList.add(attributes);
-      attributesList.add(attributes);
-
-      List<String> alias = new ArrayList<>();
-      alias.add("weight1");
-      alias.add("weight2");
-
-      session
-          .createMultiTimeseries(paths, tsDataTypes, tsEncodings, compressionTypes, null, tagsList,
-              attributesList, alias);
-    }
-  }
-
-  private static void insertRecord() throws IoTDBConnectionException, StatementExecutionException {
-    String deviceId = "root.sg1.d1";
-    List<String> measurements = new ArrayList<>();
-    List<TSDataType> types = new ArrayList<>();
-    measurements.add("s1");
-    measurements.add("s2");
-    measurements.add("s3");
-    types.add(TSDataType.INT64);
-    types.add(TSDataType.INT64);
-    types.add(TSDataType.INT64);
-
-    for (long time = 0; time < 100; time++) {
-      List<Object> values = new ArrayList<>();
-      values.add(1L);
-      values.add(2L);
-      values.add(3L);
-      session.insertRecord(deviceId, time, measurements, types, values);
-    }
-  }
-
-  private static void insertStrRecord() throws IoTDBConnectionException, StatementExecutionException {
-    String deviceId = "root.sg1.d1";
-    List<String> measurements = new ArrayList<>();
-    measurements.add("s1");
-    measurements.add("s2");
-    measurements.add("s3");
-
-    for (long time = 0; time < 10; time++) {
-      List<String> values = new ArrayList<>();
-      values.add("1");
-      values.add("2");
-      values.add("3");
-      session.insertRecord(deviceId, time, measurements, values);
-    }
-  }
-
-  private static void insertRecordInObject()
-      throws IoTDBConnectionException, StatementExecutionException {
-    String deviceId = "root.sg1.d1";
-    List<String> measurements = new ArrayList<>();
-    List<TSDataType> types = new ArrayList<>();
-    measurements.add("s1");
-    measurements.add("s2");
-    measurements.add("s3");
-    types.add(TSDataType.INT64);
-    types.add(TSDataType.INT64);
-    types.add(TSDataType.INT64);
-
-    for (long time = 0; time < 100; time++) {
-      session.insertRecord(deviceId, time, measurements, types, 1L, 1L, 1L);
-    }
-  }
-
-  private static void insertRecords() throws IoTDBConnectionException, BatchExecutionException {
-    String deviceId = "root.sg1.d1";
-    List<String> measurements = new ArrayList<>();
-    measurements.add("s1");
-    measurements.add("s2");
-    measurements.add("s3");
-    List<String> deviceIds = new ArrayList<>();
-    List<List<String>> measurementsList = new ArrayList<>();
-    List<List<Object>> valuesList = new ArrayList<>();
-    List<Long> timestamps = new ArrayList<>();
-    List<List<TSDataType>> typesList = new ArrayList<>();
-
-    for (long time = 0; time < 500; time++) {
-      List<Object> values = new ArrayList<>();
-      List<TSDataType> types = new ArrayList<>();
-      values.add(1L);
-      values.add(2L);
-      values.add(3L);
-      types.add(TSDataType.INT64);
-      types.add(TSDataType.INT64);
-      types.add(TSDataType.INT64);
-
-      deviceIds.add(deviceId);
-      measurementsList.add(measurements);
-      valuesList.add(values);
-      typesList.add(types);
-      timestamps.add(time);
-      if (time != 0 && time % 100 == 0) {
-        session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
-        deviceIds.clear();
-        measurementsList.clear();
-        valuesList.clear();
-        timestamps.clear();
+        try {
+          session.insertRecord(deviceId, time, measurements, values);
+        } catch (IoTDBConnectionException | StatementExecutionException e) {
+          e.printStackTrace();
+        }
+        System.out.println(
+            Thread.currentThread().getName() + " write 1 cost: " + (System.currentTimeMillis() - start));
       }
     }
-
-    session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
-  }
-  /**
-   * insert the data of a device. For each timestamp, the number of measurements is the same.
-   *
-   * a Tablet example:
-   *
-   *      device1
-   * time s1, s2, s3
-   * 1,   1,  1,  1
-   * 2,   2,  2,  2
-   * 3,   3,  3,  3
-   *
-   * Users need to control the count of Tablet and write a batch when it reaches the maxBatchSize
-   */
-  private static void insertTablet() throws IoTDBConnectionException, BatchExecutionException {
-    // The schema of sensors of one device
-    List<MeasurementSchema> schemaList = new ArrayList<>();
-    schemaList.add(new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.RLE));
-    schemaList.add(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.RLE));
-    schemaList.add(new MeasurementSchema("s3", TSDataType.INT64, TSEncoding.RLE));
-
-    Tablet tablet = new Tablet("root.sg1.d1", schemaList, 100);
-
-    long[] timestamps = tablet.timestamps;
-    Object[] values = tablet.values;
-
-    for (long time = 0; time < 100; time++) {
-      int row = tablet.rowSize++;
-      timestamps[row] = time;
-      for (int i = 0; i < 3; i++) {
-        long[] sensor = (long[]) values[i];
-        sensor[row] = i;
-      }
-      if (tablet.rowSize == tablet.getMaxRowNumber()) {
-        session.insertTablet(tablet, true);
-        tablet.reset();
-      }
-    }
-
-    if (tablet.rowSize != 0) {
-      session.insertTablet(tablet);
-      tablet.reset();
-    }
   }
 
-  private static void insertTablets() throws IoTDBConnectionException, BatchExecutionException {
-    // The schema of sensors of one device
-    List<MeasurementSchema> schemaList = new ArrayList<>();
-    schemaList.add(new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.RLE));
-    schemaList.add(new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.RLE));
-    schemaList.add(new MeasurementSchema("s3", TSDataType.INT64, TSEncoding.RLE));
+  static class WriteHistThread implements Runnable{
+    int device;
 
-    Tablet tablet1 = new Tablet("root.sg1.d1", schemaList, 100);
-    Tablet tablet2 = new Tablet("root.sg1.d2", schemaList, 100);
-    Tablet tablet3 = new Tablet("root.sg1.d3", schemaList, 100);
-
-    Map<String, Tablet> tabletMap = new HashMap<>();
-    tabletMap.put("root.sg1.d1", tablet1);
-    tabletMap.put("root.sg1.d2", tablet2);
-    tabletMap.put("root.sg1.d3", tablet3);
-
-    long[] timestamps1 = tablet1.timestamps;
-    Object[] values1 = tablet1.values;
-    long[] timestamps2 = tablet2.timestamps;
-    Object[] values2 = tablet2.values;
-    long[] timestamps3 = tablet3.timestamps;
-    Object[] values3 = tablet3.values;
-
-    for (long time = 0; time < 100; time++) {
-      int row1 = tablet1.rowSize++;
-      int row2 = tablet2.rowSize++;
-      int row3 = tablet3.rowSize++;
-      timestamps1[row1] = time;
-      timestamps2[row2] = time;
-      timestamps3[row3] = time;
-      for (int i = 0; i < 3; i++) {
-        long[] sensor1 = (long[]) values1[i];
-        sensor1[row1] = i;
-        long[] sensor2 = (long[]) values2[i];
-        sensor2[row2] = i;
-        long[] sensor3 = (long[]) values3[i];
-        sensor3[row3] = i;
-      }
-      if (tablet1.rowSize == tablet1.getMaxRowNumber()) {
-        session.insertTablets(tabletMap, true);
-
-        tablet1.reset();
-        tablet2.reset();
-        tablet3.reset();
-      }
+    WriteHistThread(int device) {
+      this.device = device;
     }
 
-    if (tablet1.rowSize != 0) {
-      session.insertTablets(tabletMap, true);
-      tablet1.reset();
-      tablet2.reset();
-      tablet3.reset();
+    @Override
+    public void run() {
+      long time = 86400000000L;
+      Random random = new Random();
+      while (true) {
+        try {
+          Thread.sleep(5000);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+        long start = System.currentTimeMillis();
+
+        int index = random.nextInt(250000);
+
+        List<MeasurementSchema> schemaList = new ArrayList<>();
+        schemaList.add(new MeasurementSchema("s" + index, TSDataType.FLOAT, TSEncoding.RLE));
+        schemaList.add(new MeasurementSchema("s" + (index+1), TSDataType.FLOAT, TSEncoding.RLE));
+        schemaList.add(new MeasurementSchema("s" + (index+2), TSDataType.FLOAT, TSEncoding.RLE));
+        schemaList.add(new MeasurementSchema("s" + (index+3), TSDataType.FLOAT, TSEncoding.RLE));
+        schemaList.add(new MeasurementSchema("s" + (index+4), TSDataType.FLOAT, TSEncoding.RLE));
+        schemaList.add(new MeasurementSchema("s" + (index+5), TSDataType.FLOAT, TSEncoding.RLE));
+        schemaList.add(new MeasurementSchema("s" + (index+6), TSDataType.FLOAT, TSEncoding.RLE));
+        schemaList.add(new MeasurementSchema("s" + (index+7), TSDataType.FLOAT, TSEncoding.RLE));
+        schemaList.add(new MeasurementSchema("s" + (index+8), TSDataType.FLOAT, TSEncoding.RLE));
+        schemaList.add(new MeasurementSchema("s" + (index+9), TSDataType.FLOAT, TSEncoding.RLE));
+
+
+        Tablet tablet = new Tablet("root.sg1.d1", schemaList, 50000);
+
+        long[] timestamps = tablet.timestamps;
+        Object[] values = tablet.values;
+
+        for (int num = 0; num < 50000; num++) {
+          int row = tablet.rowSize++;
+          timestamps[row] = time;
+          time += 5000;
+          for (int i = 0; i < 10; i++) {
+            float[] sensor = (float[]) values[i];
+            sensor[row] = random.nextFloat();
+          }
+          if (tablet.rowSize == tablet.getMaxRowNumber()) {
+            try {
+              sessionPool.insertTablet(tablet, true);
+            } catch (IoTDBConnectionException | BatchExecutionException e) {
+              e.printStackTrace();
+            }
+            tablet.reset();
+          }
+        }
+
+        if (tablet.rowSize != 0) {
+          try {
+            sessionPool.insertTablet(tablet);
+          } catch (IoTDBConnectionException | BatchExecutionException e) {
+            e.printStackTrace();
+          }
+          tablet.reset();
+        }
+        System.out.println(
+            Thread.currentThread().getName() + " write 500000 future point cost: " + (System.currentTimeMillis() - start) + "to s" + index);
+      }
     }
   }
 
-  private static void deleteData() throws IoTDBConnectionException, StatementExecutionException {
-    String path = "root.sg1.d1.s1";
-    long deleteTime = 99;
-    session.deleteData(path, deleteTime);
-  }
+  static class ReadLastThread implements Runnable {
+    int device;
 
-  private static void deleteTimeseries()
-      throws IoTDBConnectionException, StatementExecutionException {
-    List<String> paths = new ArrayList<>();
-    paths.add("root.sg1.d1.s1");
-    paths.add("root.sg1.d1.s2");
-    paths.add("root.sg1.d1.s3");
-    session.deleteTimeseries(paths);
-  }
-
-  private static void query() throws IoTDBConnectionException, StatementExecutionException {
-    SessionDataSet dataSet;
-    dataSet = session.executeQueryStatement("select * from root.sg1.d1");
-    System.out.println(dataSet.getColumnNames());
-    dataSet.setFetchSize(1024); // default is 512
-    while (dataSet.hasNext()) {
-      System.out.println(dataSet.next());
+    ReadLastThread(int device) {
+      this.device = device;
     }
 
-    dataSet.closeOperationHandle();
+    @Override
+    public void run() {
+      SessionDataSetWrapper dataSet = null;
+
+      try {
+        while (true) {
+          Thread.sleep(5000);
+          long start = System.currentTimeMillis();
+
+          StringBuilder builder = new StringBuilder("select last ");
+          for (int c = 50000*device; c < 50000*device + 49999; c++) {
+            builder.append("s").append(c).append(",");
+          }
+
+          builder.append("s" + ((device+1)*50000-1));
+          builder.append(" from root.sg1.d1");
+
+          dataSet = sessionPool.executeQueryStatement(builder.toString());
+          int a = 0;
+          while (dataSet.hasNext()) {
+            a++;
+            dataSet.next();
+          }
+          System.out.println(Thread.currentThread().getName() + " last query: " + a + " cost: " + (System.currentTimeMillis() - start));
+          sessionPool.closeResultSet(dataSet);
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+
+    }
   }
 
-  private static void queryByIterator()
-      throws IoTDBConnectionException, StatementExecutionException {
-    SessionDataSet dataSet;
-    dataSet = session.executeQueryStatement("select * from root.sg1.d1");
-    DataIterator iterator = dataSet.iterator();
-    System.out.println(dataSet.getColumnNames());
-    dataSet.setFetchSize(1024); // default is 512
-    while (iterator.next()) {
-      StringBuilder builder = new StringBuilder();
-      // get time
-      builder.append(iterator.getLong(1)).append(",");
-      // get second column
-      if (!iterator.isNull(2)) {
-        builder.append(iterator.getLong(2)).append(",");
-      } else {
-        builder.append("null").append(",");
-      }
+  static class ReadRawDataThread implements Runnable {
+    int device;
 
-      // get third column
-      if (!iterator.isNull("root.sg1.d1.s2")) {
-        builder.append(iterator.getLong("root.sg1.d1.s2")).append(",");
-      } else {
-        builder.append("null").append(",");
-      }
-
-      // get forth column
-      if (!iterator.isNull(4)) {
-        builder.append(iterator.getLong(4)).append(",");
-      } else {
-        builder.append("null").append(",");
-      }
-
-      // get fifth column
-      if (!iterator.isNull("root.sg1.d1.s4")) {
-        builder.append(iterator.getObject("root.sg1.d1.s4"));
-      } else {
-        builder.append("null");
-      }
-
-      System.out.println(builder.toString());
+    ReadRawDataThread(int device) {
+      this.device = device;
     }
 
-    dataSet.closeOperationHandle();
+    @Override
+    public void run() {
+      SessionDataSetWrapper dataSet = null;
+
+      Random random = new Random();
+      long time = 86400000;
+      try {
+        while (true) {
+          Thread.sleep(5000);
+          long start = System.currentTimeMillis();
+
+          StringBuilder builder = new StringBuilder("select ");
+
+          time += 5000;
+          builder.append("s" + random.nextInt(300000));
+          builder.append(" from root.sg1.d1 where time >= " + (time-86400000) + " and time <= " + time);
+
+          dataSet = sessionPool.executeQueryStatement(builder.toString());
+          int a = 0;
+          while (dataSet.hasNext()) {
+            a++;
+            dataSet.next();
+          }
+          System.out.println(Thread.currentThread().getName() + " raw data query: " + a + " cost: " + (System.currentTimeMillis() - start));
+          sessionPool.closeResultSet(dataSet);
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+
+    }
   }
 
-  private static void nonQuery() throws IoTDBConnectionException, StatementExecutionException {
-    session.executeNonQueryStatement("insert into root.sg1.d1(timestamp,s1) values(200, 1);");
+  static class ReadGroupByThread implements Runnable {
+    int device;
+
+    ReadGroupByThread(int device) {
+      this.device = device;
+    }
+
+    @Override
+    public void run() {
+      SessionDataSetWrapper dataSet = null;
+
+      Random random = new Random();
+      long time = 86400000;
+      try {
+        while (true) {
+          Thread.sleep(5000);
+          long start = System.currentTimeMillis();
+
+          time += 5000;
+
+          StringBuilder builder = new StringBuilder("select ");
+
+          builder.append("last_value(s" + random.nextInt(300000) + ")");
+          builder.append(" from root.sg1.d1 group by ([" + (time-86400000) + "," + time + "), 5m) fill(int64[PREVIOUSUNTILLAST])");
+
+          dataSet = sessionPool.executeQueryStatement(builder.toString());
+
+          int a = 0;
+          while (dataSet.hasNext()) {
+            a++;
+            dataSet.next();
+          }
+          System.out.println(Thread.currentThread().getName() + " down sampling query:  " + a + " cost: " + (System.currentTimeMillis() - start));
+          sessionPool.closeResultSet(dataSet);
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -100,7 +100,7 @@ public abstract class AbstractMemTable implements IMemTable {
   public void insert(InsertPlan insertPlan) {
     for (int i = 0; i < insertPlan.getValues().length; i++) {
 
-      if (insertPlan.getSchemas()[i] == null) {
+      if (insertPlan.getValues()[i] == null) {
         continue;
       }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -768,7 +768,8 @@ public class StorageGroupProcessor {
       String[] measurementList = plan.getMeasurements();
       for (int i = 0; i < measurementList.length; i++) {
         // Update cached last value with high priority
-        ((LeafMNode) manager.getChild(node, measurementList[i], plan.getDeviceId()))
+        ((LeafMNode) manager.getChild(node, measurementList[i],
+            plan.getDeviceId() + " in StorageGroupProcessor-771"))
             .updateCachedLast(plan.composeLastTimeValuePair(i), true, latestFlushedTime);
       }
     } catch (MetadataException e) {
@@ -823,7 +824,7 @@ public class StorageGroupProcessor {
           continue;
         }
         // Update cached last value with high priority
-        ((LeafMNode) manager.getChild(node, measurementList[i], plan.getDeviceId()))
+        ((LeafMNode) manager.getChild(node, measurementList[i], plan.getDeviceId()+ " in StorageGroupProcessor-826"))
             .updateCachedLast(plan.composeTimeValuePair(i), true, latestFlushedTime);
       }
     } catch (MetadataException e) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -819,7 +819,7 @@ public class StorageGroupProcessor {
       node = manager.getDeviceNodeWithAutoCreateAndReadLock(plan.getDeviceId());
       String[] measurementList = plan.getMeasurements();
       for (int i = 0; i < measurementList.length; i++) {
-        if (plan.getSchemas()[i] == null) {
+        if (plan.getValues()[i] == null) {
           continue;
         }
         // Update cached last value with high priority

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -768,8 +768,7 @@ public class StorageGroupProcessor {
       String[] measurementList = plan.getMeasurements();
       for (int i = 0; i < measurementList.length; i++) {
         // Update cached last value with high priority
-        ((LeafMNode) manager.getChild(node, measurementList[i],
-            plan.getDeviceId() + " in StorageGroupProcessor-771"))
+        ((LeafMNode) node.getChild(measurementList[i]))
             .updateCachedLast(plan.composeLastTimeValuePair(i), true, latestFlushedTime);
       }
     } catch (MetadataException e) {
@@ -824,7 +823,7 @@ public class StorageGroupProcessor {
           continue;
         }
         // Update cached last value with high priority
-        ((LeafMNode) manager.getChild(node, measurementList[i], plan.getDeviceId()+ " in StorageGroupProcessor-826"))
+        ((LeafMNode) node.getChild(measurementList[i]))
             .updateCachedLast(plan.composeTimeValuePair(i), true, latestFlushedTime);
       }
     } catch (MetadataException e) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -888,6 +888,9 @@ public class MManager {
             MNode fullNode = getNodeByPath(parent.getFullPath() + IoTDBConstant.PATH_SEPARATOR + child);
             if (fullNode == null) {
               logger.warn("realChild is null, qilepale");
+            } else {
+              logger.warn("got it, origin device {}, child {}, current node {}", parent.getFullPath(), child, fullNode.getFullPath());
+              return fullNode;
             }
           } else {
             logger.warn("current device: == realDevice ? {}", parent.equals(realDevice));

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -868,8 +868,14 @@ public class MManager {
     int tempCount = 0;
     while (childNode == null) {
       tempCount ++;
-      if (tempCount % 10000 == 0) {
-        logger.warn("try to get child {} 10000 times from {}", child, info);
+      try {
+        Thread.sleep(1);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        logger.warn("Current thread is interrupted, ignore");
+      }
+      if (tempCount % 1000 == 0) {
+        logger.warn("try to get child {} for {} times from {}", child, tempCount, info);
       }
       childNode = parent.getChild(child);
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -289,11 +289,7 @@ public class MManager {
         }
         storageGroupName =
             MetaUtils.getStorageGroupNameByLevel(path, config.getDefaultStorageGroupLevel());
-//        try {
-          setStorageGroup(storageGroupName);
-//        } catch (StorageGroupAlreadySetException e1) {
-//          ignore
-//        }
+        setStorageGroup(storageGroupName);
       }
 
       // check memory

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.metadata;
 
 import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.conf.adapter.ActiveTimeSeriesCounter;
 import org.apache.iotdb.db.conf.adapter.IoTDBConfigDynamicAdapter;
@@ -110,21 +111,21 @@ public class MManager {
     writeToLog = false;
 
     int cacheSize = config.getmManagerCacheSize();
-    mNodeCache =
-        new RandomDeleteCache<String, MNode>(cacheSize) {
-
-          @Override
-          public MNode loadObjectByKey(String key) throws CacheException {
-            lock.readLock().lock();
-            try {
-              return mtree.getNodeByPathWithStorageGroupCheck(key);
-            } catch (MetadataException e) {
-              throw new CacheException(e);
-            } finally {
-              lock.readLock().unlock();
-            }
-          }
-        };
+//    mNodeCache =
+//        new RandomDeleteCache<String, MNode>(cacheSize) {
+//
+//          @Override
+//          public MNode loadObjectByKey(String key) throws CacheException {
+//            lock.readLock().lock();
+//            try {
+//              return mtree.getNodeByPathWithStorageGroupCheck(key);
+//            } catch (MetadataException e) {
+//              throw new CacheException(e);
+//            } finally {
+//              lock.readLock().unlock();
+//            }
+//          }
+//        };
   }
 
   public static MManager getInstance() {
@@ -188,7 +189,7 @@ public class MManager {
     lock.writeLock().lock();
     try {
       this.mtree = new MTree();
-      this.mNodeCache.clear();
+//      this.mNodeCache.clear();
       this.tagIndex.clear();
       this.seriesNumberInStorageGroups.clear();
       this.maxSeriesNumberAmongStorageGroup = 0;
@@ -288,7 +289,11 @@ public class MManager {
         }
         storageGroupName =
             MetaUtils.getStorageGroupNameByLevel(path, config.getDefaultStorageGroupLevel());
-        setStorageGroup(storageGroupName);
+//        try {
+          setStorageGroup(storageGroupName);
+//        } catch (StorageGroupAlreadySetException e1) {
+//          ignore
+//        }
       }
 
       // check memory
@@ -374,7 +379,7 @@ public class MManager {
         }
       }
 
-      mNodeCache.clear();
+//      mNodeCache.clear();
     }
     try {
       Set<String> emptyStorageGroups = new HashSet<>();
@@ -440,7 +445,7 @@ public class MManager {
       String storageGroupName = pair.left;
 
       // TODO: delete the path node and all its ancestors
-      mNodeCache.clear();
+//      mNodeCache.clear();
       try {
         IoTDBConfigDynamicAdapter.getInstance().addOrDeleteTimeSeries(-1);
       } catch (ConfigAdjusterException e) {
@@ -508,7 +513,7 @@ public class MManager {
         for (LeafMNode leafMNode : leafMNodes) {
           removeFromTagInvertedIndex(leafMNode);
         }
-        mNodeCache.clear();
+//        mNodeCache.clear();
 
         if (config.isEnableParameterAdapter()) {
           IoTDBConfigDynamicAdapter.getInstance().addOrDeleteStorageGroup(-1);
@@ -875,6 +880,23 @@ public class MManager {
         logger.warn("Current thread is interrupted, ignore");
       }
       if (tempCount % 1000 == 0) {
+        MNode realDevice = null;
+        try {
+          realDevice = getNodeByPath(parent.getFullPath());
+          MNode realChild = realDevice.getChild(child);
+          if (realChild == null) {
+            MNode fullNode = getNodeByPath(parent.getFullPath() + IoTDBConstant.PATH_SEPARATOR + child);
+            if (fullNode == null) {
+              logger.warn("realChild is null, qilepale");
+            }
+          } else {
+            logger.warn("current device: == realDevice ? {}", parent.equals(realDevice));
+            logger.warn("current device {} realDevice {}", parent, realDevice);
+            return realChild;
+          }
+        } catch (MetadataException e) {
+          e.printStackTrace();
+        }
         logger.warn("try to get child {} for {} times from {}", child, tempCount, info);
       }
       childNode = parent.getChild(child);
@@ -908,9 +930,9 @@ public class MManager {
     MNode node = null;
     boolean shouldSetStorageGroup;
     try {
-      node = mNodeCache.get(path);
+      node = mtree.getNodeByPathWithStorageGroupCheck(path);
       return node;
-    } catch (CacheException e) {
+    } catch (MetadataException e) {
       if (!autoCreateSchema) {
         throw new PathNotExistException(path);
       }
@@ -924,9 +946,9 @@ public class MManager {
     lock.writeLock().lock();
     try {
       try {
-        node = mNodeCache.get(path);
+        node = mtree.getNodeByPathWithStorageGroupCheck(path);
         return node;
-      } catch (CacheException e) {
+      } catch (MetadataException e) {
         shouldSetStorageGroup = e.getCause() instanceof StorageGroupNotSetException;
       }
 
@@ -934,11 +956,11 @@ public class MManager {
         String storageGroupName = MetaUtils.getStorageGroupNameByLevel(path, sgLevel);
         setStorageGroup(storageGroupName);
       }
-      node = mtree.getDeviceNodeWithAutoCreating(path);
+      node = mtree.getDeviceNodeWithAutoCreating(path, sgLevel);
       return node;
     } catch (StorageGroupAlreadySetException e) {
       // ignore set storage group concurrently
-      node = mtree.getDeviceNodeWithAutoCreating(path);
+      node = mtree.getNodeByPathWithStorageGroupCheck(path);
       return node;
     } finally {
       if (node != null) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -138,7 +138,7 @@ public class MTree implements Serializable {
    *
    * <p>e.g., get root.sg.d1, get or create all internal nodes and return the node of d1
    */
-  MNode getDeviceNodeWithAutoCreating(String deviceId) throws MetadataException {
+  MNode getDeviceNodeWithAutoCreating(String deviceId, int sgLevel) throws MetadataException {
     String[] nodeNames = MetaUtils.getNodeNames(deviceId);
     if (nodeNames.length <= 1 || !nodeNames[0].equals(root.getName())) {
       throw new IllegalPathException(deviceId);
@@ -146,7 +146,12 @@ public class MTree implements Serializable {
     MNode cur = root;
     for (int i = 1; i < nodeNames.length; i++) {
       if (!cur.hasChild(nodeNames[i])) {
-        cur.addChild(nodeNames[i], new InternalMNode(cur, nodeNames[i]));
+        if (i == sgLevel) {
+          cur.addChild(nodeNames[i], new StorageGroupMNode(cur, nodeNames[i],
+              IoTDBDescriptor.getInstance().getConfig().getDefaultTTL()));
+        } else {
+          cur.addChild(nodeNames[i], new InternalMNode(cur, nodeNames[i]));
+        }
       }
       cur = cur.getChild(nodeNames[i]);
     }
@@ -205,7 +210,7 @@ public class MTree implements Serializable {
     } else {
       StorageGroupMNode storageGroupMNode =
           new StorageGroupMNode(
-              cur, nodeNames[i], path, IoTDBDescriptor.getInstance().getConfig().getDefaultTTL());
+              cur, nodeNames[i], IoTDBDescriptor.getInstance().getConfig().getDefaultTTL());
       cur.addChild(nodeNames[i], storageGroupMNode);
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/InternalMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/InternalMNode.java
@@ -18,10 +18,9 @@
  */
 package org.apache.iotdb.db.metadata.mnode;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.LinkedHashMap;
 import org.apache.iotdb.db.exception.metadata.DeleteFailedException;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -40,8 +39,8 @@ public class InternalMNode extends MNode {
 
   public InternalMNode(MNode parent, String name) {
     super(parent, name);
-    this.children = new ConcurrentHashMap<>();
-    this.aliasChildren = new ConcurrentHashMap<>();
+    this.children = new LinkedHashMap<>();
+    this.aliasChildren = new LinkedHashMap<>();
   }
 
   @Override
@@ -50,7 +49,7 @@ public class InternalMNode extends MNode {
   }
 
   @Override
-  public void addChild(String name, MNode child) {
+  public synchronized void addChild(String name, MNode child) {
     children.put(name, child);
   }
 
@@ -90,7 +89,7 @@ public class InternalMNode extends MNode {
   }
 
   @Override
-  public MNode getChild(String name) {
+  public synchronized MNode getChild(String name) {
     return children.containsKey(name) ? children.get(name) : aliasChildren.get(name);
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/InternalMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/InternalMNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.metadata.mnode;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.iotdb.db.exception.metadata.DeleteFailedException;
 
 import java.util.LinkedHashMap;
@@ -39,8 +40,8 @@ public class InternalMNode extends MNode {
 
   public InternalMNode(MNode parent, String name) {
     super(parent, name);
-    this.children = new LinkedHashMap<>();
-    this.aliasChildren = new LinkedHashMap<>();
+    this.children = new ConcurrentHashMap<>();
+    this.aliasChildren = new ConcurrentHashMap<>();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/LeafMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/LeafMNode.java
@@ -26,8 +26,12 @@ import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import java.util.Collections;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LeafMNode extends MNode {
+
+  private static final Logger logger = LoggerFactory.getLogger(LeafMNode.class);
 
   private static final long serialVersionUID = -1199657856921206435L;
 
@@ -73,7 +77,9 @@ public class LeafMNode extends MNode {
 
   @Override
   public MNode getChild(String name) {
-    return null;
+    logger.warn("current node {} is a LeafMNode, can not get child {}", super.name, name);
+    throw new RuntimeException(
+        String.format("current node %s is a LeafMNode, can not get child %s", super.name, name));
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/StorageGroupMNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/StorageGroupMNode.java
@@ -29,10 +29,10 @@ public class StorageGroupMNode extends InternalMNode {
   private long dataTTL;
 
 
-  public StorageGroupMNode(MNode parent, String name, String fullPath, long dataTTL) {
+  public StorageGroupMNode(MNode parent, String name, long dataTTL) {
     super(parent, name);
     this.dataTTL = dataTTL;
-    this.fullPath = fullPath;
+    this.fullPath = getFullPath();
   }
 
   public long getDataTTL() {

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -890,7 +890,7 @@ public class PlanExecutor implements IPlanExecutor {
 
           schemas[i] = measurementNode.getSchema();
           // reset measurement to common name instead of alias
-          measurementList[i] = measurement;
+          measurementList[i] = measurementNode.getName();
 
           if (!insertPlan.isInferType()) {
             checkType(insertPlan, i, measurementNode.getSchema().getType());

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -886,7 +886,7 @@ public class PlanExecutor implements IPlanExecutor {
             Path path = new Path(deviceId, measurement);
             internalCreateTimeseries(path.toString(), dataType);
           }
-          LeafMNode measurementNode = (LeafMNode) MManager.getInstance().getChild(node, measurement, deviceId);
+          LeafMNode measurementNode = (LeafMNode) MManager.getInstance().getChild(node, measurement, deviceId + " PlanExecutor-889");
 
           schemas[i] = measurementNode.getSchema();
           // reset measurement to common name instead of alias
@@ -1033,7 +1033,8 @@ public class PlanExecutor implements IPlanExecutor {
           TSDataType dataType = dataTypes[i];
           internalCreateTimeseries(path.getFullPath(), dataType);
         }
-        LeafMNode measurementNode = (LeafMNode) MManager.getInstance().getChild(node, measurementList[i], deviceId);
+        LeafMNode measurementNode = (LeafMNode) MManager.getInstance()
+            .getChild(node, measurementList[i], deviceId + " PlanExecutor-1036");
 
         // check data type
         if (measurementNode.getSchema().getType() != insertTabletPlan.getDataTypes()[i]) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
@@ -188,6 +188,7 @@ public class InsertPlan extends PhysicalPlan {
               measurements[i], values[i], types[i]);
           if (IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert()) {
             markMeasurementInsertionFailed(i);
+            schemas[i] = null;
           } else {
             throw e;
           }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
@@ -204,7 +204,6 @@ public class InsertPlan extends PhysicalPlan {
       failedMeasurements = new ArrayList<>();
     }
     failedMeasurements.add(measurements[index]);
-    schemas[index] = null;
     measurements[index] = null;
     types[index] = null;
     values[index] = null;
@@ -279,8 +278,10 @@ public class InsertPlan extends PhysicalPlan {
       }
     }
 
-    for (MeasurementSchema schema : schemas) {
-      schema.serializeTo(stream);
+    for (int i = 0; i < measurements.length; i++) {
+      if (measurements[i] != null) {
+        schemas[i].serializeTo(stream);
+      }
     }
 
     try {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
@@ -224,7 +224,7 @@ public class InsertPlan extends PhysicalPlan {
   }
 
   public void setDeviceId(String deviceId) {
-    this.deviceId = deviceId;
+    this.deviceId = deviceId.trim();
   }
 
   public String[] getMeasurements() {
@@ -278,9 +278,9 @@ public class InsertPlan extends PhysicalPlan {
       }
     }
 
-    for (int i = 0; i < measurements.length; i++) {
-      if (measurements[i] != null) {
-        schemas[i].serializeTo(stream);
+    for (MeasurementSchema schema: schemas) {
+      if (schema != null) {
+        schema.serializeTo(stream);
       }
     }
 

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertTabletPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertTabletPlan.java
@@ -73,18 +73,18 @@ public class InsertTabletPlan extends PhysicalPlan {
 
   public InsertTabletPlan(String deviceId, List<String> measurements) {
     super(false, OperatorType.BATCHINSERT);
-    this.deviceId = deviceId;
+    this.deviceId = deviceId.trim();
     setMeasurements(measurements);
   }
   public InsertTabletPlan(String deviceId, String[] measurements) {
     super(false, OperatorType.BATCHINSERT);
-    this.deviceId = deviceId;
+    this.deviceId = deviceId.trim();
     setMeasurements(measurements);
   }
 
   public InsertTabletPlan(String deviceId, String[] measurements, List<Integer> dataTypes) {
     super(false, OperatorType.BATCHINSERT);
-    this.deviceId = deviceId;
+    this.deviceId = deviceId.trim();
     this.measurements = measurements;
     setDataTypes(dataTypes);
   }

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -1331,6 +1331,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     if (status != null) {
       return status;
     }
+    logger.info("createTimeseries {}", req.getPath());
     return executePlan(plan);
   }
 
@@ -1340,7 +1341,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       logger.info(INFO_NOT_LOGIN, IoTDBConstant.GLOBAL_DB_NAME);
       return RpcUtils.getTSBatchExecuteStatementResp(TSStatusCode.NOT_LOGIN_ERROR);
     }
-
+    logger.info("createMultiTimeseries, first is {}", req.getPaths().get(0));
     List<TSStatus> statusList = new ArrayList<>(req.paths.size());
     for (int i = 0; i < req.paths.size(); i++) {
       CreateTimeSeriesPlan plan = new CreateTimeSeriesPlan(new Path(req.getPaths().get(i)),


### PR DESCRIPTION
(1) In MTree.getDeviceNodeWithAutoCreating(), the StorageGroup node will be created as an InternalMNode, which will cause the following MTree.getNodeByPathWithStorageGroupCheck() always throw StorageGroupNotExistException.

(2) If the measurement name has blank, when we generate new Path, the blank will be trim out. Then we create a path without blank. But in the following check, we will get the child with blank, then it stuck.