### PR TITLE
[IOTDB-761]cherry-picked from v0.10: flink-tsfile-connecto and flink-example dependency conflict: "Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed"

### DIFF
--- a/example/flink/pom.xml
+++ b/example/flink/pom.xml
@@ -35,6 +35,14 @@
             <groupId>org.apache.iotdb</groupId>
             <artifactId>flink-iotdb-connector</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <!-- org.apache.iotdb:hadoop-tsfile uses hadoop-common:2.7.3, which uses commons-compress:1.4.1-->
+                <!-- flink-java uses commons-compress:1.18-->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>

--- a/flink-tsfile-connector/pom.xml
+++ b/flink-tsfile-connector/pom.xml
@@ -39,11 +39,26 @@
             <groupId>org.apache.iotdb</groupId>
             <artifactId>hadoop-tsfile</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <!-- flink-java uses commons-math3:3.3.5 while hadoop uses 3.1.1-->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-math3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-java</artifactId>
             <version>${flink.version}</version>
+            <exclusions>
+                <!-- org.apache.iotdb:hadoop-tsfile uses hadoop-common:2.7.3, which uses commons-compress:1.4.1-->
+                <!-- flink-java uses commons-compress:1.18-->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-tsfile-connector/pom.xml
+++ b/flink-tsfile-connector/pom.xml
@@ -64,6 +64,14 @@
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java_2.11</artifactId>
             <version>${flink.version}</version>
+            <exclusions>
+                <!-- org.apache.iotdb:hadoop-tsfile uses hadoop-common:2.7.3, which uses commons-compress:1.4.1-->
+                <!-- flink-java uses commons-compress:1.18-->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
There are two dependency conflicts that cause the maven failure:

Flink 1.10 uses commons-compress 1.18 while hadoop-tsfile (Hadoop 2.7.3) module uses 1.4.1;
Flink 1.10 uses commons-math3 3.1.1 while hadoop-tsfile (Hadoop 2.7.3) module uses 3.5
So, when running `mvn release:parepare`, exception message will be thrown like:

Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed.

The solution is to exclude the stale version of those dependencies.

this is 
 