### PR TITLE
[IOTDB-723] add raft log delete mechanism

### DIFF
--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -61,3 +61,9 @@ MAX_REMOVED_LOG_SIZE=134217728
 # whether to use batch append entries in log catch up
 USE_BATCH_IN_CATCH_UP=true
 
+# max number of committed logs to be saved
+MAX_NUMBER_OF_LOGS=100
+
+# deletion check period of the submitted log
+LOG_DELETION_CHECK_INTERVAL_SECOND=3600
+

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
@@ -53,6 +53,16 @@ public class ClusterConfig {
 
   private boolean useBatchInLogCatchUp = true;
 
+  /**
+   * max number of committed logs to be saved
+   */
+  private int maxNumberOfLogs = 100;
+
+  /**
+   * deletion check period of the submitted log
+   */
+  private int logDeleteCheckIntervalSecond = 3600;
+
   public boolean isUseBatchInLogCatchUp() {
     return useBatchInLogCatchUp;
   }
@@ -147,5 +157,21 @@ public class ClusterConfig {
 
   public void setQueryTimeoutInSec(int queryTimeoutInSec) {
     this.queryTimeoutInSec = queryTimeoutInSec;
+  }
+
+  public int getMaxNumberOfLogs() {
+    return maxNumberOfLogs;
+  }
+
+  public void setMaxNumberOfLogs(int maxNumberOfLogs) {
+    this.maxNumberOfLogs = maxNumberOfLogs;
+  }
+
+  public int getLogDeleteCheckIntervalSecond() {
+    return logDeleteCheckIntervalSecond;
+  }
+
+  public void setLogDeleteCheckIntervalSecond(int logDeleteCheckIntervalSecond) {
+    this.logDeleteCheckIntervalSecond = logDeleteCheckIntervalSecond;
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -216,6 +216,13 @@ public class ClusterDescriptor {
     config.setUseBatchInLogCatchUp(Boolean.parseBoolean(properties.getProperty(
         "USE_BATCH_IN_CATCH_UP", String.valueOf(config.isUseBatchInLogCatchUp()))));
 
+    config.setMaxNumberOfLogs(Integer.parseInt(
+        properties.getProperty("MAX_NUMBER_OF_LOGS", String.valueOf(config.getMaxNumberOfLogs()))));
+
+    config.setLogDeleteCheckIntervalSecond(Integer.parseInt(properties
+        .getProperty("LOG_DELETION_CHECK_INTERVAL_SECOND",
+            String.valueOf(config.getLogDeleteCheckIntervalSecond()))));
+
     String seedUrls = properties.getProperty("SEED_NODES");
     if (seedUrls != null) {
       List<String> urlList = getSeedUrlList(seedUrls);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/manage/CommittedEntryManager.java
@@ -94,6 +94,15 @@ public class CommittedEntryManager {
   }
 
   /**
+   * Return the entries's size
+   *
+   * @return entries's size
+   */
+  public long getTotalSize() {
+    return getLastIndex() - getFirstIndex() + 1;
+  }
+
+  /**
    * Return the entry's term for given index. Note that the called should ensure index <=
    * entries[entries.size()-1].index.
    *


### PR DESCRIPTION
The main logic for deleting raft logs is as follows:
Each server periodically(3600 seconds) triggers the operation to check the deletion of the log. If the distance between the last deletion log index and  the current maximum commited index exceeds a certain threshold, it performs the deletion operation, otherwise do nothing.

please leave your opinions, thanks