### PR TITLE
[IOTDB-745] fix partial write and sync close bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -111,7 +111,7 @@ public abstract class AbstractMemTable implements IMemTable {
           insertPlan.getSchemas()[i], insertPlan.getTime(), value);
     }
 
-    totalPointsNum += insertPlan.getValues().length - insertPlan.getFailedMeasurements().size();
+    totalPointsNum += insertPlan.getMeasurements().length - insertPlan.getFailedMeasurementNumber();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -111,7 +111,7 @@ public abstract class AbstractMemTable implements IMemTable {
           insertPlan.getSchemas()[i], insertPlan.getTime(), value);
     }
 
-    totalPointsNum += insertPlan.getValues().length;
+    totalPointsNum += insertPlan.getValues().length - insertPlan.getFailedMeasurements().size();
   }
 
   @Override
@@ -171,6 +171,9 @@ public abstract class AbstractMemTable implements IMemTable {
 
   @Override
   public boolean reachTotalPointNumThreshold() {
+    if (totalPointsNum == 0) {
+      return false;
+    }
     return totalPointsNum >= totalPointsNumThreshold;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -378,7 +378,9 @@ public class TsFileProcessor {
 
       //we have to add the memtable into flushingList first and then set the shouldClose tag.
       // see https://issues.apache.org/jira/browse/IOTDB-510
-      IMemTable tmpMemTable = workMemTable == null ? new NotifyFlushMemTable() : workMemTable;
+      IMemTable tmpMemTable = workMemTable == null || workMemTable.memSize() == 0
+          ? new NotifyFlushMemTable()
+          : workMemTable;
 
       try {
         addAMemtableIntoFlushingList(tmpMemTable);

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -905,7 +905,7 @@ public class PlanExecutor implements IPlanExecutor {
             checkType(insertPlan, i, measurementNode.getSchema().getType());
           }
         } catch (MetadataException e) {
-          logger.warn("meet error when check {}.{}", deviceId, measurement, e);
+          logger.warn("meet error when check {}.{}, message: {}", deviceId, measurement, e.getMessage());
           if (enablePartialInsert) {
             insertPlan.markMeasurementInsertionFailed(i);
           } else {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
@@ -358,6 +358,10 @@ public class InsertPlan extends PhysicalPlan {
     return failedMeasurements;
   }
 
+  public int getFailedMeasurementNumber() {
+    return failedMeasurements == null ? 0 : failedMeasurements.size();
+  }
+
   public TSDataType[] getTypes() {
     return types;
   }


### PR DESCRIPTION
If we submit an empty memtable when close, it will not trigger a flush task, so the sync close will block.