### PR TITLE
[ISSUE-1281] Show timeseries with heat sort

### DIFF
--- a/docs/UserGuide/Operation Manual/DDL Data Definition Language.md
+++ b/docs/UserGuide/Operation Manual/DDL Data Definition Language.md
@@ -119,9 +119,9 @@ ALTER timeseries root.turbine.d1.s1 UPSERT ALIAS=newAlias TAGS(tag3=v3, tag4=v4)
 
 ## Show Timeseries
 
-* SHOW TIMESERIES prefixPath? showWhereClause? limitClause?
+* SHOW LATEST? TIMESERIES prefixPath? showWhereClause? limitClause?
 
-  There are three optional clauses could be added behind SHOW TIMESERIES, return information of time series 
+  There are four optional clauses could be added in SHOW TIMESERIES, return information of time series 
   
 Timeseries information includes: timeseries path, alias of measurement, storage group it belongs to, data type, encoding type, compression type, tags and attributes.
  
@@ -162,6 +162,10 @@ The results are shown below respectly:
 * SHOW TIMESERIES LIMIT INT OFFSET INT
 
   returns all the timeseries information start from the offset and limit the number of series returned
+  
+* SHOW LATEST TIMESERIES
+
+  all the returned timeseries information should be sorted in descending order of the last timestamp of timeseries
   
 It is worth noting that when the queried path does not exist, the system will return no timeseries.  
 

