### PR TITLE
[IOTDB-695] Accelerate the count timeseries query

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -701,15 +701,15 @@ public class MManager {
   }
 
   /**
-   * To calculate the count of timeseries in the given level for given prefix path.
+   * To calculate the count of nodes in the given level for given prefix path.
    *
    * @param prefixPath a prefix path or a full path, can not contain '*'
    * @param level the level can not be smaller than the level of the prefixPath
    */
-  public int getAllTimeseriesCountInGivenLevel(String prefixPath, int level) throws MetadataException {
+  public int getNodesCountInGivenLevel(String prefixPath, int level) throws MetadataException {
     lock.readLock().lock();
     try {
-      return mtree.getAllTimeseriesCountInGivenLevel(prefixPath, level);
+      return mtree.getNodesCountInGivenLevel(prefixPath, level);
     } finally {
       lock.readLock().unlock();
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -671,8 +671,6 @@ public class MManager {
     lock.readLock().lock();
     try {
       return mtree.getAllTimeseriesName(prefixPath);
-    } catch (MetadataException e) {
-      throw new MetadataException(e);
     } finally {
       lock.readLock().unlock();
     }
@@ -685,8 +683,6 @@ public class MManager {
     lock.readLock().lock();
     try {
       return mtree.getAllTimeseriesPath(prefixPath);
-    } catch (MetadataException e) {
-      throw new MetadataException(e);
     } finally {
       lock.readLock().unlock();
     }
@@ -699,8 +695,21 @@ public class MManager {
     lock.readLock().lock();
     try {
       return mtree.getAllTimeseriesCount(prefixPath);
-    } catch (MetadataException e) {
-      throw new MetadataException(e);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /**
+   * To calculate the count of timeseries in the given level for given prefix path.
+   *
+   * @param prefixPath a prefix path or a full path, can not contain '*'
+   * @param level the level can not be smaller than the level of the prefixPath
+   */
+  public int getAllTimeseriesCountInGivenLevel(String prefixPath, int level) throws MetadataException {
+    lock.readLock().lock();
+    try {
+      return mtree.getAllTimeseriesCountInGivenLevel(prefixPath, level);
     } finally {
       lock.readLock().unlock();
     }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MManager.java
@@ -692,6 +692,20 @@ public class MManager {
     }
   }
 
+  /**
+   * To calculate the count of timeseries for given prefix path.
+   */
+  public int getAllTimeseriesCount(String prefixPath) throws MetadataException {
+    lock.readLock().lock();
+    try {
+      return mtree.getAllTimeseriesCount(prefixPath);
+    } catch (MetadataException e) {
+      throw new MetadataException(e);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
   public List<ShowTimeSeriesResult> getAllTimeseriesSchema(ShowTimeSeriesPlan plan)
       throws MetadataException {
     lock.readLock().lock();

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -564,9 +564,9 @@ public class MTree implements Serializable {
   }
 
   /**
-   * Get the count of timeseries in the given level under the given prefix path.
+   * Get the count of nodes in the given level under the given prefix path.
    */
-  int getAllTimeseriesCountInGivenLevel(String prefixPath, int level) throws MetadataException {
+  int getNodesCountInGivenLevel(String prefixPath, int level) throws MetadataException {
     String[] nodes = MetaUtils.getNodeNames(prefixPath);
     if (nodes.length == 0 || !nodes[0].equals(root.getName())) {
       throw new IllegalPathException(prefixPath);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -60,7 +60,9 @@ import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
-/** The hierarchical struct of the Metadata Tree is implemented in this class. */
+/**
+ * The hierarchical struct of the Metadata Tree is implemented in this class.
+ */
 public class MTree implements Serializable {
 
   private static final long serialVersionUID = -4200394435237291964L;
@@ -79,12 +81,12 @@ public class MTree implements Serializable {
    * Create a timeseries with a full path from root to leaf node Before creating a timeseries, the
    * storage group should be set first, throw exception otherwise
    *
-   * @param path timeseries path
-   * @param dataType data type
-   * @param encoding encoding
+   * @param path       timeseries path
+   * @param dataType   data type
+   * @param encoding   encoding
    * @param compressor compressor
-   * @param props props
-   * @param alias alias of measurement
+   * @param props      props
+   * @param alias      alias of measurement
    */
   LeafMNode createTimeseries(
       String path,
@@ -215,7 +217,9 @@ public class MTree implements Serializable {
     }
   }
 
-  /** Delete a storage group */
+  /**
+   * Delete a storage group
+   */
   List<LeafMNode> deleteStorageGroup(String path) throws MetadataException {
     MNode cur = getNodeByPath(path);
     if (!(cur instanceof StorageGroupMNode)) {
@@ -351,7 +355,9 @@ public class MTree implements Serializable {
     return cur;
   }
 
-  /** Get storage group node, if the give path is not a storage group, throw exception */
+  /**
+   * Get storage group node, if the give path is not a storage group, throw exception
+   */
   StorageGroupMNode getStorageGroupNode(String path) throws MetadataException {
     MNode node = getNodeByPath(path);
     if (node instanceof StorageGroupMNode) {
@@ -361,7 +367,9 @@ public class MTree implements Serializable {
     }
   }
 
-  /** Get device node, if the give path is not a device, throw exception */
+  /**
+   * Get device node, if the give path is not a device, throw exception
+   */
   MNode getDeviceNode(String path) throws MetadataException {
     return getNodeByPath(path);
   }
@@ -451,7 +459,9 @@ public class MTree implements Serializable {
     return res;
   }
 
-  /** Get all storage group MNodes */
+  /**
+   * Get all storage group MNodes
+   */
   List<StorageGroupMNode> getAllStorageGroupNodes() {
     List<StorageGroupMNode> ret = new ArrayList<>();
     Deque<MNode> nodeStack = new ArrayDeque<>();
@@ -488,7 +498,9 @@ public class MTree implements Serializable {
     throw new StorageGroupNotSetException(path);
   }
 
-  /** Check whether the given path contains a storage group */
+  /**
+   * Check whether the given path contains a storage group
+   */
   boolean checkStorageGroupByPath(String path) {
     String[] nodes = MetaUtils.getNodeNames(path);
     MNode cur = root;
@@ -530,7 +542,7 @@ public class MTree implements Serializable {
     List<Path> paths = new ArrayList<>();
     for (String[] p : res) {
       Path path = new Path(p[0]);
-      if (prePath.getMeasurement().equals(p[1])){
+      if (prePath.getMeasurement().equals(p[1])) {
         path.setAlias(p[1]);
       }
       paths.add(path);
@@ -548,7 +560,7 @@ public class MTree implements Serializable {
     if (nodes.length == 0 || !nodes[0].equals(root.getName())) {
       throw new IllegalPathException(prefixPath);
     }
-    return getCount(root, nodes,1, 0);
+    return getCount(root, nodes, 1, 0);
   }
 
   /**
@@ -604,7 +616,7 @@ public class MTree implements Serializable {
     }
     if (node instanceof InternalMNode) {
       for (MNode child : node.getChildren().values()) {
-        cnt = getCountInGivenLevel(child, cnt,targetLevel - 1);
+        cnt = getCountInGivenLevel(child, cnt, targetLevel - 1);
       }
     }
     return cnt;
@@ -717,11 +729,11 @@ public class MTree implements Serializable {
   /**
    * Traverse the MTree to match all child node path in next level
    *
-   * @param node the current traversing node
-   * @param nodes split the prefix path with '.'
-   * @param idx the current index of array nodes
+   * @param node   the current traversing node
+   * @param nodes  split the prefix path with '.'
+   * @param idx    the current index of array nodes
    * @param parent store the node string having traversed
-   * @param res store all matched device names
+   * @param res    store all matched device names
    * @param length expected length of path
    */
   private void findChildNodePathInNextLevel(
@@ -777,11 +789,11 @@ public class MTree implements Serializable {
   /**
    * Traverse the MTree to match all devices with prefix path.
    *
-   * @param node the current traversing node
-   * @param nodes split the prefix path with '.'
-   * @param idx the current index of array nodes
+   * @param node   the current traversing node
+   * @param nodes  split the prefix path with '.'
+   * @param idx    the current index of array nodes
    * @param parent store the node string having traversed
-   * @param res store all matched device names
+   * @param res    store all matched device names
    */
   private void findDevices(MNode node, String[] nodes, int idx, String parent, Set<String> res) {
     String nodeReg = MetaUtils.getNodeRegByIdx(idx, nodes);
@@ -874,7 +886,9 @@ public class MTree implements Serializable {
     return jsonObject;
   }
 
-  /** combine multiple metadata in string format */
+  /**
+   * combine multiple metadata in string format
+   */
   static String combineMetadataInStrings(String[] metadataStrs) {
     JSONObject[] jsonObjects = new JSONObject[metadataStrs.length];
     for (int i = 0; i < jsonObjects.length; i++) {

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -361,7 +361,7 @@ public class PlanExecutor implements IPlanExecutor {
   }
 
   private QueryDataSet processCountNodes(CountPlan countPlan) throws MetadataException {
-    int num = getPathsNumInGivenLevel(countPlan.getPath().toString(), countPlan.getLevel());
+    int num = getNodesNumInGivenLevel(countPlan.getPath().toString(), countPlan.getLevel());
     SingleDataSet singleDataSet =
         new SingleDataSet(
             Collections.singletonList(new Path(COLUMN_COUNT)),
@@ -399,8 +399,8 @@ public class PlanExecutor implements IPlanExecutor {
     return MManager.getInstance().getAllTimeseriesCount(path);
   }
 
-  protected int getPathsNumInGivenLevel(String path, int level) throws MetadataException {
-    return MManager.getInstance().getAllTimeseriesCountInGivenLevel(path, level);
+  protected int getNodesNumInGivenLevel(String path, int level) throws MetadataException {
+    return MManager.getInstance().getNodesCountInGivenLevel(path, level);
   }
 
   protected List<String> getPathsName(String path) throws MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -51,8 +51,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import org.apache.iotdb.db.auth.AuthException;
-import org.apache.iotdb.db.auth.authorizer.IAuthorizer;
 import org.apache.iotdb.db.auth.authorizer.BasicAuthorizer;
+import org.apache.iotdb.db.auth.authorizer.IAuthorizer;
 import org.apache.iotdb.db.auth.entity.PathPrivilege;
 import org.apache.iotdb.db.auth.entity.Role;
 import org.apache.iotdb.db.auth.entity.User;
@@ -386,7 +386,7 @@ public class PlanExecutor implements IPlanExecutor {
       Field field = new Field(TSDataType.TEXT);
       field.setBinaryV(new Binary(columnPath));
       Field field1 = new Field(TSDataType.TEXT);
-      field1.setBinaryV(new Binary(Integer.toString(getPaths(columnPath).size())));
+      field1.setBinaryV(new Binary(Integer.toString(getPathsNum(columnPath))));
       record.addField(field);
       record.addField(field1);
       listDataSet.putRecord(record);
@@ -394,7 +394,11 @@ public class PlanExecutor implements IPlanExecutor {
     return listDataSet;
   }
 
-  protected List<String> getPaths(String path) throws MetadataException {
+  protected int getPathsNum(String path) throws MetadataException {
+    return mManager.getInstance().getAllTimeseriesCount(path);
+  }
+
+  protected List<String> getPathsName(String path) throws MetadataException {
     return MManager.getInstance().getAllTimeseriesName(path);
   }
 
@@ -403,7 +407,7 @@ public class PlanExecutor implements IPlanExecutor {
   }
 
   private QueryDataSet processCountTimeSeries(CountPlan countPlan) throws MetadataException {
-    int num = getPaths(countPlan.getPath().toString()).size();
+    int num = getPathsNum(countPlan.getPath().toString());
     SingleDataSet singleDataSet =
         new SingleDataSet(
             Collections.singletonList(new Path(COLUMN_CHILD_PATHS)),
@@ -675,7 +679,7 @@ public class PlanExecutor implements IPlanExecutor {
     try {
       Set<String> existingPaths = new HashSet<>();
       for (Path p : deletePlan.getPaths()) {
-        existingPaths.addAll(getPaths(p.getFullPath()));
+        existingPaths.addAll(getPathsName(p.getFullPath()));
       }
       if (existingPaths.isEmpty()) {
         throw new QueryProcessException("TimeSeries does not exist and its data cannot be deleted");

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -396,11 +396,11 @@ public class PlanExecutor implements IPlanExecutor {
   }
 
   protected int getPathsNum(String path) throws MetadataException {
-    return mManager.getInstance().getAllTimeseriesCount(path);
+    return MManager.getInstance().getAllTimeseriesCount(path);
   }
 
   protected int getPathsNumInGivenLevel(String path, int level) throws MetadataException {
-    return mManager.getInstance().getAllTimeseriesCountInGivenLevel(path, level);
+    return MManager.getInstance().getAllTimeseriesCountInGivenLevel(path, level);
   }
 
   protected List<String> getPathsName(String path) throws MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -361,8 +361,7 @@ public class PlanExecutor implements IPlanExecutor {
   }
 
   private QueryDataSet processCountNodes(CountPlan countPlan) throws MetadataException {
-    List<String> nodes = getNodesList(countPlan.getPath().toString(), countPlan.getLevel());
-    int num = nodes.size();
+    int num = getPathsNumInGivenLevel(countPlan.getPath().toString(), countPlan.getLevel());
     SingleDataSet singleDataSet =
         new SingleDataSet(
             Collections.singletonList(new Path(COLUMN_COUNT)),
@@ -376,6 +375,7 @@ public class PlanExecutor implements IPlanExecutor {
   }
 
   private QueryDataSet processCountNodeTimeSeries(CountPlan countPlan) throws MetadataException {
+    // get the nodes that need to group by first
     List<String> nodes = getNodesList(countPlan.getPath().toString(), countPlan.getLevel());
     ListDataSet listDataSet =
         new ListDataSet(
@@ -386,6 +386,7 @@ public class PlanExecutor implements IPlanExecutor {
       Field field = new Field(TSDataType.TEXT);
       field.setBinaryV(new Binary(columnPath));
       Field field1 = new Field(TSDataType.TEXT);
+      // get the count of every group
       field1.setBinaryV(new Binary(Integer.toString(getPathsNum(columnPath))));
       record.addField(field);
       record.addField(field1);
@@ -396,6 +397,10 @@ public class PlanExecutor implements IPlanExecutor {
 
   protected int getPathsNum(String path) throws MetadataException {
     return mManager.getInstance().getAllTimeseriesCount(path);
+  }
+
+  protected int getPathsNumInGivenLevel(String path, int level) throws MetadataException {
+    return mManager.getInstance().getAllTimeseriesCountInGivenLevel(path, level);
   }
 
   protected List<String> getPathsName(String path) throws MetadataException {

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -439,10 +439,10 @@ public class MTreeTest {
 
       assertEquals(4, root.getAllTimeseriesCount("root.laptop"));
 
-      assertEquals(2, root.getAllTimeseriesCountInGivenLevel("root.laptop", 2));
-      assertEquals(4, root.getAllTimeseriesCountInGivenLevel("root.laptop", 3));
-      assertEquals(2, root.getAllTimeseriesCountInGivenLevel("root.laptop.d1", 3));
-      assertEquals(0, root.getAllTimeseriesCountInGivenLevel("root.laptop.d1", 4));
+      assertEquals(2, root.getNodesCountInGivenLevel("root.laptop", 2));
+      assertEquals(4, root.getNodesCountInGivenLevel("root.laptop", 3));
+      assertEquals(2, root.getNodesCountInGivenLevel("root.laptop.d1", 3));
+      assertEquals(0, root.getNodesCountInGivenLevel("root.laptop.d1", 4));
     } catch (MetadataException e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/metadata/MTreeTest.java
@@ -421,4 +421,31 @@ public class MTreeTest {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void testGetAllTimeseriesCount() {
+    // set storage group first
+    MTree root = new MTree();
+    try {
+      root.setStorageGroup("root.laptop");
+      root.createTimeseries("root.laptop.d1.s1", TSDataType.INT32, TSEncoding.PLAIN,
+          CompressionType.GZIP, null, null);
+      root.createTimeseries("root.laptop.d1.s2", TSDataType.INT32, TSEncoding.PLAIN,
+          CompressionType.GZIP, null, null);
+      root.createTimeseries("root.laptop.d2.s1", TSDataType.INT32, TSEncoding.PLAIN,
+          CompressionType.GZIP, null, null);
+      root.createTimeseries("root.laptop.d2.s2", TSDataType.INT32, TSEncoding.PLAIN,
+          CompressionType.GZIP, null, null);
+
+      assertEquals(4, root.getAllTimeseriesCount("root.laptop"));
+
+      assertEquals(2, root.getAllTimeseriesCountInGivenLevel("root.laptop", 2));
+      assertEquals(4, root.getAllTimeseriesCountInGivenLevel("root.laptop", 3));
+      assertEquals(2, root.getAllTimeseriesCountInGivenLevel("root.laptop.d1", 3));
+      assertEquals(0, root.getAllTimeseriesCountInGivenLevel("root.laptop.d1", 4));
+    } catch (MetadataException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
For count timeseries, we get all timeseries and then calculate the count. Which occupy much memory and not efficient. It's better to count while traversing the MTree.