### PR TITLE
[Distrubuted] Peer tracker optimization

### DIFF
--- a/cluster/src/assembly/resources/conf/logback.xml
+++ b/cluster/src/assembly/resources/conf/logback.xml
@@ -109,7 +109,7 @@
             <charset>utf-8</charset>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
+            <level>DEBUG</level>
         </filter>
     </appender>
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_COST_MEASURE">

--- a/cluster/src/main/java/org/apache/iotdb/cluster/ClusterMain.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/ClusterMain.java
@@ -180,6 +180,7 @@ public class ClusterMain {
       MetaClient client = new MetaClient(factory, new TAsyncClientManager(), node, null);
 
       try {
+        logger.info("Start removing node {} with the help of node {}", nodeToRemove, node);
         Long response = SyncClientAdaptor.removeNode(client, nodeToRemove);
         if (response != null) {
           if (response == Response.RESPONSE_AGREE) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/BaseApplier.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/BaseApplier.java
@@ -83,13 +83,16 @@ abstract class BaseApplier implements LogApplier {
       boolean causedByStorageGroupNotSet = metaMissingException instanceof StorageGroupNotSetException;
 
       if (causedByPathNotExist) {
-        logger.debug("Timeseries is not found locally, try pulling it from another group: {}",
-            e.getCause().getMessage());
+        if (logger.isDebugEnabled()) {
+          logger.debug("Timeseries is not found locally[{}], try pulling it from another group: {}",
+              metaGroupMember.getName(), e.getCause().getMessage());
+        }
         try {
           List<MeasurementSchema> schemas = metaGroupMember
               .pullTimeSeriesSchemas(Collections.singletonList(plan.getDeviceId()));
           for (MeasurementSchema schema : schemas) {
-            registerMeasurement(plan.getDeviceId() + IoTDBConstant.PATH_SEPARATOR + schema.getMeasurementId(),
+            registerMeasurement(
+                plan.getDeviceId() + IoTDBConstant.PATH_SEPARATOR + schema.getMeasurementId(),
                 schema);
           }
         } catch (MetadataException e1) {
@@ -106,15 +109,17 @@ abstract class BaseApplier implements LogApplier {
   }
 
   /**
-   * If e or one of its recursive causes is a PathNotExistException or
-   * StorageGroupNotSetException, return such an exception or null if it cannot be found.
+   * If e or one of its recursive causes is a PathNotExistException or StorageGroupNotSetException,
+   * return such an exception or null if it cannot be found.
+   *
    * @param currEx
    * @return null or a PathNotExistException or a StorageGroupNotSetException
    */
   private Throwable findMetaMissingException(Throwable currEx) {
     while (true) {
-      if (currEx instanceof PathNotExistException || currEx instanceof StorageGroupNotSetException) {
-       return currEx;
+      if (currEx instanceof PathNotExistException
+          || currEx instanceof StorageGroupNotSetException) {
+        return currEx;
       }
       if (currEx.getCause() == null) {
         break;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/DataLogApplier.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/DataLogApplier.java
@@ -38,7 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * DataLogApplier applies logs like data insertion/deletion/update and timeseries creation to IoTDB.
+ * DataLogApplier applies logs like data insertion/deletion/update and timeseries creation to
+ * IoTDB.
  */
 public class DataLogApplier extends BaseApplier {
 
@@ -54,6 +55,8 @@ public class DataLogApplier extends BaseApplier {
   @Override
   public void apply(Log log)
       throws QueryProcessException, StorageGroupNotSetException, StorageEngineException {
+    logger.debug("DataMember [{}] start applying Log {}", dataGroupMember.getName(), log);
+
     if (log instanceof PhysicalPlanLog) {
       PhysicalPlanLog physicalPlanLog = (PhysicalPlanLog) log;
       PhysicalPlan plan = physicalPlanLog.getPlan();

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/MetaLogApplier.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/MetaLogApplier.java
@@ -21,12 +21,10 @@ package org.apache.iotdb.cluster.log.applier;
 
 import org.apache.iotdb.cluster.log.Log;
 import org.apache.iotdb.cluster.log.logtypes.AddNodeLog;
-import org.apache.iotdb.cluster.log.logtypes.CloseFileLog;
 import org.apache.iotdb.cluster.log.logtypes.PhysicalPlanLog;
 import org.apache.iotdb.cluster.log.logtypes.RemoveNodeLog;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
-import org.apache.iotdb.db.engine.StorageEngine;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
@@ -49,7 +47,7 @@ public class MetaLogApplier extends BaseApplier {
   @Override
   public void apply(Log log)
       throws QueryProcessException, StorageGroupNotSetException, StorageEngineException {
-    logger.debug("Applying {}", log);
+    logger.debug("MetaMember [{}] start applying Log {}", metaGroupMember.getName(), log);
     if (log instanceof AddNodeLog) {
       AddNodeLog addNodeLog = (AddNodeLog) log;
       Node newNode = addNodeLog.getNewNode();

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/catchup/LogCatchUpTask.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/catchup/LogCatchUpTask.java
@@ -110,7 +110,7 @@ public class LogCatchUpTask implements Callable<Void> {
 
       handler.setLog(log);
       request.setEntry(log.serialize());
-      logger.debug("Catching up {} with log {}", node, log);
+      logger.debug("{}: Catching up {} with log {}", raftMember.getName(), node, log);
 
       synchronized (appendSucceed) {
         AsyncClient client = raftMember.connectNode(node);
@@ -168,7 +168,9 @@ public class LogCatchUpTask implements Callable<Void> {
       } else {
         request.setPrevLogTerm(logs.get(i - 1).getCurrLogTerm());
       }
-      logger.debug("Catching up {} with log {}", node, logList);
+      if (logger.isDebugEnabled()) {
+        logger.debug("{}: Catching up {} with log {}", raftMember.getName(), node, logList);
+      }
 
       // do append entries
       synchronized (appendSucceed) {
@@ -191,8 +193,8 @@ public class LogCatchUpTask implements Callable<Void> {
     } else {
       doLogCatchUp();
     }
+    logger.debug("{}: Catch up {} finished", raftMember.getName(), node);
 
-    logger.debug("Catch up {} finished", node);
     // the next catch up is enabled
     raftMember.getLastCatchUpResponseTime().remove(node);
     return null;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/catchup/SnapshotCatchUpTask.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/catchup/SnapshotCatchUpTask.java
@@ -84,11 +84,12 @@ public class SnapshotCatchUpTask extends LogCatchUpTask implements Callable<Void
   @Override
   public Void call() throws InterruptedException, TException, LeaderUnknownException {
     if (doSnapshotCatchUp()) {
-      logger.debug("Snapshot catch up {} finished, begin to catch up log", node);
+      logger
+          .debug("{}: Snapshot catch up {} finished, begin to catch up log", raftMember.getName(),
+              node);
       doLogCatchUp();
     }
-
-    logger.debug("Catch up {} finished", node);
+    logger.debug("{}: Catch up {} finished", raftMember.getName(), node);
     // the next catch up is enabled
     raftMember.getLastCatchUpResponseTime().remove(node);
     return null;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
@@ -111,9 +111,11 @@ public class CommittedEntryManager {
       throw new EntryCompactedException(index, dummyIndex);
     }
     if ((int) (index - dummyIndex) >= entries.size()) {
-      logger.debug(
-          "invalid committedEntryManager maybeTerm : parameter: index({}) > lastIndex({})",
-          index, getLastIndex());
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            "invalid committedEntryManager maybeTerm : parameter: index({}) > lastIndex({})",
+            index, getLastIndex());
+      }
       return -1;
     }
     return entries.get((int) (index - dummyIndex)).getCurrLogTerm();

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/PartitionedSnapshotLogManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/PartitionedSnapshotLogManager.java
@@ -41,8 +41,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * PartitionedSnapshotLogManager provides a PartitionedSnapshot as snapshot, dividing each log to
- * a sub-snapshot according to its slot and stores timeseries schemas of each slot.
+ * PartitionedSnapshotLogManager provides a PartitionedSnapshot as snapshot, dividing each log to a
+ * sub-snapshot according to its slot and stores timeseries schemas of each slot.
  */
 public abstract class PartitionedSnapshotLogManager<T extends Snapshot> extends RaftLogManager {
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/UnCommittedEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/UnCommittedEntryManager.java
@@ -31,198 +31,200 @@ import org.slf4j.LoggerFactory;
 
 public class UnCommittedEntryManager {
 
-    private static final Logger logger = LoggerFactory.getLogger(UnCommittedEntryManager.class);
-    // all entries that have not been committed.
-    private List<Log> entries;
-    // the first uncommitted entry index.
-    private long offset;
+  private static final Logger logger = LoggerFactory.getLogger(UnCommittedEntryManager.class);
+  // all entries that have not been committed.
+  private List<Log> entries;
+  // the first uncommitted entry index.
+  private long offset;
 
-    public UnCommittedEntryManager(long offset) {
-        this.offset = offset;
-        this.entries = new ArrayList<>();
+  public UnCommittedEntryManager(long offset) {
+    this.offset = offset;
+    this.entries = new ArrayList<>();
+  }
+
+  /**
+   * Return the first uncommitted index.
+   *
+   * @return offset
+   */
+  public long getFirstUnCommittedIndex() {
+    return offset;
+  }
+
+
+  /**
+   * Return last entry's index if this instance has at least one uncommitted entry.
+   *
+   * @return -1 if entries are empty, or last entry's index
+   */
+  public long maybeLastIndex() {
+    int entryNum = entries.size();
+    if (entryNum != 0) {
+      return offset + entryNum - 1;
     }
+    return -1;
+  }
 
-    /**
-     * Return the first uncommitted index.
-     *
-     * @return offset
-     */
-    public long getFirstUnCommittedIndex() {
-        return offset;
+  /**
+   * Return the entry's term for given index. Note that the called should ensure index >= offset.
+   *
+   * @param index request entry index
+   * @return -1 if index < offset, throw EntryUnavailableException if index > last or entries is
+   * empty, or return the entry's term for given index
+   * @throws EntryUnavailableException
+   */
+  public long maybeTerm(long index) throws EntryUnavailableException {
+    if (index < offset) {
+      logger.debug(
+          "invalid unCommittedEntryManager maybeTerm : parameter: index({}) < offset({})",
+          index, offset);
+      return -1;
     }
-
-
-    /**
-     * Return last entry's index if this instance has at least one uncommitted entry.
-     *
-     * @return -1 if entries are empty, or last entry's index
-     */
-    public long maybeLastIndex() {
-        int entryNum = entries.size();
-        if (entryNum != 0) {
-            return offset + entryNum - 1;
-        }
-        return -1;
+    long last = maybeLastIndex();
+    if (last == -1 || index > last) {
+      long boundary = last == -1 ? offset - 1 : last;
+      logger.info(
+          "unCommittedEntryManager maybeTerm out of bound : parameter: index({}) > lastIndex({})",
+          index, boundary);
+      throw new EntryUnavailableException(index, boundary);
     }
+    return entries.get((int) (index - offset)).getCurrLogTerm();
+  }
 
-    /**
-     * Return the entry's term for given index. Note that the called should ensure index >= offset.
-     *
-     * @param index request entry index
-     * @return -1 if index < offset, throw EntryUnavailableException if index > last or entries is
-     * empty, or return the entry's term for given index
-     * @throws EntryUnavailableException
-     */
-    public long maybeTerm(long index) throws EntryUnavailableException {
-        if (index < offset) {
-            logger.debug(
-                "invalid unCommittedEntryManager maybeTerm : parameter: index({}) < offset({})",
-                index, offset);
-            return -1;
-        }
-        long last = maybeLastIndex();
-        if (last == -1 || index > last) {
-            long boundary = last == -1 ? offset - 1 : last;
-            logger.info(
-                "unCommittedEntryManager maybeTerm out of bound : parameter: index({}) > lastIndex({})",
-                index, boundary);
-            throw new EntryUnavailableException(index, boundary);
-        }
-        return entries.get((int) (index - offset)).getCurrLogTerm();
+  /**
+   * Remove useless prefix entries as long as these entries has been committed and persisted. This
+   * method is called after persisting newly committed entries or applying a snapshot.
+   *
+   * @param index request entry's index
+   */
+  public void stableTo(long index) {
+    if (index < offset + entries.size() && index >= offset) {
+      entries.subList(0, (int) (index + 1 - offset)).clear();
+      offset = index + 1;
     }
+  }
 
-    /**
-     * Remove useless prefix entries as long as these entries has been committed and persisted. This
-     * method is called after persisting newly committed entries or applying a snapshot.
-     *
-     * @param index request entry's index
-     */
-    public void stableTo(long index) {
-        if (index < offset + entries.size() && index >= offset) {
-            entries.subList(0, (int) (index + 1 - offset)).clear();
-            offset = index + 1;
-        }
-    }
+  /**
+   * Update offset and clear entries because leader's snapshot is more up-to-date. This method is
+   * only called for applying snapshot from leader.
+   *
+   * @param snapshot leader's snapshot
+   */
+  public void applyingSnapshot(Snapshot snapshot) {
+    this.offset = snapshot.getLastLogIndex() + 1;
+    this.entries.clear();
+  }
 
-    /**
-     * Update offset and clear entries because leader's snapshot is more up-to-date. This method is
-     * only called for applying snapshot from leader.
-     *
-     * @param snapshot leader's snapshot
-     */
-    public void applyingSnapshot(Snapshot snapshot) {
-        this.offset = snapshot.getLastLogIndex() + 1;
-        this.entries.clear();
+  /**
+   * TruncateAndAppend uncommitted entries. This method will truncate conflict entries if it finds
+   * inconsistencies. Note that the caller should ensure appendingEntries[0].index <=
+   * entries[entries.size()-1].index + 1. Note that the caller should ensure not to truncate entries
+   * which have been committed.
+   *
+   * @param appendingEntries request entries
+   */
+  public void truncateAndAppend(List<Log> appendingEntries) {
+    long after = appendingEntries.get(0).getCurrLogIndex();
+    long len = after - offset;
+    if (len < 0) {
+      // the logs are being truncated to before our current offset portion, which is committed entries
+      logger.error("The logs which first index is {} are going to truncate committed logs",
+          after);
+    } else if (len == entries.size()) {
+      // after is the next index in the entries
+      // directly append
+      entries.addAll(appendingEntries);
+    } else {
+      // clear conflict entries
+      // then append
+      logger.info("truncate the entries after index {}", after);
+      int truncateIndex = (int) (after - offset);
+      if (truncateIndex < entries.size()) {
+        entries.subList(truncateIndex, entries.size()).clear();
+      }
+      entries.addAll(appendingEntries);
     }
+  }
 
-    /**
-     * TruncateAndAppend uncommitted entries. This method will truncate conflict entries if it finds
-     * inconsistencies. Note that the caller should ensure appendingEntries[0].index <=
-     * entries[entries.size()-1].index + 1. Note that the caller should ensure not to truncate entries
-     * which have been committed.
-     *
-     * @param appendingEntries request entries
-     */
-    public void truncateAndAppend(List<Log> appendingEntries) {
-        long after = appendingEntries.get(0).getCurrLogIndex();
-        long len = after - offset;
-        if (len < 0) {
-            // the logs are being truncated to before our current offset portion, which is committed entries
-            logger.error("The logs which first index is {} are going to truncate committed logs",
-                after);
-        } else if (len == entries.size()) {
-            // after is the next index in the entries
-            // directly append
-            entries.addAll(appendingEntries);
-        } else {
-            // clear conflict entries
-            // then append
-            logger.info("truncate the entries after index {}", after);
-            int truncateIndex = (int) (after - offset);
-            if (truncateIndex < entries.size()) {
-                entries.subList(truncateIndex, entries.size()).clear();
-            }
-            entries.addAll(appendingEntries);
-        }
+  /**
+   * TruncateAndAppend uncommitted entry. This method will truncate conflict entries if it finds
+   * inconsistencies. Note that the caller should ensure not to truncate entries which have been
+   * committed.
+   *
+   * @param appendingEntry request entry
+   */
+  public void truncateAndAppend(Log appendingEntry) {
+    long after = appendingEntry.getCurrLogIndex();
+    long len = after - offset;
+    if (len < 0) {
+      // the logs are being truncated to before our current offset portion, which is committed entries
+      logger.error("The logs which first index is {} are going to truncate committed logs",
+          after);
+    } else if (len == entries.size()) {
+      // after is the next index in the entries
+      // directly append
+      entries.add(appendingEntry);
+    } else {
+      // clear conflict entries
+      // then append
+      logger.info("truncate the entries after index {}, append a new entry {}", after,
+          appendingEntry);
+      int truncateIndex = (int) (after - offset);
+      if (truncateIndex < entries.size()) {
+        entries.subList(truncateIndex, entries.size()).clear();
+      }
+      entries.add(appendingEntry);
     }
+  }
 
-    /**
-     * TruncateAndAppend uncommitted entry. This method will truncate conflict entries if it finds
-     * inconsistencies. Note that the caller should ensure not to truncate entries which have been
-     * committed.
-     *
-     * @param appendingEntry request entry
-     */
-    public void truncateAndAppend(Log appendingEntry) {
-        long after = appendingEntry.getCurrLogIndex();
-        long len = after - offset;
-        if (len < 0) {
-            // the logs are being truncated to before our current offset portion, which is committed entries
-            logger.error("The logs which first index is {} are going to truncate committed logs",
-                after);
-        } else if (len == entries.size()) {
-            // after is the next index in the entries
-            // directly append
-            entries.add(appendingEntry);
-        } else {
-            // clear conflict entries
-            // then append
-            logger.info("truncate the entries after index {}, append a new entry {}", after,
-                appendingEntry);
-            int truncateIndex = (int) (after - offset);
-            if (truncateIndex < entries.size()) {
-                entries.subList(truncateIndex, entries.size()).clear();
-            }
-            entries.add(appendingEntry);
-        }
+  /**
+   * Pack entries from low through high - 1, just like slice (entries[low:high]). offset <= low <=
+   * high. Note that caller must ensure low <= high.
+   *
+   * @param low  request index low bound
+   * @param high request index upper bound
+   */
+  public List<Log> getEntries(long low, long high) {
+    if (low > high) {
+      if (logger.isDebugEnabled()) {
+        logger
+            .debug("invalid unCommittedEntryManager getEntries: parameter: low({}) > high({})",
+                low, high);
+      }
+      return Collections.emptyList();
     }
+    long upper = offset + entries.size();
+    if (low > upper) {
+      // don't throw a exception to support
+      // getEntries(low, Integer.MAX_VALUE) if low is larger than lastIndex.
+      logger.info(
+          "unCommittedEntryManager getEntries[{},{}) out of bound : [{},{}] , return empty ArrayList",
+          low, high, offset, upper);
+      return Collections.emptyList();
+    }
+    if (low < offset) {
+      logger.debug("unCommittedEntryManager getEntries[{},{}) out of bound : [{},{}]", low,
+          high, offset, upper);
+      low = offset;
+    }
+    if (high > upper) {
+      logger.info(
+          "unCommittedEntryManager getEntries[{},{}) out of bound : [{},{}] , adjust parameter 'high' to {}",
+          low, high, offset, upper, upper);
+      // don't throw a exception to support getEntries(low, Integer.MAX_VALUE).
+      high = upper;
+    }
+    return entries.subList((int) (low - offset), (int) (high - offset));
+  }
 
-    /**
-     * Pack entries from low through high - 1, just like slice (entries[low:high]). offset <= low <=
-     * high. Note that caller must ensure low <= high.
-     *
-     * @param low  request index low bound
-     * @param high request index upper bound
-     */
-    public List<Log> getEntries(long low, long high) {
-        if (low > high) {
-            logger
-                .debug("invalid unCommittedEntryManager getEntries: parameter: low({}) > high({})",
-                    low, high);
-            return Collections.emptyList();
-        }
-        long upper = offset + entries.size();
-        if (low > upper) {
-            // don't throw a exception to support
-            // getEntries(low, Integer.MAX_VALUE) if low is larger than lastIndex.
-            logger.info(
-                "unCommittedEntryManager getEntries[{},{}) out of bound : [{},{}] , return empty ArrayList",
-                low, high, offset, upper);
-            return Collections.emptyList();
-        }
-        if (low < offset) {
-            logger.debug("unCommittedEntryManager getEntries[{},{}) out of bound : [{},{}]", low,
-                high, offset, upper);
-            low = offset;
-        }
-        if (high > upper) {
-            logger.info(
-                "unCommittedEntryManager getEntries[{},{}) out of bound : [{},{}] , adjust parameter 'high' to {}",
-                low, high, offset, upper, upper);
-            // don't throw a exception to support getEntries(low, Integer.MAX_VALUE).
-            high = upper;
-        }
-        return entries.subList((int) (low - offset), (int) (high - offset));
-    }
+  @TestOnly
+  public UnCommittedEntryManager(long offset, List<Log> entries) {
+    this.offset = offset;
+    this.entries = entries;
+  }
 
-    @TestOnly
-    public UnCommittedEntryManager(long offset, List<Log> entries) {
-        this.offset = offset;
-        this.entries = entries;
-    }
-
-    @TestOnly
-    public List<Log> getAllEntries() {
-        return entries;
-    }
+  @TestOnly
+  public List<Log> getAllEntries() {
+    return entries;
+  }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/serializable/SyncLogDequeSerializer.java
@@ -262,7 +262,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
         logger.warn("Cannot create log meta file");
       }
     } catch (IOException e) {
-      logger.error("Cannot create new log meta file ",  e);
+      logger.error("Cannot create new log meta file ", e);
     }
   }
 
@@ -274,7 +274,8 @@ public class SyncLogDequeSerializer implements StableEntryManager {
 
   private File createNewLogFile(String dirName) throws IOException {
     File logFile = SystemFileFactory.INSTANCE
-        .getFile(dirName + File.separator + LOG_FILE_PREFIX + "-" + versionController.nextVersion());
+        .getFile(
+            dirName + File.separator + LOG_FILE_PREFIX + "-" + versionController.nextVersion());
     if (!logFile.createNewFile()) {
       logger.warn("Cannot create new log file {}", logFile);
     }
@@ -429,7 +430,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
           // actual log
           Log log = readLog(logReader);
           result.add(log);
-          logNumInFile ++;
+          logNumInFile++;
         }
       } catch (IOException e) {
         logger.error("Error in recovering logs from {}: ", logFile, e);
@@ -450,7 +451,7 @@ public class SyncLogDequeSerializer implements StableEntryManager {
     try {
       log = parser.parse(ByteBuffer.wrap(ReadWriteIOUtils.readBytes(logReader, logSize)));
     } catch (UnknownLogTypeException e) {
-      logger.error("Unknown log detected ",  e);
+      logger.error("Unknown log detected ", e);
     }
 
     logSizeDeque.addLast(totalSize);
@@ -485,9 +486,11 @@ public class SyncLogDequeSerializer implements StableEntryManager {
         state = new HardState();
       }
     }
-    logger.info("Recovered log meta: {}, firstLogPos: {}, removedLogSize: {}, availableVersion: [{},"
-            + " {}], state: {}",
-        meta, firstLogPosition, removedLogSize, minAvailableVersion, maxAvailableVersion, state);
+    logger
+        .info("Recovered log meta: {}, firstLogPos: {}, removedLogSize: {}, availableVersion: [{},"
+                + " {}], state: {}",
+            meta, firstLogPosition, removedLogSize, minAvailableVersion, maxAvailableVersion,
+            state);
     return meta;
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/groupby/MergeGroupByExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/groupby/MergeGroupByExecutor.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MergeGroupByExecutor implements GroupByExecutor {
+
   private static final Logger logger = LoggerFactory.getLogger(MergeGroupByExecutor.class);
 
   private List<AggregateResult> results = new ArrayList<>();
@@ -86,7 +87,8 @@ public class MergeGroupByExecutor implements GroupByExecutor {
         results.get(i).merge(subResults.get(i));
       }
     }
-    logger.debug("Aggregation result of {}@[{}, {}] is {}", path, curStartTime, curEndTime, results);
+    logger.debug("Aggregation result of {}@[{}, {}] is {}", path, curStartTime, curEndTime,
+        results);
     return results;
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/ClientServer.java
@@ -42,7 +42,6 @@ import org.apache.iotdb.cluster.query.RemoteQueryContext;
 import org.apache.iotdb.cluster.rpc.thrift.Node;
 import org.apache.iotdb.cluster.server.handlers.caller.GenericHandler;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
@@ -174,7 +173,7 @@ public class ClientServer extends TSServiceImpl {
     if (serverService == null) {
       return;
     }
-    
+
     poolServer.stop();
     serverService.shutdownNow();
     serverTransport.close();
@@ -189,9 +188,8 @@ public class ClientServer extends TSServiceImpl {
    */
   @Override
   protected TSStatus executeNonQueryPlan(PhysicalPlan plan) {
-      return metaGroupMember.executeNonQuery(plan);
+    return metaGroupMember.executeNonQuery(plan);
   }
-
 
 
   /**
@@ -297,7 +295,4 @@ public class ClientServer extends TSServiceImpl {
       }
     }
   }
-
-
-
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/handlers/caller/ElectionHandler.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/handlers/caller/ElectionHandler.java
@@ -105,7 +105,7 @@ public class ElectionHandler implements AsyncMethodCallback<Long> {
   @Override
   public void onError(Exception exception) {
     if (exception instanceof ConnectException) {
-      logger.debug("{}: Cannot connect to {}: {}", memberName, voter, exception.getMessage());
+      logger.warn("{}: Cannot connect to {}: {}", memberName, voter, exception.getMessage());
     } else {
       logger.warn("{}: A voter {} encountered an error:", memberName, voter, exception);
     }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/handlers/caller/HeartbeatHandler.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/handlers/caller/HeartbeatHandler.java
@@ -93,7 +93,7 @@ public class HeartbeatHandler implements AsyncMethodCallback<HeartBeatResponse> 
   @Override
   public void onError(Exception exception) {
     if (exception instanceof ConnectException) {
-      logger.debug("{}: Cannot connect to {}: {}", memberName, receiver, exception.getMessage());
+      logger.warn("{}: Cannot connect to {}: {}", memberName, receiver, exception.getMessage());
     } else {
       logger.error("{}: Heart beat error, receiver {}, {}", memberName, receiver,
           exception.getMessage());

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/handlers/caller/HeartbeatHandler.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/handlers/caller/HeartbeatHandler.java
@@ -69,6 +69,7 @@ public class HeartbeatHandler implements AsyncMethodCallback<HeartBeatResponse> 
           .computeIfAbsent(follower, k -> new Peer(localMember.getLogManager().getLastLogIndex()));
       if (!peer.isCatchUp() || !localMember.getLogManager()
           .isLogUpToDate(lastLogTerm, lastLogIdx)) {
+        peer.setNextIndex(lastLogIdx + 1);
         logger.debug("{}: catching up node {}, index-term: {}-{}/{}-{}, peer nextIndex {}, peer "
                 + "match index {}",
             memberName, follower,

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/handlers/caller/LogCatchUpInBatchHandler.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/handlers/caller/LogCatchUpInBatchHandler.java
@@ -45,6 +45,7 @@ public class LogCatchUpInBatchHandler implements AsyncMethodCallback<Long> {
   public void onComplete(Long response) {
     logger.debug("{}: Received a catch-up result size of {} from {}", memberName, logs.size(),
         follower);
+
     long resp = response;
     if (resp == RESPONSE_AGREE) {
       synchronized (appendSucceed) {
@@ -52,6 +53,7 @@ public class LogCatchUpInBatchHandler implements AsyncMethodCallback<Long> {
         appendSucceed.notifyAll();
       }
       logger.debug("{}: Succeeded to send logs, size is {}", memberName, logs.size());
+
     } else if (resp == RESPONSE_LOG_MISMATCH) {
       // this is not probably possible
       logger.error("{}: Log mismatch occurred when sending log, which size is {}", memberName,
@@ -62,6 +64,7 @@ public class LogCatchUpInBatchHandler implements AsyncMethodCallback<Long> {
     } else {
       // the follower's term has updated, which means a new leader is elected
       logger.debug("{}: Received a rejection because term is updated to: {}", memberName, resp);
+
       raftMember.stepDown(resp);
 
       synchronized (appendSucceed) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/heartbeat/HeartbeatThread.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/heartbeat/HeartbeatThread.java
@@ -86,7 +86,8 @@ public class HeartbeatThread implements Runnable {
               logger.info("{}: The leader {} timed out", memberName, localMember.getLeader());
               localMember.setCharacter(NodeCharacter.ELECTOR);
             } else {
-              logger.debug("{}: Heartbeat is still valid", memberName);
+              logger.debug("{}: Heartbeat from leader {} is still valid", memberName,
+                  localMember.getLeader());
               Thread.sleep(RaftServer.getConnectionTimeoutInMS());
             }
             break;
@@ -143,6 +144,7 @@ public class HeartbeatThread implements Runnable {
 
         if (localMember.getCharacter() != NodeCharacter.LEADER) {
           // if the character changes, abort the remaining heartbeats
+          logger.warn("The leadership of node {} is ended.", localMember.getThisNode());
           return;
         }
 
@@ -202,7 +204,8 @@ public class HeartbeatThread implements Runnable {
    * Start one round of election. Increase the local term, ask for vote from each of the nodes in
    * the group and become the leader if at least half of them agree.
    */
-  @SuppressWarnings({"java:S2274"}) // enable timeout
+  @SuppressWarnings({"java:S2274"})
+  // enable timeout
   void startElection() {
     synchronized (localMember.getTerm()) {
       long nextTerm = localMember.getTerm().incrementAndGet();

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/heartbeat/MetaHeartbeatThread.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/heartbeat/MetaHeartbeatThread.java
@@ -36,10 +36,11 @@ public class MetaHeartbeatThread extends HeartbeatThread {
   }
 
   /**
-   * Send a heartbeat to "node" through "client".
-   * If the node's identifier is unknown, set the requireIdentifierFlag. If the last identifier
-   * it has sent conflicts with another, further set the regenerateIdentifierFlag.
-   * Also send the partition table to the node if the table is required.
+   * Send a heartbeat to "node" through "client". If the node's identifier is unknown, set the
+   * requireIdentifierFlag. If the last identifier it has sent conflicts with another, further set
+   * the regenerateIdentifierFlag. Also send the partition table to the node if the table is
+   * required.
+   *
    * @param node
    * @param client
    */

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
@@ -395,7 +395,9 @@ public class DataGroupMember extends RaftMember implements TSDataService.AsyncIf
     PartitionedSnapshot snapshot = new PartitionedSnapshot<>(FileSnapshot::new);
     try {
       snapshot.deserialize(ByteBuffer.wrap(request.getSnapshotBytes()));
-      logger.debug("{} received a snapshot {}", name, snapshot);
+      if (logger.isDebugEnabled()) {
+        logger.debug("{} received a snapshot {}", name, snapshot);
+      }
       applyPartitionedSnapshot(snapshot);
       resultHandler.onComplete(null);
     } catch (Exception e) {
@@ -452,7 +454,9 @@ public class DataGroupMember extends RaftMember implements TSDataService.AsyncIf
    * @param snapshot
    */
   public void applySnapshot(Snapshot snapshot, int slot) throws SnapshotApplicationException {
-    logger.debug("{}: applying snapshot {}", name, snapshot);
+    if (logger.isDebugEnabled()) {
+      logger.debug("{}: applying snapshot {}", name, snapshot);
+    }
     // ensure storage groups are synchronized
     metaGroupMember.syncLeader();
     if (snapshot instanceof FileSnapshot) {
@@ -770,8 +774,10 @@ public class DataGroupMember extends RaftMember implements TSDataService.AsyncIf
       // wait if the data of the slot is in another node
       slotManager.waitSlot(requiredSlot);
     }
-    logger.debug("{}: {} slots are requested, first:{}, last: {}", name, requiredSlots.size(),
-        requiredSlots.get(0), requiredSlots.get(requiredSlots.size() - 1));
+    if (logger.isDebugEnabled()) {
+      logger.debug("{}: {} slots are requested, first:{}, last: {}", name, requiredSlots.size(),
+          requiredSlots.get(0), requiredSlots.get(requiredSlots.size() - 1));
+    }
 
     // If the logs between [currCommitLogIndex, currLastLogIndex] are committed after the
     // snapshot is generated, they will be invisible to the new slot owner and thus lost forever

--- a/cluster/src/test/java/org/apache/iotdb/cluster/server/handlers/caller/AppendNodeEntryHandlerTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/server/handlers/caller/AppendNodeEntryHandlerTest.java
@@ -28,13 +28,23 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.iotdb.cluster.common.TestException;
 import org.apache.iotdb.cluster.common.TestLog;
+import org.apache.iotdb.cluster.common.TestMetaGroupMember;
 import org.apache.iotdb.cluster.common.TestUtils;
 import org.apache.iotdb.cluster.log.Log;
 import org.apache.iotdb.cluster.server.Peer;
 import org.apache.iotdb.cluster.server.Response;
+import org.apache.iotdb.cluster.server.member.RaftMember;
+import org.junit.Before;
 import org.junit.Test;
 
 public class AppendNodeEntryHandlerTest {
+
+  private RaftMember member;
+
+  @Before
+  public void setUp() {
+    this.member = new TestMetaGroupMember();
+  }
 
   @Test
   public void testAgreement() throws InterruptedException {
@@ -49,6 +59,7 @@ public class AppendNodeEntryHandlerTest {
         handler.setLeaderShipStale(leadershipStale);
         handler.setVoteCounter(quorum);
         handler.setLog(log);
+        handler.setMember(member);
         handler.setReceiverTerm(receiverTerm);
         handler.setReceiver(TestUtils.getNode(i));
         handler.setPeer(peer);
@@ -76,6 +87,7 @@ public class AppendNodeEntryHandlerTest {
       handler.setLeaderShipStale(leadershipStale);
       handler.setVoteCounter(quorum);
       handler.setLog(log);
+      handler.setMember(member);
       handler.setReceiverTerm(receiverTerm);
       handler.setReceiver(TestUtils.getNode(i));
       handler.setPeer(peer);
@@ -100,6 +112,7 @@ public class AppendNodeEntryHandlerTest {
       handler.setLeaderShipStale(leadershipStale);
       handler.setVoteCounter(quorum);
       handler.setLog(log);
+      handler.setMember(member);
       handler.setReceiverTerm(receiverTerm);
       handler.setReceiver(TestUtils.getNode(0));
       handler.setPeer(peer);
@@ -123,6 +136,7 @@ public class AppendNodeEntryHandlerTest {
     handler.setLeaderShipStale(leadershipStale);
     handler.setVoteCounter(quorum);
     handler.setLog(log);
+    handler.setMember(member);
     handler.setReceiverTerm(receiverTerm);
     handler.setReceiver(TestUtils.getNode(0));
     handler.setPeer(peer);


### PR DESCRIPTION
during matchIndex checking,start checking from follower's lastLogIndex instead of leader's lastLogIndex to accelerate checking