--- a/docs/zh/UserGuide/Operation Manual/DDL Data Definition Language.md
+++ b/docs/zh/UserGuide/Operation Manual/DDL Data Definition Language.md
@@ -117,9 +117,9 @@ ALTER timeseries root.turbine.d1.s1 UPSERT ALIAS=newAlias TAGS(tag2=newV2, tag3=
 
 ## 查看时间序列
 
-* SHOW TIMESERIES prefixPath? showWhereClause? limitClause?
+* SHOW LATEST? TIMESERIES prefixPath? showWhereClause? limitClause?
 
-  SHOW TIMESERIES 后可以跟三种可选的子句，查询结果为这些时间序列的所有信息
+  SHOW TIMESERIES 中可以有四种可选的子句，查询结果为这些时间序列的所有信息
 
 时间序列信息具体包括：时间序列路径名，存储组，Measurement别名，数据类型，编码方式，压缩方式，属性和标签。
 
@@ -161,7 +161,12 @@ show timeseries root.ln where description contains 'test1'
 
   只返回从指定下标开始的结果，最大返回条数被 LIMIT 限制，用于分页查询
 
+* SHOW LATEST TIMESERIES
+
+  表示查询出的时间序列需要按照最近插入时间戳降序排列
+  
 需要注意的是，当查询路径不存在时，系统会返回0条时间序列。
+
 
 ## 查看子路径
 

--- a/server/src/main/antlr4/org/apache/iotdb/db/qp/strategy/SqlBase.g4
+++ b/server/src/main/antlr4/org/apache/iotdb/db/qp/strategy/SqlBase.g4
@@ -69,7 +69,7 @@ statement
     | SHOW FLUSH TASK INFO #showFlushTaskInfo
     | SHOW DYNAMIC PARAMETER #showDynamicParameter
     | SHOW VERSION #showVersion
-    | SHOW TIMESERIES prefixPath? showWhereClause? orderByHeatClause? limitClause? #showTimeseries
+    | SHOW LATEST? TIMESERIES prefixPath? showWhereClause? limitClause? #showTimeseries
     | SHOW STORAGE GROUP #showStorageGroup
     | SHOW CHILD PATHS prefixPath? #showChildPaths
     | SHOW DEVICES prefixPath? #showDevices
@@ -166,10 +166,6 @@ showWhereClause
     ;
 containsExpression
     : name=ID OPERATOR_CONTAINS value=propertyValue
-    ;
-
-orderByHeatClause
-    : ORDER BY HEAT
     ;
 
 orExpression
@@ -882,12 +878,8 @@ FALSE
     : F A L S E
     ;
 
-ORDER
-    : O R D E R
-    ;
-
-HEAT
-    : H E A T
+LATEST
+    : L A T E S T
     ;
 
 //============================

--- a/server/src/main/antlr4/org/apache/iotdb/db/qp/strategy/SqlBase.g4
+++ b/server/src/main/antlr4/org/apache/iotdb/db/qp/strategy/SqlBase.g4
@@ -69,7 +69,7 @@ statement
     | SHOW FLUSH TASK INFO #showFlushTaskInfo
     | SHOW DYNAMIC PARAMETER #showDynamicParameter
     | SHOW VERSION #showVersion
-    | SHOW TIMESERIES prefixPath? showWhereClause? limitClause? #showTimeseries
+    | SHOW TIMESERIES prefixPath? showWhereClause? orderByHeatClause? limitClause? #showTimeseries
     | SHOW STORAGE GROUP #showStorageGroup
     | SHOW CHILD PATHS prefixPath? #showChildPaths
     | SHOW DEVICES prefixPath? #showDevices
@@ -166,6 +166,10 @@ showWhereClause
     ;
 containsExpression
     : name=ID OPERATOR_CONTAINS value=propertyValue
+    ;
+
+orderByHeatClause
+    : ORDER BY HEAT
     ;
 
 orExpression
@@ -875,6 +879,14 @@ TRUE
 
 FALSE
     : F A L S E
+    ;
+
+ORDER
+    : O R D E R
+    ;
+
+HEAT
+    : H E A T
     ;
 //============================
 // End of the keywords list

--- a/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/MTree.java
@@ -43,9 +43,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.JSONObject;
-import com.alibaba.fastjson.serializer.SerializerFeature;
 import org.apache.iotdb.db.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.metadata.AliasAlreadyExistException;
@@ -56,8 +53,8 @@ import org.apache.iotdb.db.exception.metadata.PathNotExistException;
 import org.apache.iotdb.db.exception.metadata.StorageGroupAlreadySetException;
 import org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException;
 import org.apache.iotdb.db.metadata.mnode.InternalMNode;
-import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
 import org.apache.iotdb.db.metadata.mnode.MNode;
+import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
 import org.apache.iotdb.db.metadata.mnode.StorageGroupMNode;
 import org.apache.iotdb.db.qp.physical.sys.ShowTimeSeriesPlan;
 import org.apache.iotdb.db.query.context.QueryContext;
@@ -69,24 +66,6 @@ import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
-
-import java.io.Serializable;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Queue;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.regex.Pattern;
-
-import static org.apache.iotdb.db.conf.IoTDBConstant.PATH_SEPARATOR;
-import static org.apache.iotdb.db.conf.IoTDBConstant.PATH_WILDCARD;
 
 /**
  * The hierarchical struct of the Metadata Tree is implemented in this class.
@@ -713,8 +692,8 @@ public class MTree implements Serializable {
   /**
    * Iterate through MTree to fetch metadata info of all leaf nodes under the given seriesPath
    *
-   * @param timeseriesSchemaList Collection<timeseriesSchema> result: [name, alias, storage group,
-   *                          dataType, encoding, compression, offset, lastTimeStamp]
+   * @param timeseriesSchemaList List<timeseriesSchema>
+   * result: [name, alias, storage group, dataType, encoding, compression, offset, lastTimeStamp]
    */
   private void findPath(MNode node, String[] nodes, int idx, String parent,
       List<String[]> timeseriesSchemaList, boolean hasLimit) throws MetadataException {

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -967,11 +967,11 @@ public class PlanExecutor implements IPlanExecutor {
       }
     } else if (deviceNode != null) {
       // device and measurement exists in MTree
-      LeafMNode measurementNode = (LeafMNode) MManager.getInstance().getChild(deviceNode, measurement);
+      LeafMNode measurementNode = (LeafMNode) mManager.getChild(deviceNode, measurement);
       measurementSchema = measurementNode.getSchema();
     } else {
       // device in not in MTree, try the cache
-      measurementSchema = MManager.getInstance().getSeriesSchema(deviceId, measurement);
+      measurementSchema = mManager.getSeriesSchema(deviceId, measurement);
     }
     return measurementSchema;
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/ShowTimeSeriesOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/ShowTimeSeriesOperator.java
@@ -30,11 +30,12 @@ public class ShowTimeSeriesOperator extends ShowOperator {
   private int limit = 0;
   private int offset = 0;
   // if is true, the result will be sorted according to the inserting frequency of the timeseries
-  private boolean orderByHeat;
+  private final boolean orderByHeat;
 
-  public ShowTimeSeriesOperator(int tokeIntType, Path path) {
+  public ShowTimeSeriesOperator(int tokeIntType, Path path, boolean orderByHeat) {
     super(tokeIntType);
     this.path = path;
+    this.orderByHeat = orderByHeat;
   }
 
   public Path getPath() {
@@ -83,9 +84,5 @@ public class ShowTimeSeriesOperator extends ShowOperator {
 
   public boolean isOrderByHeat() {
     return orderByHeat;
-  }
-
-  public void setOrderByHeat(boolean orderByHeat) {
-    this.orderByHeat = orderByHeat;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/ShowTimeSeriesOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/logical/sys/ShowTimeSeriesOperator.java
@@ -29,6 +29,8 @@ public class ShowTimeSeriesOperator extends ShowOperator {
   private String value;
   private int limit = 0;
   private int offset = 0;
+  // if is true, the result will be sorted according to the inserting frequency of the timeseries
+  private boolean orderByHeat;
 
   public ShowTimeSeriesOperator(int tokeIntType, Path path) {
     super(tokeIntType);
@@ -77,5 +79,13 @@ public class ShowTimeSeriesOperator extends ShowOperator {
 
   public void setOffset(int offset) {
     this.offset = offset;
+  }
+
+  public boolean isOrderByHeat() {
+    return orderByHeat;
+  }
+
+  public void setOrderByHeat(boolean orderByHeat) {
+    this.orderByHeat = orderByHeat;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowTimeSeriesPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/sys/ShowTimeSeriesPlan.java
@@ -33,6 +33,8 @@ public class ShowTimeSeriesPlan extends ShowPlan {
   private String value;
   private int limit = 0;
   private int offset = 0;
+  // if is true, the result will be sorted according to the inserting frequency of the timeseries
+  private boolean orderByHeat;
 
   public ShowTimeSeriesPlan(Path path) {
     super(ShowContentType.TIMESERIES);
@@ -40,7 +42,7 @@ public class ShowTimeSeriesPlan extends ShowPlan {
   }
 
   public ShowTimeSeriesPlan(Path path, boolean isContains, String key, String value, int limit,
-      int offset) {
+      int offset, boolean orderByHeat) {
     super(ShowContentType.TIMESERIES);
     this.path = path;
     this.isContains = isContains;
@@ -48,6 +50,7 @@ public class ShowTimeSeriesPlan extends ShowPlan {
     this.value = value;
     this.limit = limit;
     this.offset = offset;
+    this.orderByHeat = orderByHeat;
   }
 
   public ShowTimeSeriesPlan() {
@@ -78,6 +81,14 @@ public class ShowTimeSeriesPlan extends ShowPlan {
     return offset;
   }
 
+  public boolean isOrderByHeat() {
+    return orderByHeat;
+  }
+
+  public void setOrderByHeat(boolean orderByHeat) {
+    this.orderByHeat = orderByHeat;
+  }
+
   @Override
   public void serialize(DataOutputStream outputStream) throws IOException {
     outputStream.write(PhysicalPlanType.SHOW_TIMESERIES.ordinal());
@@ -89,6 +100,7 @@ public class ShowTimeSeriesPlan extends ShowPlan {
 
     outputStream.writeInt(limit);
     outputStream.writeInt(offset);
+    outputStream.writeBoolean(orderByHeat);
   }
 
   @Override
@@ -100,5 +112,6 @@ public class ShowTimeSeriesPlan extends ShowPlan {
 
     limit = buffer.getInt();
     limit = buffer.getInt();
+    orderByHeat = buffer.get() == 1;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -196,10 +196,10 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     Path path = (pathContext != null ? parsePrefixPath(pathContext) : new Path(SQLConstant.ROOT));
     if (ctx.INT() != null) {
       initializedOperator = new CountOperator(SQLConstant.TOK_COUNT_NODE_TIMESERIES,
-              path, Integer.parseInt(ctx.INT().getText()));
+          path, Integer.parseInt(ctx.INT().getText()));
     } else {
       initializedOperator = new CountOperator(SQLConstant.TOK_COUNT_TIMESERIES,
-              path);
+          path);
     }
   }
 
@@ -243,7 +243,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterCountNodes(CountNodesContext ctx) {
     super.enterCountNodes(ctx);
     initializedOperator = new CountOperator(SQLConstant.TOK_COUNT_NODES,
-            parsePrefixPath(ctx.prefixPath()), Integer.parseInt(ctx.INT().getText()));
+        parsePrefixPath(ctx.prefixPath()), Integer.parseInt(ctx.INT().getText()));
   }
 
   @Override
@@ -251,10 +251,10 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterShowDevices(ctx);
     if (ctx.prefixPath() != null) {
       initializedOperator = new ShowDevicesOperator(SQLConstant.TOK_DEVICES,
-              parsePrefixPath(ctx.prefixPath()));
+          parsePrefixPath(ctx.prefixPath()));
     } else {
       initializedOperator = new ShowDevicesOperator(SQLConstant.TOK_DEVICES,
-              new Path(SQLConstant.ROOT));
+          new Path(SQLConstant.ROOT));
     }
   }
 
@@ -263,10 +263,10 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterShowChildPaths(ctx);
     if (ctx.prefixPath() != null) {
       initializedOperator = new ShowChildPathsOperator(SQLConstant.TOK_CHILD_PATHS,
-              parsePrefixPath(ctx.prefixPath()));
+          parsePrefixPath(ctx.prefixPath()));
     } else {
       initializedOperator = new ShowChildPathsOperator(SQLConstant.TOK_CHILD_PATHS,
-              new Path(SQLConstant.ROOT));
+          new Path(SQLConstant.ROOT));
     }
   }
 
@@ -281,20 +281,23 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     super.enterLoadFiles(ctx);
     if (ctx.autoCreateSchema() != null) {
       if (ctx.autoCreateSchema().INT() != null) {
-        initializedOperator = new LoadFilesOperator(new File(removeStringQuote(ctx.STRING_LITERAL().getText())),
-                Boolean.parseBoolean(ctx.autoCreateSchema().booleanClause().getText()),
-                Integer.parseInt(ctx.autoCreateSchema().INT().getText())
+        initializedOperator = new LoadFilesOperator(
+            new File(removeStringQuote(ctx.STRING_LITERAL().getText())),
+            Boolean.parseBoolean(ctx.autoCreateSchema().booleanClause().getText()),
+            Integer.parseInt(ctx.autoCreateSchema().INT().getText())
         );
       } else {
-        initializedOperator = new LoadFilesOperator(new File(removeStringQuote(ctx.STRING_LITERAL().getText())),
-                Boolean.parseBoolean(ctx.autoCreateSchema().booleanClause().getText()),
-                IoTDBDescriptor.getInstance().getConfig().getDefaultStorageGroupLevel()
+        initializedOperator = new LoadFilesOperator(
+            new File(removeStringQuote(ctx.STRING_LITERAL().getText())),
+            Boolean.parseBoolean(ctx.autoCreateSchema().booleanClause().getText()),
+            IoTDBDescriptor.getInstance().getConfig().getDefaultStorageGroupLevel()
         );
       }
     } else {
-      initializedOperator = new LoadFilesOperator(new File(removeStringQuote(ctx.STRING_LITERAL().getText())),
-              true,
-              IoTDBDescriptor.getInstance().getConfig().getDefaultStorageGroupLevel()
+      initializedOperator = new LoadFilesOperator(
+          new File(removeStringQuote(ctx.STRING_LITERAL().getText())),
+          true,
+          IoTDBDescriptor.getInstance().getConfig().getDefaultStorageGroupLevel()
       );
     }
   }
@@ -302,14 +305,16 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   @Override
   public void enterMoveFile(MoveFileContext ctx) {
     super.enterMoveFile(ctx);
-    initializedOperator = new MoveFileOperator(new File(removeStringQuote(ctx.STRING_LITERAL(0).getText())),
-            new File(removeStringQuote(ctx.STRING_LITERAL(1).getText())));
+    initializedOperator = new MoveFileOperator(
+        new File(removeStringQuote(ctx.STRING_LITERAL(0).getText())),
+        new File(removeStringQuote(ctx.STRING_LITERAL(1).getText())));
   }
 
   @Override
   public void enterRemoveFile(RemoveFileContext ctx) {
     super.enterRemoveFile(ctx);
-    initializedOperator = new RemoveFileOperator(new File(removeStringQuote(ctx.STRING_LITERAL().getText())));
+    initializedOperator = new RemoveFileOperator(
+        new File(removeStringQuote(ctx.STRING_LITERAL().getText())));
   }
 
   @Override
@@ -344,12 +349,13 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   @Override
   public void enterShowTimeseries(ShowTimeseriesContext ctx) {
     super.enterShowTimeseries(ctx);
+    boolean orderByHeat = ctx.LATEST() != null;
     if (ctx.prefixPath() != null) {
       initializedOperator = new ShowTimeSeriesOperator(SQLConstant.TOK_TIMESERIES,
-              parsePrefixPath(ctx.prefixPath()));
+          parsePrefixPath(ctx.prefixPath()), orderByHeat);
     } else {
-      initializedOperator = new ShowTimeSeriesOperator(SQLConstant.TOK_TIMESERIES,
-              new Path("root"));
+      initializedOperator = new ShowTimeSeriesOperator(SQLConstant.TOK_TIMESERIES, new Path("root"),
+          orderByHeat);
     }
   }
 
@@ -428,7 +434,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterCreateUser(CreateUserContext ctx) {
     super.enterCreateUser(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_CREATE,
-            AuthorOperator.AuthorType.CREATE_USER);
+        AuthorOperator.AuthorType.CREATE_USER);
     authorOperator.setUserName(ctx.ID().getText());
     authorOperator.setPassWord(removeStringQuote(ctx.password.getText()));
     initializedOperator = authorOperator;
@@ -439,7 +445,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterCreateRole(CreateRoleContext ctx) {
     super.enterCreateRole(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_CREATE,
-            AuthorOperator.AuthorType.CREATE_ROLE);
+        AuthorOperator.AuthorType.CREATE_ROLE);
     authorOperator.setRoleName(ctx.ID().getText());
     initializedOperator = authorOperator;
     operatorType = SQLConstant.TOK_AUTHOR_CREATE;
@@ -449,7 +455,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterAlterUser(AlterUserContext ctx) {
     super.enterAlterUser(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_UPDATE_USER,
-            AuthorOperator.AuthorType.UPDATE_USER);
+        AuthorOperator.AuthorType.UPDATE_USER);
     if (ctx.ID() != null) {
       authorOperator.setUserName(ctx.ID().getText());
     } else {
@@ -464,7 +470,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterDropUser(DropUserContext ctx) {
     super.enterDropUser(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_DROP,
-            AuthorOperator.AuthorType.DROP_USER);
+        AuthorOperator.AuthorType.DROP_USER);
     authorOperator.setUserName(ctx.ID().getText());
     initializedOperator = authorOperator;
     operatorType = SQLConstant.TOK_AUTHOR_DROP;
@@ -474,7 +480,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterDropRole(DropRoleContext ctx) {
     super.enterDropRole(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_DROP,
-            AuthorOperator.AuthorType.DROP_ROLE);
+        AuthorOperator.AuthorType.DROP_ROLE);
     authorOperator.setRoleName(ctx.ID().getText());
     initializedOperator = authorOperator;
     operatorType = SQLConstant.TOK_AUTHOR_DROP;
@@ -484,7 +490,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterGrantUser(GrantUserContext ctx) {
     super.enterGrantUser(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_GRANT,
-            AuthorOperator.AuthorType.GRANT_USER);
+        AuthorOperator.AuthorType.GRANT_USER);
     authorOperator.setUserName(ctx.ID().getText());
     authorOperator.setPrivilegeList(parsePrivilege(ctx.privileges()));
     authorOperator.setNodeNameList(parsePrefixPath(ctx.prefixPath()));
@@ -496,7 +502,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterGrantRole(GrantRoleContext ctx) {
     super.enterGrantRole(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_GRANT,
-            AuthorType.GRANT_ROLE);
+        AuthorType.GRANT_ROLE);
     authorOperator.setRoleName(ctx.ID().getText());
     authorOperator.setPrivilegeList(parsePrivilege(ctx.privileges()));
     authorOperator.setNodeNameList(parsePrefixPath(ctx.prefixPath()));
@@ -508,7 +514,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterRevokeUser(RevokeUserContext ctx) {
     super.enterRevokeUser(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_GRANT,
-            AuthorType.REVOKE_USER);
+        AuthorType.REVOKE_USER);
     authorOperator.setUserName(ctx.ID().getText());
     authorOperator.setPrivilegeList(parsePrivilege(ctx.privileges()));
     authorOperator.setNodeNameList(parsePrefixPath(ctx.prefixPath()));
@@ -520,7 +526,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterRevokeRole(RevokeRoleContext ctx) {
     super.enterRevokeRole(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_GRANT,
-            AuthorType.REVOKE_ROLE);
+        AuthorType.REVOKE_ROLE);
     authorOperator.setRoleName(ctx.ID().getText());
     authorOperator.setPrivilegeList(parsePrivilege(ctx.privileges()));
     authorOperator.setNodeNameList(parsePrefixPath(ctx.prefixPath()));
@@ -532,7 +538,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterGrantRoleToUser(GrantRoleToUserContext ctx) {
     super.enterGrantRoleToUser(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_GRANT,
-            AuthorOperator.AuthorType.GRANT_ROLE_TO_USER);
+        AuthorOperator.AuthorType.GRANT_ROLE_TO_USER);
     authorOperator.setRoleName(ctx.roleName.getText());
     authorOperator.setUserName(ctx.userName.getText());
     initializedOperator = authorOperator;
@@ -543,7 +549,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterRevokeRoleFromUser(RevokeRoleFromUserContext ctx) {
     super.enterRevokeRoleFromUser(ctx);
     AuthorOperator authorOperator = new AuthorOperator(SQLConstant.TOK_AUTHOR_GRANT,
-            AuthorType.REVOKE_ROLE_FROM_USER);
+        AuthorType.REVOKE_ROLE_FROM_USER);
     authorOperator.setRoleName(ctx.roleName.getText());
     authorOperator.setUserName(ctx.userName.getText());
     initializedOperator = authorOperator;
@@ -565,8 +571,8 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       sc.addTail(nodeName.getText());
     }
     initializedOperator = new LoadDataOperator(SQLConstant.TOK_DATALOAD,
-            removeStringQuote(csvPath),
-            sc.toString());
+        removeStringQuote(csvPath),
+        sc.toString());
     operatorType = SQLConstant.TOK_DATALOAD;
   }
 
@@ -597,7 +603,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterListUser(ListUserContext ctx) {
     super.enterListUser(ctx);
     initializedOperator = new AuthorOperator(SQLConstant.TOK_LIST,
-            AuthorOperator.AuthorType.LIST_USER);
+        AuthorOperator.AuthorType.LIST_USER);
     operatorType = SQLConstant.TOK_LIST;
   }
 
@@ -605,7 +611,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterListRole(ListRoleContext ctx) {
     super.enterListRole(ctx);
     initializedOperator = new AuthorOperator(SQLConstant.TOK_LIST,
-            AuthorOperator.AuthorType.LIST_ROLE);
+        AuthorOperator.AuthorType.LIST_ROLE);
     operatorType = SQLConstant.TOK_LIST;
   }
 
@@ -613,7 +619,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterListPrivilegesUser(ListPrivilegesUserContext ctx) {
     super.enterListPrivilegesUser(ctx);
     AuthorOperator operator = new AuthorOperator(SQLConstant.TOK_LIST,
-            AuthorOperator.AuthorType.LIST_USER_PRIVILEGE);
+        AuthorOperator.AuthorType.LIST_USER_PRIVILEGE);
     operator.setUserName(ctx.ID().getText());
     operator.setNodeNameList(parsePrefixPath(ctx.prefixPath()));
     initializedOperator = operator;
@@ -624,7 +630,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterListPrivilegesRole(ListPrivilegesRoleContext ctx) {
     super.enterListPrivilegesRole(ctx);
     AuthorOperator operator = new AuthorOperator(SQLConstant.TOK_LIST,
-            AuthorOperator.AuthorType.LIST_ROLE_PRIVILEGE);
+        AuthorOperator.AuthorType.LIST_ROLE_PRIVILEGE);
     operator.setRoleName((ctx.ID().getText()));
     operator.setNodeNameList(parsePrefixPath(ctx.prefixPath()));
     initializedOperator = operator;
@@ -635,7 +641,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterListUserPrivileges(ListUserPrivilegesContext ctx) {
     super.enterListUserPrivileges(ctx);
     AuthorOperator operator = new AuthorOperator(SQLConstant.TOK_LIST,
-            AuthorOperator.AuthorType.LIST_USER_PRIVILEGE);
+        AuthorOperator.AuthorType.LIST_USER_PRIVILEGE);
     operator.setUserName(ctx.ID().getText());
     initializedOperator = operator;
     operatorType = SQLConstant.TOK_LIST;
@@ -645,7 +651,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterListRolePrivileges(ListRolePrivilegesContext ctx) {
     super.enterListRolePrivileges(ctx);
     AuthorOperator operator = new AuthorOperator(SQLConstant.TOK_LIST,
-            AuthorOperator.AuthorType.LIST_ROLE_PRIVILEGE);
+        AuthorOperator.AuthorType.LIST_ROLE_PRIVILEGE);
     operator.setRoleName(ctx.ID().getText());
     initializedOperator = operator;
     operatorType = SQLConstant.TOK_LIST;
@@ -655,7 +661,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterListAllRoleOfUser(ListAllRoleOfUserContext ctx) {
     super.enterListAllRoleOfUser(ctx);
     AuthorOperator operator = new AuthorOperator(SQLConstant.TOK_LIST,
-            AuthorOperator.AuthorType.LIST_USER_ROLES);
+        AuthorOperator.AuthorType.LIST_USER_ROLES);
     initializedOperator = operator;
     operator.setUserName(ctx.ID().getText());
     operatorType = SQLConstant.TOK_LIST;
@@ -665,7 +671,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterListAllUserOfRole(ListAllUserOfRoleContext ctx) {
     super.enterListAllUserOfRole(ctx);
     AuthorOperator operator = new AuthorOperator(SQLConstant.TOK_LIST,
-            AuthorOperator.AuthorType.LIST_ROLE_USERS);
+        AuthorOperator.AuthorType.LIST_ROLE_USERS);
     initializedOperator = operator;
     operator.setRoleName((ctx.ID().getText()));
     operatorType = SQLConstant.TOK_LIST;
@@ -736,7 +742,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       deletePaths.add(parsePrefixPath(prefixPath));
     }
     DeleteTimeSeriesOperator deleteTimeSeriesOperator = new DeleteTimeSeriesOperator(
-            SQLConstant.TOK_METADATA_DELETE);
+        SQLConstant.TOK_METADATA_DELETE);
     deleteTimeSeriesOperator.setDeletePathList(deletePaths);
     initializedOperator = deleteTimeSeriesOperator;
     operatorType = SQLConstant.TOK_METADATA_DELETE;
@@ -746,7 +752,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   public void enterSetStorageGroup(SetStorageGroupContext ctx) {
     super.enterSetStorageGroup(ctx);
     SetStorageGroupOperator setStorageGroupOperator = new SetStorageGroupOperator(
-            SQLConstant.TOK_METADATA_SET_FILE_LEVEL);
+        SQLConstant.TOK_METADATA_SET_FILE_LEVEL);
     Path path = parseFullPath(ctx.fullPath());
     setStorageGroupOperator.setPath(path);
     initializedOperator = setStorageGroupOperator;
@@ -762,7 +768,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       deletePaths.add(parseFullPath(fullPath));
     }
     DeleteStorageGroupOperator deleteStorageGroupOperator = new DeleteStorageGroupOperator(
-            SQLConstant.TOK_METADATA_DELETE_FILE_LEVEL);
+        SQLConstant.TOK_METADATA_DELETE_FILE_LEVEL);
     deleteStorageGroupOperator.setDeletePathList(deletePaths);
     initializedOperator = deleteStorageGroupOperator;
     operatorType = SQLConstant.TOK_METADATA_DELETE_FILE_LEVEL;
