### PR TITLE
[IOTDB-722] support three consistency levels: strong, mid and weak

### DIFF
--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -72,6 +72,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.iotdb</groupId>
+            <artifactId>iotdb-jdbc</artifactId>
+            <version>0.10.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
         </dependency>

--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -67,3 +67,11 @@ MAX_NUMBER_OF_LOGS=100
 # deletion check period of the submitted log
 LOG_DELETION_CHECK_INTERVAL_SECOND=3600
 
+# consistency level, now three consistency levels are supported: strong, mid and weak.
+# Strong consistency means the server will first try to synchronize with the leader to get the
+# newest meta data, if failed(timeout), directly report an error to the user;
+# While mid consistency means the server will first try to synchronize with the leader,
+# but if failed(timeout), it will give up and just use current data it has cached before;
+# Weak consistency do not synchronize with the leader and simply use the local data
+CONSISTENCY_LEVEL=mid
+

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
@@ -74,6 +74,16 @@ public class ClusterConfig {
    */
   private int selectorNumOfClientPool = 10;
 
+  /**
+   * consistency level, now three consistency levels are supported: strong, mid and weak. Strong
+   * consistency means the server will first try to synchronize with the leader to get the newest
+   * meta data, if failed(timeout), directly report an error to the user; While mid consistency
+   * means the server will first try to synchronize with the leader, but if failed(timeout), it will
+   * give up and just use current data it has cached before; Weak consistency do not synchronize
+   * with the leader and simply use the local data
+   */
+  private ConsistencyLevel consistencyLevel = ConsistencyLevel.MID_CONSISTENCY;
+
   public int getSelectorNumOfClientPool() {
     return selectorNumOfClientPool;
   }
@@ -200,5 +210,13 @@ public class ClusterConfig {
 
   public void setLogDeleteCheckIntervalSecond(int logDeleteCheckIntervalSecond) {
     this.logDeleteCheckIntervalSecond = logDeleteCheckIntervalSecond;
+  }
+
+  public ConsistencyLevel getConsistencyLevel() {
+    return consistencyLevel;
+  }
+
+  public void setConsistencyLevel(ConsistencyLevel consistencyLevel) {
+    this.consistencyLevel = consistencyLevel;
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
@@ -31,7 +31,9 @@ public class ClusterConfig {
   private int localDataPort = 40010;
   private int localClientPort = 55560;
 
-  // each one is a "<IP | domain name>:<meta port>:<data port>" string tuple
+  /**
+   * each one is a "<IP | domain name>:<meta port>:<data port>" string tuple
+   */
   private List<String> seedNodeUrls = Arrays.asList("127.0.0.1:9003:40010", "127.0.0.1"
       + ":9004:40011", "127.0.0.1:9005:40012");
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -235,7 +235,6 @@ public class ClusterDescriptor {
     }
   }
 
-
   private List<String> getSeedUrlList(String seedUrls) {
     if (seedUrls == null) {
       return null;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -223,12 +223,18 @@ public class ClusterDescriptor {
         .getProperty("LOG_DELETION_CHECK_INTERVAL_SECOND",
             String.valueOf(config.getLogDeleteCheckIntervalSecond()))));
 
+    String consistencyLevel = properties.getProperty("CONSISTENCY_LEVEL");
+    if (consistencyLevel != null) {
+      config.setConsistencyLevel(ConsistencyLevel.getConsistencyLevel(consistencyLevel));
+    }
+
     String seedUrls = properties.getProperty("SEED_NODES");
     if (seedUrls != null) {
       List<String> urlList = getSeedUrlList(seedUrls);
       config.setSeedNodeUrls(urlList);
     }
   }
+
 
   private List<String> getSeedUrlList(String seedUrls) {
     if (seedUrls == null) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ConsistencyLevel.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ConsistencyLevel.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.cluster.config;
+
+
+public enum ConsistencyLevel {
+  /**
+   * Strong consistency means the server will first try to synchronize with the leader to get the
+   * newest meta data, if failed(timeout), directly report an error to the user;
+   */
+  STRONG_CONSISTENCY("strong"),
+
+  /**
+   * mid consistency means the server will first try to synchronize with the leader, but if
+   * failed(timeout), it will give up and just use current data it has cached before;
+   */
+  MID_CONSISTENCY("mid"),
+
+  /**
+   * weak consistency do not synchronize with the leader and simply use the local data
+   */
+  WEAK_CONSISTENCY("weak"),
+  ;
+
+  private String consistencyLevel;
+
+  ConsistencyLevel(String consistencyLevel) {
+    this.consistencyLevel = consistencyLevel;
+  }
+
+
+  public static ConsistencyLevel getConsistencyLevel(String consistencyLevel) {
+    if (consistencyLevel == null) {
+      return ConsistencyLevel.MID_CONSISTENCY;
+    }
+    switch (consistencyLevel.toLowerCase()) {
+      case "strong":
+        return ConsistencyLevel.STRONG_CONSISTENCY;
+      case "mid":
+        return ConsistencyLevel.MID_CONSISTENCY;
+      case "weak":
+        return ConsistencyLevel.WEAK_CONSISTENCY;
+      default:
+        return ConsistencyLevel.MID_CONSISTENCY;
+    }
+  }
+
+}

--- a/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
@@ -23,6 +23,7 @@ package org.apache.iotdb.cluster.exception;
  * syncLeader failed
  */
 public class CheckConsistencyException extends Exception {
+
   public CheckConsistencyException(String errMag) {
     super(String.format("check consistency failed, error message=%s ", errMag));
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.cluster.exception;
+
+/**
+ * Raised when check consistency failed, now only happens if there is a strong-consistency and
+ * syncLeader failed
+ */
+public class CheckConsistencyException extends Exception {
+
+  public CheckConsistencyException(String errMag) {
+    super(String.format("check consistency failed, error message %s ", errMag));
+  }
+}

--- a/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
@@ -25,6 +25,6 @@ package org.apache.iotdb.cluster.exception;
 public class CheckConsistencyException extends Exception {
 
   public CheckConsistencyException(String errMag) {
-    super(String.format("check consistency failed, error message %s ", errMag));
+    super(String.format("check consistency failed, error message=%s ", errMag));
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
@@ -23,7 +23,6 @@ package org.apache.iotdb.cluster.exception;
  * syncLeader failed
  */
 public class CheckConsistencyException extends Exception {
-
   public CheckConsistencyException(String errMag) {
     super(String.format("check consistency failed, error message=%s ", errMag));
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
@@ -26,4 +26,7 @@ public class CheckConsistencyException extends Exception {
   public CheckConsistencyException(String errMag) {
     super(String.format("check consistency failed, error message=%s ", errMag));
   }
+
+  public static CheckConsistencyException CHECK_STRONG_CONSISTENCY_EXCEPTION = new CheckConsistencyException(
+      "strong consistency, sync with leader failed");
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/BaseApplier.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/BaseApplier.java
@@ -65,8 +65,8 @@ abstract class BaseApplier implements LogApplier {
         if (e.getCause() instanceof StorageGroupNotSetException) {
           try {
             metaGroupMember.syncLeaderWithConsistencyCheck();
-          } catch (CheckConsistencyException checkConsistencyException) {
-            throw e;
+          } catch (CheckConsistencyException ce) {
+            throw new QueryProcessException(ce.getMessage());
           }
           getQueryExecutor().processNonQuery(plan);
         } else {
@@ -108,8 +108,8 @@ abstract class BaseApplier implements LogApplier {
       } else if (causedByStorageGroupNotSet) {
         try {
           metaGroupMember.syncLeaderWithConsistencyCheck();
-        } catch (CheckConsistencyException checkConsistencyException) {
-          throw new QueryProcessException(checkConsistencyException.getMessage());
+        } catch (CheckConsistencyException ce) {
+          throw new QueryProcessException(ce.getMessage());
         }
         getQueryExecutor().processNonQuery(plan);
       } else {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/DataLogApplier.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/DataLogApplier.java
@@ -102,8 +102,8 @@ public class DataLogApplier extends BaseApplier {
       // synchronization
       try {
         metaGroupMember.syncLeaderWithConsistencyCheck();
-      } catch (CheckConsistencyException checkConsistencyException) {
-        throw new QueryProcessException(checkConsistencyException.getMessage());
+      } catch (CheckConsistencyException ce) {
+        throw new QueryProcessException(ce.getMessage());
       }
       if (plan instanceof InsertPlan) {
         InsertPlan insertPlan = (InsertPlan) plan;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/query/ClusterPlanExecutor.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iotdb.cluster.client.async.DataClient;
 import org.apache.iotdb.cluster.client.sync.SyncClientAdaptor;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
+import org.apache.iotdb.cluster.exception.CheckConsistencyException;
 import org.apache.iotdb.cluster.partition.PartitionGroup;
 import org.apache.iotdb.cluster.query.dataset.ClusterAlignByDeviceDataSet;
 import org.apache.iotdb.cluster.query.filter.SlotSgFilter;
@@ -97,16 +98,24 @@ public class ClusterPlanExecutor extends PlanExecutor {
 
   @Override
   public QueryDataSet processQuery(PhysicalPlan queryPlan, QueryContext context)
-          throws IOException, StorageEngineException, QueryFilterOptimizationException, QueryProcessException,
-          MetadataException {
+      throws IOException, StorageEngineException, QueryFilterOptimizationException, QueryProcessException,
+      MetadataException {
     if (queryPlan instanceof QueryPlan) {
       logger.debug("Executing a query: {}", queryPlan);
       return processDataQuery((QueryPlan) queryPlan, context);
     } else if (queryPlan instanceof ShowPlan) {
-      metaGroupMember.syncLeader();
+      try {
+        metaGroupMember.syncLeaderWithConsistencyCheck();
+      } catch (CheckConsistencyException e) {
+        throw new QueryProcessException(e.getMessage());
+      }
       return processShowQuery((ShowPlan) queryPlan);
     } else if (queryPlan instanceof AuthorPlan) {
-      metaGroupMember.syncLeader();
+      try {
+        metaGroupMember.syncLeaderWithConsistencyCheck();
+      } catch (CheckConsistencyException e) {
+        throw new QueryProcessException(e.getMessage());
+      }
       return processAuthorQuery((AuthorPlan) queryPlan);
     } else {
       throw new QueryProcessException(String.format("Unrecognized query plan %s", queryPlan));
@@ -121,7 +130,11 @@ public class ClusterPlanExecutor extends PlanExecutor {
   @Override
   protected int getPathsNum(String path) throws MetadataException {
     // make sure this node knows all storage groups
-    metaGroupMember.syncLeader();
+    try {
+      metaGroupMember.syncLeaderWithConsistencyCheck();
+    } catch (CheckConsistencyException e) {
+      throw new MetadataException(e.getMessage());
+    }
     // get all storage groups this path may belong to
     // the key is the storage group name and the value is the path to be queried with storage group
     // added, e.g:
@@ -129,7 +142,12 @@ public class ClusterPlanExecutor extends PlanExecutor {
     // "root.group1" -> "root.group1.*", "root.group2" -> "root.group2.*" ...
     Map<String, String> sgPathMap = MManager.getInstance().determineStorageGroup(path);
     logger.debug("The storage groups of path {} are {}", path, sgPathMap.keySet());
-    int ret = getPathCount(sgPathMap, -1);
+    int ret = 0;
+    try {
+      ret = getPathCount(sgPathMap, -1);
+    } catch (CheckConsistencyException e) {
+      throw new MetadataException(e.getMessage());
+    }
     logger.debug("The number of paths satisfying {} is {}", path, ret);
     return ret;
   }
@@ -137,7 +155,11 @@ public class ClusterPlanExecutor extends PlanExecutor {
   @Override
   protected int getNodesNumInGivenLevel(String path, int level) throws MetadataException {
     // make sure this node knows all storage groups
-    metaGroupMember.syncLeader();
+    try {
+      metaGroupMember.syncLeaderWithConsistencyCheck();
+    } catch (CheckConsistencyException e) {
+      throw new MetadataException(e.getMessage());
+    }
     // get all storage groups this path may belong to
     // the key is the storage group name and the value is the path to be queried with storage group
     // added, e.g:
@@ -145,7 +167,12 @@ public class ClusterPlanExecutor extends PlanExecutor {
     // "root.group1" -> "root.group1.*", "root.group2" -> "root.group2.*" ...
     Map<String, String> sgPathMap = MManager.getInstance().determineStorageGroup(path);
     logger.debug("The storage groups of path {} are {}", path, sgPathMap.keySet());
-    int ret = getPathCount(sgPathMap, level);
+    int ret = 0;
+    try {
+      ret = getPathCount(sgPathMap, level);
+    } catch (CheckConsistencyException e) {
+      throw new MetadataException(e.getMessage());
+    }
     logger.debug("The number of paths satisfying {}@{} is {}", path, level, ret);
     return ret;
   }
@@ -155,12 +182,12 @@ public class ClusterPlanExecutor extends PlanExecutor {
    *
    * @param sgPathMap the key is the storage group name and the value is the path to be queried with
    *                  storage group added
-   * @param level the max depth to match the pattern, -1 means matching the whole pattern
+   * @param level     the max depth to match the pattern, -1 means matching the whole pattern
    * @return the number of paths that match the pattern at given level
    * @throws MetadataException
    */
   private int getPathCount(Map<String, String> sgPathMap, int level)
-      throws MetadataException {
+      throws MetadataException, CheckConsistencyException {
     AtomicInteger result = new AtomicInteger();
     // split the paths by the data group they belong to
     Map<PartitionGroup, List<String>> groupPathMap = new HashMap<>();
@@ -168,11 +195,13 @@ public class ClusterPlanExecutor extends PlanExecutor {
       String storageGroupName = sgPathEntry.getKey();
       String pathUnderSG = sgPathEntry.getValue();
       // find the data group that should hold the timeseries schemas of the storage group
-      PartitionGroup partitionGroup = metaGroupMember.getPartitionTable().route(storageGroupName, 0);
+      PartitionGroup partitionGroup = metaGroupMember.getPartitionTable()
+          .route(storageGroupName, 0);
       if (partitionGroup.contains(metaGroupMember.getThisNode())) {
         // this node is a member of the group, perform a local query after synchronizing with the
         // leader
-        metaGroupMember.getLocalDataMember(partitionGroup.getHeader()).syncLeader();
+        metaGroupMember.getLocalDataMember(partitionGroup.getHeader())
+            .syncLeaderWithConsistencyCheck();
         int localResult = getLocalPathCount(pathUnderSG, level);
         logger.debug("{}: get path count of {} locally, result {}", metaGroupMember.getName(),
             partitionGroup, localResult);
@@ -234,7 +263,8 @@ public class ClusterPlanExecutor extends PlanExecutor {
     return localResult;
   }
 
-  private int getRemotePathCount(PartitionGroup partitionGroup, List<String> pathsToQuery, int level)
+  private int getRemotePathCount(PartitionGroup partitionGroup, List<String> pathsToQuery,
+      int level)
       throws MetadataException {
     // choose the node with lowest latency or highest throughput
     List<Node> coordinatedNodes = QueryCoordinator.getINSTANCE().reorderNodes(partitionGroup);
@@ -265,21 +295,35 @@ public class ClusterPlanExecutor extends PlanExecutor {
   }
 
   @Override
-  protected List<String> getNodesList(String schemaPattern, int level) {
+  protected List<String> getNodesList(String schemaPattern, int level) throws MetadataException {
 
     ConcurrentSkipListSet<String> nodeSet = new ConcurrentSkipListSet<>();
     ExecutorService pool = new ScheduledThreadPoolExecutor(THREAD_POOL_SIZE);
 
+    List<Future> futureList = new ArrayList<>();
     for (PartitionGroup group : metaGroupMember.getPartitionTable().getGlobalGroups()) {
-      pool.submit(() -> {
-        List<String> paths = getNodesList(group, schemaPattern, level);
+      futureList.add(pool.submit(() -> {
+        List<String> paths = null;
+        try {
+          paths = getNodesList(group, schemaPattern, level);
+        } catch (CheckConsistencyException e) {
+          throw new RuntimeException(e);
+        }
         if (paths != null) {
           nodeSet.addAll(paths);
         } else {
           logger.error("Fail to get node list of {}@{} from {}", schemaPattern, level, group);
         }
-      });
+      }));
     }
+    for (Future future : futureList) {
+      try {
+        future.get();
+      } catch (RuntimeException | InterruptedException | ExecutionException e) {
+        throw new MetadataException(e.getMessage());
+      }
+    }
+
     pool.shutdown();
     try {
       pool.awaitTermination(WAIT_REMOTE_QUERY_TIME, WAIT_REMOTE_QUERY_TIME_UNIT);
@@ -291,7 +335,7 @@ public class ClusterPlanExecutor extends PlanExecutor {
   }
 
   private List<String> getNodesList(PartitionGroup group, String schemaPattern,
-      int level) {
+      int level) throws CheckConsistencyException {
     if (group.contains(metaGroupMember.getThisNode())) {
       return getLocalNodesList(group, schemaPattern, level);
     } else {
@@ -300,15 +344,16 @@ public class ClusterPlanExecutor extends PlanExecutor {
   }
 
   private List<String> getLocalNodesList(PartitionGroup group, String schemaPattern,
-      int level) {
+      int level) throws CheckConsistencyException {
     Node header = group.getHeader();
     DataGroupMember localDataMember = metaGroupMember.getLocalDataMember(header);
-    localDataMember.syncLeader();
+    localDataMember.syncLeaderWithConsistencyCheck();
     try {
       return MManager.getInstance().getNodesList(schemaPattern, level,
           new SlotSgFilter(metaGroupMember.getPartitionTable().getNodeSlots(header)));
     } catch (MetadataException e) {
-      logger.error("Cannot not get node list of {}@{} from {} locally", schemaPattern, level, group);
+      logger
+          .error("Cannot not get node list of {}@{} from {} locally", schemaPattern, level, group);
       return Collections.emptyList();
     }
   }
@@ -336,20 +381,36 @@ public class ClusterPlanExecutor extends PlanExecutor {
   }
 
   @Override
-  protected Set<String> getPathNextChildren(String path) {
+  protected Set<String> getPathNextChildren(String path) throws MetadataException {
     ConcurrentSkipListSet<String> resultSet = new ConcurrentSkipListSet<>();
     ExecutorService pool = new ScheduledThreadPoolExecutor(THREAD_POOL_SIZE);
 
+    List<Future> futureList = new ArrayList<>();
+
     for (PartitionGroup group : metaGroupMember.getPartitionTable().getGlobalGroups()) {
-      pool.submit(() -> {
-        List<String> nextChildren = getNextChildren(group, path);
+      futureList.add(pool.submit(() -> {
+        List<String> nextChildren = null;
+        try {
+          nextChildren = getNextChildren(group, path);
+        } catch (CheckConsistencyException e) {
+          throw new RuntimeException(e.getMessage());
+        }
         if (nextChildren != null) {
           resultSet.addAll(nextChildren);
         } else {
           logger.error("Fail to get next children of {} from {}", path, group);
         }
-      });
+      }));
     }
+
+    for (Future future : futureList) {
+      try {
+        future.get();
+      } catch (RuntimeException | InterruptedException | ExecutionException e) {
+        throw new MetadataException(e.getMessage());
+      }
+    }
+
     pool.shutdown();
     try {
       pool.awaitTermination(WAIT_REMOTE_QUERY_TIME, WAIT_REMOTE_QUERY_TIME_UNIT);
@@ -360,7 +421,8 @@ public class ClusterPlanExecutor extends PlanExecutor {
     return resultSet;
   }
 
-  private List<String> getNextChildren(PartitionGroup group, String path) {
+  private List<String> getNextChildren(PartitionGroup group, String path)
+      throws CheckConsistencyException {
     if (group.contains(metaGroupMember.getThisNode())) {
       return getLocalNextChildren(group, path);
     } else {
@@ -368,10 +430,11 @@ public class ClusterPlanExecutor extends PlanExecutor {
     }
   }
 
-  private List<String> getLocalNextChildren(PartitionGroup group, String path) {
+  private List<String> getLocalNextChildren(PartitionGroup group, String path)
+      throws CheckConsistencyException {
     Node header = group.getHeader();
     DataGroupMember localDataMember = metaGroupMember.getLocalDataMember(header);
-    localDataMember.syncLeader();
+    localDataMember.syncLeaderWithConsistencyCheck();
     try {
       return new ArrayList<>(
           MManager.getInstance().getChildNodePathInNextLevel(path));
@@ -404,12 +467,14 @@ public class ClusterPlanExecutor extends PlanExecutor {
   }
 
   @Override
-  protected List<ShowTimeSeriesResult> showTimeseriesWithIndex(ShowTimeSeriesPlan plan) {
+  protected List<ShowTimeSeriesResult> showTimeseriesWithIndex(ShowTimeSeriesPlan plan)
+      throws MetadataException {
     return showTimeseries(plan);
   }
 
   @Override
-  protected List<ShowTimeSeriesResult> showTimeseries(ShowTimeSeriesPlan plan) {
+  protected List<ShowTimeSeriesResult> showTimeseries(ShowTimeSeriesPlan plan)
+      throws MetadataException {
     ConcurrentSkipListSet<ShowTimeSeriesResult> resultSet = new ConcurrentSkipListSet<>();
     ExecutorService pool = new ScheduledThreadPoolExecutor(THREAD_POOL_SIZE);
     List<PartitionGroup> globalGroups = metaGroupMember.getPartitionTable().getGlobalGroups();
@@ -427,9 +492,26 @@ public class ClusterPlanExecutor extends PlanExecutor {
       logger.debug("Fetch timeseries schemas of {} from {} groups", plan.getPaths(),
           globalGroups.size());
     }
+
+    List<Future> futureList = new ArrayList<>();
     for (PartitionGroup group : globalGroups) {
-      pool.submit(() -> showTimeseries(group, plan, resultSet));
+      futureList.add(pool.submit(() -> {
+        try {
+          showTimeseries(group, plan, resultSet);
+        } catch (CheckConsistencyException e) {
+          throw new RuntimeException(e.getMessage());
+        }
+      }));
     }
+
+    for (Future future : futureList) {
+      try {
+        future.get();
+      } catch (RuntimeException | InterruptedException | ExecutionException e) {
+        throw new MetadataException(e.getMessage());
+      }
+    }
+
     pool.shutdown();
     try {
       pool.awaitTermination(WAIT_REMOTE_QUERY_TIME, WAIT_REMOTE_QUERY_TIME_UNIT);
@@ -452,7 +534,7 @@ public class ClusterPlanExecutor extends PlanExecutor {
   }
 
   private void showTimeseries(PartitionGroup group, ShowTimeSeriesPlan plan,
-      Set<ShowTimeSeriesResult> resultSet) {
+      Set<ShowTimeSeriesResult> resultSet) throws CheckConsistencyException {
     if (group.contains(metaGroupMember.getThisNode())) {
       showLocalTimeseries(group, plan, resultSet);
     } else {
@@ -461,10 +543,10 @@ public class ClusterPlanExecutor extends PlanExecutor {
   }
 
   private void showLocalTimeseries(PartitionGroup group, ShowTimeSeriesPlan plan,
-      Set<ShowTimeSeriesResult> resultSet) {
+      Set<ShowTimeSeriesResult> resultSet) throws CheckConsistencyException {
     Node header = group.getHeader();
     DataGroupMember localDataMember = metaGroupMember.getLocalDataMember(header);
-    localDataMember.syncLeader();
+    localDataMember.syncLeaderWithConsistencyCheck();
     try {
       if (plan.getKey() != null && plan.getValue() != null) {
         resultSet.addAll(MManager.getInstance().getAllTimeseriesSchema(plan));
@@ -570,7 +652,7 @@ public class ClusterPlanExecutor extends PlanExecutor {
 
   @Override
   protected AlignByDeviceDataSet getAlignByDeviceDataSet(AlignByDevicePlan plan,
-                                                         QueryContext context, IQueryRouter router)
+      QueryContext context, IQueryRouter router)
       throws MetadataException {
     return new ClusterAlignByDeviceDataSet(plan, context, router, metaGroupMember);
   }
@@ -588,8 +670,8 @@ public class ClusterPlanExecutor extends PlanExecutor {
         break;
       default:
         throw new QueryProcessException(String
-                .format("Unrecognized load configuration plan type: %s",
-                        plan.getLoadConfigurationPlanType()));
+            .format("Unrecognized load configuration plan type: %s",
+                plan.getLoadConfigurationPlanType()));
     }
   }
 

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -1049,7 +1049,7 @@ public abstract class RaftMember implements RaftService.AsyncIface {
     switch (consistencyLevel) {
       case STRONG_CONSISTENCY:
         if (!syncLeader()) {
-          throw new CheckConsistencyException("strong consistency, sync with leader failed");
+          throw CheckConsistencyException.CHECK_STRONG_CONSISTENCY_EXCEPTION;
         }
         return;
       case MID_CONSISTENCY:
@@ -1060,6 +1060,7 @@ public abstract class RaftMember implements RaftService.AsyncIface {
         // do nothing
         return;
       default:
+        // this should not happen in theory
         throw new CheckConsistencyException("unknown consistency" + consistencyLevel.name());
     }
   }

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/applier/DataLogApplierTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/applier/DataLogApplierTest.java
@@ -165,11 +165,12 @@ public class DataLogApplierTest extends IoTDBTest {
     insertPlan.setDeviceId(TestUtils.getTestSg(1));
     insertPlan.setTime(1);
     insertPlan.setInferType(true);
-    insertPlan.setMeasurements(new String[] {TestUtils.getTestMeasurement(0)});
+    insertPlan.setMeasurements(new String[]{TestUtils.getTestMeasurement(0)});
     insertPlan.setTypes(new TSDataType[insertPlan.getMeasurements().length]);
-    insertPlan.setValues(new Object[] {"1.0"});
+    insertPlan.setValues(new Object[]{"1.0"});
     insertPlan.setInferType(true);
-    insertPlan.setSchemasAndTransferType(new MeasurementSchema[] {TestUtils.getTestMeasurementSchema(0)});
+    insertPlan
+        .setSchemasAndTransferType(new MeasurementSchema[]{TestUtils.getTestMeasurementSchema(0)});
 
     applier.apply(log);
     QueryDataSet dataSet = query(Collections.singletonList(TestUtils.getTestSeries(1, 0)), null);
@@ -197,7 +198,9 @@ public class DataLogApplierTest extends IoTDBTest {
       applier.apply(log);
       fail("exception should be thrown");
     } catch (QueryProcessException e) {
-      assertEquals("org.apache.iotdb.db.exception.metadata.PathNotExistException: Path [root.test5.s0] does not exist", e.getMessage());
+      assertEquals(
+          "org.apache.iotdb.db.exception.metadata.PathNotExistException: Path [root.test5.s0] does not exist",
+          e.getMessage());
     }
 
     // this storage group is not even set
@@ -206,7 +209,9 @@ public class DataLogApplierTest extends IoTDBTest {
       applier.apply(log);
       fail("exception should be thrown");
     } catch (QueryProcessException e) {
-      assertEquals("org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException: Storage group is not set for current seriesPath: [root.test6.s0]", e.getMessage());
+      assertEquals(
+          "org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException: Storage group is not set for current seriesPath: [root.test6.s0]",
+          e.getMessage());
     }
   }
 
@@ -221,7 +226,7 @@ public class DataLogApplierTest extends IoTDBTest {
     int cnt = 0;
     while (dataSet.hasNext()) {
       RowRecord record = dataSet.next();
-      assertEquals(cnt + 51L , record.getTimestamp());
+      assertEquals(cnt + 51L, record.getTimestamp());
       assertEquals((cnt + 51) * 1.0, record.getFields().get(0).getDoubleV(), 0.00001);
       cnt++;
     }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -273,7 +273,7 @@ public class IoTDBStatement implements Statement {
         }
       } else {
         allSuccess =
-            allSuccess && execResp.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode();
+            allSuccess && execResp.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode();
         result[i] = execResp.getCode();
         message = execResp.getMessage();
       }

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -275,6 +275,7 @@ public class IoTDBStatement implements Statement {
         allSuccess =
             allSuccess && execResp.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode();
         result[i] = execResp.getCode();
+        message = execResp.getMessage();
       }
     }
     if (!allSuccess) {


### PR DESCRIPTION
This pr is going to support three consistency levels  strong, mid and weak. Strong consistency means the server will first try to synchronize with the leader to get the newest meta data, if failed(timeout), directly report an error to the user; While mid consistency means the server will first try to synchronize with the leader, but if failed(timeout), it will give up and just use current data it has cached before; Weak consistency do not synchronize with the leader and simply use the local data. 