### PR TITLE
[IOTDB-772] The start-server.sh uses tool long java command in WinOS

### DIFF
--- a/server/src/assembly/resources/sbin/start-server.bat
+++ b/server/src/assembly/resources/sbin/start-server.bat
@@ -94,11 +94,8 @@ set JAVA_OPTS=-ea^
 
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
-set CLASSPATH="%IOTDB_HOME%\lib"
+set CLASSPATH="%IOTDB_HOME%\lib\*"
 
-@REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
-set CLASSPATH=%CLASSPATH%;iotdb.IoTDB
 goto okClasspath
 
 :append

--- a/server/src/assembly/resources/tools/detect-watermark.bat
+++ b/server/src/assembly/resources/tools/detect-watermark.bat
@@ -38,10 +38,8 @@ set JAVA_OPTS=-ea^
 
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
-set CLASSPATH="%IOTDB_HOME%\lib"
+set CLASSPATH="%IOTDB_HOME%\lib\*"
 
-@REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
 goto okClasspath
 
 :append

--- a/server/src/assembly/resources/tools/logVisualize/log-visualizer-cmd.bat
+++ b/server/src/assembly/resources/tools/logVisualize/log-visualizer-cmd.bat
@@ -38,10 +38,8 @@ set JAVA_OPTS=-ea^
 
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
-set CLASSPATH="%IOTDB_HOME%\lib"
+set CLASSPATH="%IOTDB_HOME%\lib\*"
 
-@REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
 goto okClasspath
 
 :append

--- a/server/src/assembly/resources/tools/logVisualize/log-visualizer-gui.bat
+++ b/server/src/assembly/resources/tools/logVisualize/log-visualizer-gui.bat
@@ -38,10 +38,8 @@ set JAVA_OPTS=-ea^
 
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
-set CLASSPATH="%IOTDB_HOME%\lib"
+set CLASSPATH="%IOTDB_HOME%\lib\*"
 
-@REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
 goto okClasspath
 
 :append

--- a/server/src/assembly/resources/tools/memory-tool.bat
+++ b/server/src/assembly/resources/tools/memory-tool.bat
@@ -38,10 +38,8 @@ set JAVA_OPTS=-ea^
 
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
-set CLASSPATH="%IOTDB_HOME%\lib"
+set CLASSPATH="%IOTDB_HOME%\lib\*"
 
-@REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
 goto okClasspath
 
 :append

--- a/server/src/assembly/resources/tools/start-WalChecker.bat
+++ b/server/src/assembly/resources/tools/start-WalChecker.bat
@@ -70,11 +70,8 @@ set JAVA_OPTS=-ea^
 
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
-set CLASSPATH="%IOTDB_HOME%\lib"
+set CLASSPATH="%IOTDB_HOME%\lib\*"
 
-REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
-set CLASSPATH=%CLASSPATH%;WalChecker
 goto okClasspath
 
 :append

--- a/server/src/assembly/resources/tools/start-sync-client.bat
+++ b/server/src/assembly/resources/tools/start-sync-client.bat
@@ -42,11 +42,8 @@ set JAVA_OPTS=-ea^
 
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
-set CLASSPATH="%IOTDB_HOME%\lib"
+set CLASSPATH="%IOTDB_HOME%\lib\*"
 
-@REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
-set CLASSPATH=%CLASSPATH%;SyncClient
 goto okClasspath
 
 :append

--- a/server/src/assembly/resources/tools/tsfileToolSet/print-iotdb-data-dir.bat
+++ b/server/src/assembly/resources/tools/tsfileToolSet/print-iotdb-data-dir.bat
@@ -35,10 +35,8 @@ if NOT DEFINED JAVA_HOME goto :err
 @REM -----------------------------------------------------------------------------
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
-set CLASSPATH="%IOTDB_HOME%\lib"
+set CLASSPATH="%IOTDB_HOME%\lib\*"
 
-@REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
 goto okClasspath
 
 :append

--- a/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-resource-files.bat
+++ b/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-resource-files.bat
@@ -34,10 +34,8 @@ if NOT DEFINED JAVA_HOME goto :err
 @REM -----------------------------------------------------------------------------
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
-set CLASSPATH="%IOTDB_HOME%\lib"
+set CLASSPATH="%IOTDB_HOME%\lib\*"
 
-@REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
 goto okClasspath
 
 :append

--- a/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-sketch.bat
+++ b/server/src/assembly/resources/tools/tsfileToolSet/print-tsfile-sketch.bat
@@ -35,10 +35,8 @@ if NOT DEFINED JAVA_HOME goto :err
 @REM -----------------------------------------------------------------------------
 @REM ***** CLASSPATH library setting *****
 @REM Ensure that any user defined CLASSPATH variables are not used on startup
-set CLASSPATH="%IOTDB_HOME%\lib"
+set CLASSPATH="%IOTDB_HOME%\lib\*"
 
-@REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
 goto okClasspath
 
 :append

--- a/server/src/assembly/resources/tools/upgrade/offline-upgrade.bat
+++ b/server/src/assembly/resources/tools/upgrade/offline-upgrade.bat
@@ -41,7 +41,7 @@ set JAVA_OPTS=-ea^
 set CLASSPATH="%IOTDB_HOME%\lib"
 
 @REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-for %%i in ("%IOTDB_HOME%\lib\*.jar") do call :append "%%i"
+for %%i in ("%IOTDB_HOME%\lib\iotdb-*.jar") do call :append "%%i"
 goto okClasspath
 
 :append


### PR DESCRIPTION
on WinOS, we can use "lib\*" to refer all jar files in the lib folder...