@@ -877,7 +883,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       queryOp.setSlidingStep(parseDuration(ctx.DURATION(1).getText()));
       if (queryOp.getSlidingStep() < queryOp.getUnit()) {
         throw new SQLParserException(
-          "The third parameter sliding step shouldn't be smaller than the second parameter time interval.");
+            "The third parameter sliding step shouldn't be smaller than the second parameter time interval.");
       }
     }
 
@@ -916,7 +922,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     TSDataType dataType = parseType(ctx.dataType().getText());
     if (ctx.linearClause() != null && dataType == TSDataType.TEXT) {
       throw new SQLParserException(String.format("type %s cannot use %s fill function"
-              , dataType, ctx.linearClause().LINEAR().getText()));
+          , dataType, ctx.linearClause().LINEAR().getText()));
     }
 
     int defaultFillInterval = IoTDBDescriptor.getInstance().getConfig().getDefaultFillInterval();
@@ -1002,7 +1008,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       offset = Integer.parseInt(ctx.INT().getText());
     } catch (NumberFormatException e) {
       throw new SQLParserException(
-              "Out of range. OFFSET <OFFSETValue>: OFFSETValue should be Int32.");
+          "Out of range. OFFSET <OFFSETValue>: OFFSETValue should be Int32.");
     }
     if (offset < 0) {
       throw new SQLParserException("OFFSET <OFFSETValue>: OFFSETValue should >= 0.");
@@ -1022,7 +1028,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       slimit = Integer.parseInt(ctx.INT().getText());
     } catch (NumberFormatException e) {
       throw new SQLParserException(
-              "Out of range. SLIMIT <SN>: SN should be Int32.");
+          "Out of range. SLIMIT <SN>: SN should be Int32.");
     }
     if (slimit <= 0) {
       throw new SQLParserException("SLIMIT <SN>: SN should be greater than 0.");
@@ -1038,11 +1044,11 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       soffset = Integer.parseInt(ctx.INT().getText());
     } catch (NumberFormatException e) {
       throw new SQLParserException(
-              "Out of range. SOFFSET <SOFFSETValue>: SOFFSETValue should be Int32.");
+          "Out of range. SOFFSET <SOFFSETValue>: SOFFSETValue should be Int32.");
     }
     if (soffset < 0) {
       throw new SQLParserException(
-              "SOFFSET <SOFFSETValue>: SOFFSETValue should >= 0.");
+          "SOFFSET <SOFFSETValue>: SOFFSETValue should >= 0.");
     }
     queryOp.setSeriesOffset(soffset);
   }
@@ -1091,7 +1097,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       path.add(nodeNameWithoutStar.getText());
     }
     return new Path(
-            new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
+        new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
   }
 
   @Override
@@ -1153,7 +1159,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   }
 
   private Map<String, String> extractMap(List<PropertyContext> property2,
-                                         PropertyContext property3) {
+      PropertyContext property3) {
     String value;
     Map<String, String> tags = new HashMap<>(property2.size());
     if (property3 != null) {
@@ -1273,7 +1279,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       path.add(nodeName.getText());
     }
     return new Path(
-            new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
+        new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
   }
 
   /**
@@ -1300,7 +1306,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
           unit += durationStr.charAt(i);
         }
         total += DatetimeUtils
-                .convertDurationStrToLong(tmp, unit.toLowerCase(), timestampPrecision);
+            .convertDurationStrToLong(tmp, unit.toLowerCase(), timestampPrecision);
         tmp = 0;
       }
     }
@@ -1354,13 +1360,6 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       value = propertyValueContext.getText();
     }
     operator.setValue(value);
-  }
-
-  @Override
-  public void enterOrderByHeatClause(SqlBaseParser.OrderByHeatClauseContext ctx) {
-    super.enterOrderByHeatClause(ctx);
-    ShowTimeSeriesOperator operator = (ShowTimeSeriesOperator) initializedOperator;
-    operator.setOrderByHeat(true);
   }
 
   private FilterOperator parseOrExpression(OrExpressionContext ctx) {
@@ -1460,10 +1459,10 @@ public class LogicalGenerator extends SqlBaseBaseListener {
         throw new SQLParserException(path.toString(), "Date can only be used to time");
       }
       basic = new BasicFunctionOperator(ctx.comparisonOperator().type.getType(), path,
-              Long.toString(parseDateExpression(ctx.constant().dateExpression())));
+          Long.toString(parseDateExpression(ctx.constant().dateExpression())));
     } else {
       basic = new BasicFunctionOperator(ctx.comparisonOperator().type.getType(), path,
-              ctx.constant().getText());
+          ctx.constant().getText());
     }
     return basic;
   }
@@ -1475,7 +1474,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       path.add(nodeName.getText());
     }
     return new Path(
-            new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
+        new StringContainer(path.toArray(new String[0]), TsFileConstant.PATH_SEPARATOR));
   }
 
   /**
@@ -1510,9 +1509,11 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       String timePrecision = IoTDBDescriptor.getInstance().getConfig().getTimestampPrecision();
       switch (timePrecision) {
         case "ns":
-          return System.currentTimeMillis() * 1000_000 + (System.nanoTime() - startupNano) % 1000_000;
+          return System.currentTimeMillis() * 1000_000
+              + (System.nanoTime() - startupNano) % 1000_000;
         case "us":
-          return System.currentTimeMillis() * 1000 + (System.nanoTime() - startupNano) / 1000 % 1000;
+          return System.currentTimeMillis() * 1000
+              + (System.nanoTime() - startupNano) / 1000 % 1000;
         default:
           return System.currentTimeMillis();
       }
@@ -1521,9 +1522,9 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       return DatetimeUtils.convertDatetimeStrToLong(timestampStr, zoneId);
     } catch (Exception e) {
       throw new SQLParserException(String
-              .format("Input time format %s error. "
-                      + "Input like yyyy-MM-dd HH:mm:ss, yyyy-MM-ddTHH:mm:ss or "
-                      + "refer to user document for more info.", timestampStr));
+          .format("Input time format %s error. "
+              + "Input like yyyy-MM-dd HH:mm:ss, yyyy-MM-ddTHH:mm:ss or "
+              + "refer to user document for more info.", timestampStr));
     }
   }
 
@@ -1535,9 +1536,9 @@ public class LogicalGenerator extends SqlBaseBaseListener {
   private long parseDeleteTimeFilter(DeleteDataOperator operator) {
     FilterOperator filterOperator = operator.getFilterOperator();
     if (filterOperator.getTokenIntType() != SQLConstant.LESSTHAN
-            && filterOperator.getTokenIntType() != SQLConstant.LESSTHANOREQUALTO) {
+        && filterOperator.getTokenIntType() != SQLConstant.LESSTHANOREQUALTO) {
       throw new SQLParserException(
-              "For delete command, where clause must be like : time < XXX or time <= XXX");
+          "For delete command, where clause must be like : time < XXX or time <= XXX");
     }
     long time = Long.parseLong(((BasicFunctionOperator) filterOperator).getValue());
     if (filterOperator.getTokenIntType() == SQLConstant.LESSTHAN) {
@@ -1589,14 +1590,14 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       case INT32:
       case INT64:
         if (!(tsEncoding.equals(TSEncoding.RLE) || tsEncoding.equals(TSEncoding.PLAIN)
-                || tsEncoding.equals(TSEncoding.TS_2DIFF))) {
+            || tsEncoding.equals(TSEncoding.TS_2DIFF))) {
           throwExp = true;
         }
         break;
       case FLOAT:
       case DOUBLE:
         if (!(tsEncoding.equals(TSEncoding.RLE) || tsEncoding.equals(TSEncoding.PLAIN)
-                || tsEncoding.equals(TSEncoding.TS_2DIFF) || tsEncoding.equals(TSEncoding.GORILLA))) {
+            || tsEncoding.equals(TSEncoding.TS_2DIFF) || tsEncoding.equals(TSEncoding.GORILLA))) {
           throwExp = true;
         }
         break;
@@ -1610,7 +1611,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     }
     if (throwExp) {
       throw new SQLParserException(
-              String.format("encoding %s does not support %s", tsEncoding, tsDataType));
+          String.format("encoding %s does not support %s", tsEncoding, tsDataType));
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/LogicalGenerator.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.runtime.SQLParserException;
@@ -47,7 +46,6 @@ import org.apache.iotdb.db.qp.logical.sys.AlterTimeSeriesOperator;
 import org.apache.iotdb.db.qp.logical.sys.AlterTimeSeriesOperator.AlterType;
 import org.apache.iotdb.db.qp.logical.sys.AuthorOperator;
 import org.apache.iotdb.db.qp.logical.sys.AuthorOperator.AuthorType;
-import org.apache.iotdb.db.qp.logical.sys.LoadConfigurationOperator.LoadConfigurationOperatorType;
 import org.apache.iotdb.db.qp.logical.sys.ClearCacheOperator;
 import org.apache.iotdb.db.qp.logical.sys.CountOperator;
 import org.apache.iotdb.db.qp.logical.sys.CreateTimeSeriesOperator;
@@ -56,6 +54,7 @@ import org.apache.iotdb.db.qp.logical.sys.DeleteStorageGroupOperator;
 import org.apache.iotdb.db.qp.logical.sys.DeleteTimeSeriesOperator;
 import org.apache.iotdb.db.qp.logical.sys.FlushOperator;
 import org.apache.iotdb.db.qp.logical.sys.LoadConfigurationOperator;
+import org.apache.iotdb.db.qp.logical.sys.LoadConfigurationOperator.LoadConfigurationOperatorType;
 import org.apache.iotdb.db.qp.logical.sys.LoadDataOperator;
 import org.apache.iotdb.db.qp.logical.sys.LoadFilesOperator;
 import org.apache.iotdb.db.qp.logical.sys.MergeOperator;
@@ -165,14 +164,11 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.common.Path;
 import org.apache.iotdb.tsfile.utils.StringContainer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is a listener and you can get an operator which is a logical plan.
  */
 public class LogicalGenerator extends SqlBaseBaseListener {
-  private static Logger logger = LoggerFactory.getLogger(LogicalGenerator.class);
 
   private RootOperator initializedOperator = null;
   private ZoneId zoneId;
@@ -1058,7 +1054,7 @@ public class LogicalGenerator extends SqlBaseBaseListener {
     List<String> measurementList = new ArrayList<>();
     for (NodeNameWithoutStarContext nodeNameWithoutStar : nodeNamesWithoutStar) {
       String measurement = nodeNameWithoutStar.getText();
-      if (measurement.contains("\"") || measurement.contains("\'")) {
+      if (measurement.contains("\"") || measurement.contains("'")) {
         measurement = measurement.substring(1, measurement.length() - 1);
       }
       measurementList.add(measurement);
@@ -1358,6 +1354,13 @@ public class LogicalGenerator extends SqlBaseBaseListener {
       value = propertyValueContext.getText();
     }
     operator.setValue(value);
+  }
+
+  @Override
+  public void enterOrderByHeatClause(SqlBaseParser.OrderByHeatClauseContext ctx) {
+    super.enterOrderByHeatClause(ctx);
+    ShowTimeSeriesOperator operator = (ShowTimeSeriesOperator) initializedOperator;
+    operator.setOrderByHeat(true);
   }
 
   private FilterOperator parseOrExpression(OrExpressionContext ctx) {

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSortedShowTimeseriesIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSortedShowTimeseriesIT.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.jdbc.Config;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IoTDBSortedShowTimeseriesIT {
+
+  private static String[] sqls = new String[]{
+      "SET STORAGE GROUP TO root.turbine",
+
+      "create timeseries root.turbine.d0.s0(temperature) with datatype=FLOAT, encoding=RLE, compression=SNAPPY " +
+          "tags(unit=f, description='turbine this is a test1') attributes(H_Alarm=100, M_Alarm=50)",
+
+      "create timeseries root.turbine.d0.s1(power) with datatype=FLOAT, encoding=RLE, compression=SNAPPY " +
+          "tags(unit=kw, description='turbine this is a test2') attributes(H_Alarm=99.9, M_Alarm=44.4)",
+
+      "create timeseries root.turbine.d0.s2(cpu) with datatype=FLOAT, encoding=RLE, compression=SNAPPY " +
+          "tags(unit=cores, description='turbine this is a cpu') attributes(H_Alarm=99.9, M_Alarm=44.4)",
+
+      "create timeseries root.turbine.d0.s3(gpu0) with datatype=FLOAT, encoding=RLE, compression=SNAPPY " +
+          "tags(unit=cores, description='turbine this is a gpu') attributes(H_Alarm=99.9, M_Alarm=44.4)",
+
+      "create timeseries root.turbine.d0.s4(tpu0) with datatype=FLOAT, encoding=RLE, compression=SNAPPY " +
+          "tags(unit=cores, description='turbine this is a tpu') attributes(H_Alarm=99.9, M_Alarm=44.4)",
+
+      "create timeseries root.turbine.d1.s0(status) with datatype=INT32, encoding=RLE " +
+          "tags(description='turbine this is a test3') attributes(H_Alarm=9, M_Alarm=5)",
+
+      "create timeseries root.turbine.d2.s0(temperature) with datatype=FLOAT, encoding=RLE, compression=SNAPPY " +
+          "tags(unit=f, description='turbine d2 this is a test1') attributes(MaxValue=100, MinValue=1)",
+
+      "create timeseries root.turbine.d2.s1(power) with datatype=FLOAT, encoding=RLE, compression=SNAPPY " +
+          "tags(unit=kw, description='turbine d2 this is a test2') attributes(MaxValue=99.9, MinValue=44.4)",
+
+      "create timeseries root.turbine.d2.s3(status) with datatype=INT32, encoding=RLE " +
+          "tags(description='turbine d2 this is a test3') attributes(MaxValue=9, MinValue=5)",
+
+      "create timeseries root.ln.d0.s0(temperature) with datatype=FLOAT, encoding=RLE, compression=SNAPPY " +
+          "tags(unit=c, description='ln this is a test1') attributes(H_Alarm=1000, M_Alarm=500)",
+
+      "create timeseries root.ln.d0.s1(power) with datatype=FLOAT, encoding=RLE, compression=SNAPPY " +
+          "tags(unit=w, description='ln this is a test2') attributes(H_Alarm=9.9, M_Alarm=4.4)",
+
+      "create timeseries root.ln.d1.s0(status) with datatype=INT32, encoding=RLE " +
+          "tags(description='ln this is a test3') attributes(H_Alarm=90, M_Alarm=50)",
+
+      "insert into root.turbine.d0(timestamp,s0) values(1, 1)",
+      "insert into root.turbine.d0(timestamp,s1) values(2, 2)",
+      "insert into root.turbine.d0(timestamp,s2) values(3, 3)",
+      "insert into root.turbine.d0(timestamp,s3) values(4, 4)",
+      "insert into root.turbine.d0(timestamp,s4) values(5, 5)",
+      "insert into root.turbine.d1(timestamp,s0) values(1, 11)",
+      "insert into root.turbine.d2(timestamp,s0,s1,s3) values(6,6,6,6)"
+  };
+
+  @Before
+  public void setUp() throws Exception {
+    EnvironmentUtils.closeStatMonitor();
+    EnvironmentUtils.envSetUp();
+    createSchema();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void showTimeseriesOrderByHeatTest1() throws ClassNotFoundException {
+    String[] retArray1 = new String[]{
+        "root.turbine.d0.s0,temperature,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a test1,100,50,null,null,f",
+        "root.turbine.d0.s1,power,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a test2,99.9,44.4,null,null,kw",
+        "root.turbine.d0.s2,cpu,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a cpu,99.9,44.4,null,null,cores",
+        "root.turbine.d0.s3,gpu0,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a gpu,99.9,44.4,null,null,cores",
+        "root.turbine.d0.s4,tpu0,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a tpu,99.9,44.4,null,null,cores",
+        "root.turbine.d1.s0,status,root.turbine,INT32,RLE,SNAPPY,turbine this is a test3,9,5,null,null,null",
+        "root.turbine.d2.s0,temperature,root.turbine,FLOAT,RLE,SNAPPY,turbine d2 this is a test1,null,null,100,1,f",
+        "root.turbine.d2.s1,power,root.turbine,FLOAT,RLE,SNAPPY,turbine d2 this is a test2,null,null,99.9,44.4,kw",
+        "root.turbine.d2.s3,status,root.turbine,INT32,RLE,SNAPPY,turbine d2 this is a test3,null,null,9,5,null",
+        "root.ln.d0.s0,temperature,root.ln,FLOAT,RLE,SNAPPY,ln this is a test1,1000,500,null,null,c",
+        "root.ln.d0.s1,power,root.ln,FLOAT,RLE,SNAPPY,ln this is a test2,9.9,4.4,null,null,w",
+        "root.ln.d1.s0,status,root.ln,INT32,RLE,SNAPPY,ln this is a test3,90,50,null,null,null"
+    };
+
+    String[] retArray2 = new String[]{
+        "root.turbine.d2.s0,temperature,root.turbine,FLOAT,RLE,SNAPPY,turbine d2 this is a test1,null,null,100,1,f",
+        "root.turbine.d2.s1,power,root.turbine,FLOAT,RLE,SNAPPY,turbine d2 this is a test2,null,null,99.9,44.4,kw",
+        "root.turbine.d2.s3,status,root.turbine,INT32,RLE,SNAPPY,turbine d2 this is a test3,null,null,9,5,null",
+        "root.turbine.d0.s4,tpu0,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a tpu,99.9,44.4,null,null,cores",
+        "root.turbine.d0.s3,gpu0,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a gpu,99.9,44.4,null,null,cores",
+        "root.turbine.d0.s2,cpu,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a cpu,99.9,44.4,null,null,cores",
+        "root.turbine.d0.s1,power,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a test2,99.9,44.4,null,null,kw",
+        "root.turbine.d0.s0,temperature,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a test1,100,50,null,null,f",
+        "root.turbine.d1.s0,status,root.turbine,INT32,RLE,SNAPPY,turbine this is a test3,9,5,null,null,null",
+        "root.ln.d0.s0,temperature,root.ln,FLOAT,RLE,SNAPPY,ln this is a test1,1000,500,null,null,c",
+        "root.ln.d0.s1,power,root.ln,FLOAT,RLE,SNAPPY,ln this is a test2,9.9,4.4,null,null,w",
+        "root.ln.d1.s0,status,root.ln,INT32,RLE,SNAPPY,ln this is a test3,90,50,null,null,null",
+    };
+
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      boolean hasResultSet = statement.execute("show timeseries");
+      Assert.assertTrue(hasResultSet);
+      ResultSet resultSet = statement.getResultSet();
+      int count = 0;
+      while (resultSet.next()) {
+        String ans = resultSet.getString("timeseries")
+            + "," + resultSet.getString("alias")
+            + "," + resultSet.getString("storage group")
+            + "," + resultSet.getString("dataType")
+            + "," + resultSet.getString("encoding")
+            + "," + resultSet.getString("compression")
+            + "," + resultSet.getString("description")
+            + "," + resultSet.getString("H_Alarm")
+            + "," + resultSet.getString("M_Alarm")
+            + "," + resultSet.getString("MaxValue")
+            + "," + resultSet.getString("MinValue")
+            + "," + resultSet.getString("unit");
+
+        assertEquals(retArray1[count], ans);
+        count++;
+      }
+      assertEquals(retArray1.length, count);
+
+      hasResultSet = statement.execute("show timeseries order by heat");
+      Assert.assertTrue(hasResultSet);
+      resultSet = statement.getResultSet();
+      count = 0;
+      while (resultSet.next()) {
+        String ans = resultSet.getString("timeseries")
+            + "," + resultSet.getString("alias")
+            + "," + resultSet.getString("storage group")
+            + "," + resultSet.getString("dataType")
+            + "," + resultSet.getString("encoding")
+            + "," + resultSet.getString("compression")
+            + "," + resultSet.getString("description")
+            + "," + resultSet.getString("H_Alarm")
+            + "," + resultSet.getString("M_Alarm")
+            + "," + resultSet.getString("MaxValue")
+            + "," + resultSet.getString("MinValue")
+            + "," + resultSet.getString("unit");
+
+        System.out.println("\"" + ans + "\",");
+        assertEquals(retArray2[count], ans);
+        count++;
+      }
+      assertEquals(retArray2.length, count);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void showTimeseriesOrderByHeatWithLimitTest() throws ClassNotFoundException {
+
+    String[] retArray = new String[]{
+        "root.turbine.d2.s0,temperature,root.turbine,FLOAT,RLE,SNAPPY,turbine d2 this is a test1,null,null,100,1,f",
+        "root.turbine.d2.s1,power,root.turbine,FLOAT,RLE,SNAPPY,turbine d2 this is a test2,null,null,99.9,44.4,kw",
+        "root.turbine.d2.s3,status,root.turbine,INT32,RLE,SNAPPY,turbine d2 this is a test3,null,null,9,5,null",
+        "root.turbine.d0.s4,tpu0,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a tpu,99.9,44.4,null,null,cores",
+        "root.turbine.d0.s3,gpu0,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a gpu,99.9,44.4,null,null,cores",
+    };
+
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      boolean hasResultSet = statement.execute("show timeseries order by heat limit 5");
+      Assert.assertTrue(hasResultSet);
+      ResultSet resultSet = statement.getResultSet();
+      int count = 0;
+      while (resultSet.next()) {
+        String ans = resultSet.getString("timeseries")
+            + "," + resultSet.getString("alias")
+            + "," + resultSet.getString("storage group")
+            + "," + resultSet.getString("dataType")
+            + "," + resultSet.getString("encoding")
+            + "," + resultSet.getString("compression")
+            + "," + resultSet.getString("description")
+            + "," + resultSet.getString("H_Alarm")
+            + "," + resultSet.getString("M_Alarm")
+            + "," + resultSet.getString("MaxValue")
+            + "," + resultSet.getString("MinValue")
+            + "," + resultSet.getString("unit");
+
+        assertEquals(retArray[count], ans);
+        count++;
+      }
+      assertEquals(retArray.length, count);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void showTimeseriesOrderByHeatWithWhereTest() throws ClassNotFoundException {
+
+    String[] retArray = new String[]{
+        "root.turbine.d0.s4,tpu0,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a tpu,99.9,44.4,cores",
+        "root.turbine.d0.s3,gpu0,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a gpu,99.9,44.4,cores",
+        "root.turbine.d0.s2,cpu,root.turbine,FLOAT,RLE,SNAPPY,turbine this is a cpu,99.9,44.4,cores",
+    };
+
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      boolean hasResultSet = statement.execute("show timeseries where unit=cores order by heat");
+      Assert.assertTrue(hasResultSet);
+      ResultSet resultSet = statement.getResultSet();
+      int count = 0;
+      while (resultSet.next()) {
+        String ans = resultSet.getString("timeseries")
+            + "," + resultSet.getString("alias")
+            + "," + resultSet.getString("storage group")
+            + "," + resultSet.getString("dataType")
+            + "," + resultSet.getString("encoding")
+            + "," + resultSet.getString("compression")
+            + "," + resultSet.getString("description")
+            + "," + resultSet.getString("H_Alarm")
+            + "," + resultSet.getString("M_Alarm")
+            + "," + resultSet.getString("unit");
+
+        assertEquals(retArray[count], ans);
+        count++;
+      }
+      assertEquals(retArray.length, count);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  private void createSchema() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      for (String sql : sqls) {
+        statement.execute(sql);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+}

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSortedShowTimeseriesIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSortedShowTimeseriesIT.java
@@ -154,7 +154,7 @@ public class IoTDBSortedShowTimeseriesIT {
       }
       assertEquals(retArray1.length, count);
 
-      hasResultSet = statement.execute("show timeseries order by heat");
+      hasResultSet = statement.execute("show LATEST timeseries");
       Assert.assertTrue(hasResultSet);
       resultSet = statement.getResultSet();
       count = 0;
@@ -200,7 +200,7 @@ public class IoTDBSortedShowTimeseriesIT {
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
 
-      boolean hasResultSet = statement.execute("show timeseries order by heat limit 5");
+      boolean hasResultSet = statement.execute("show LATEST timeseries limit 5");
       Assert.assertTrue(hasResultSet);
       ResultSet resultSet = statement.getResultSet();
       int count = 0;
@@ -243,7 +243,7 @@ public class IoTDBSortedShowTimeseriesIT {
         .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/", "root", "root");
         Statement statement = connection.createStatement()) {
 
-      boolean hasResultSet = statement.execute("show timeseries where unit=cores order by heat");
+      boolean hasResultSet = statement.execute("show LATEST timeseries where unit=cores");
       Assert.assertTrue(hasResultSet);
       ResultSet resultSet = statement.getResultSet();
       int count = 0;


### PR DESCRIPTION
The 'orderByHeatClause' is added to support this feature. The detailed syntax is:


orderByHeatClause
    : ORDER BY HEAT
    ;


It's an optional clause, if user doesn't specify it. The action of 'show timeseries' will just be like before, the result set is sorted by the registered time of the time series.


If it is specified, firstly we will obtain all the satisfying timeseries as before, then we will sort them by the last point's timestamp. That means if the timeseries is inserted recently, it will be shown in the front. 


In the implementation, as we have got the LeafMNode before, so we can use the cachedLastValuePair field in it to get last timestamp, if the cachedLastValuePair is null, we will construct a LastQueryPlan to get it.