### PR TITLE
[IOTDB-722] support three consistency levels: strong, mid and weak

### DIFF
--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -67,3 +67,11 @@ MAX_NUMBER_OF_LOGS=100
 # deletion check period of the submitted log
 LOG_DELETION_CHECK_INTERVAL_SECOND=3600
 
+# consistency level, now three consistency levels are supported: strong, mid and weak.
+# Strong consistency means the server will first try to synchronize with the leader to get the
+# newest meta data, if failed(timeout), directly report an error to the user;
+# While mid consistency means the server will first try to synchronize with the leader,
+# but if failed(timeout), it will give up and just use current data it has cached before;
+# Weak consistency do not synchronize with the leader and simply use the local data
+CONSISTENCY_LEVEL=mid
+

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterConfig.java
@@ -31,7 +31,9 @@ public class ClusterConfig {
   private int localDataPort = 40010;
   private int localClientPort = 55560;
 
-  // each one is a "<IP | domain name>:<meta port>:<data port>" string tuple
+  /**
+   * each one is a "<IP | domain name>:<meta port>:<data port>" string tuple
+   */
   private List<String> seedNodeUrls = Arrays.asList("127.0.0.1:9003:40010", "127.0.0.1"
       + ":9004:40011", "127.0.0.1:9005:40012");
 
@@ -73,6 +75,16 @@ public class ClusterConfig {
    * clients.
    */
   private int selectorNumOfClientPool = Runtime.getRuntime().availableProcessors() * 2;
+
+  /**
+   * consistency level, now three consistency levels are supported: strong, mid and weak. Strong
+   * consistency means the server will first try to synchronize with the leader to get the newest
+   * meta data, if failed(timeout), directly report an error to the user; While mid consistency
+   * means the server will first try to synchronize with the leader, but if failed(timeout), it will
+   * give up and just use current data it has cached before; Weak consistency do not synchronize
+   * with the leader and simply use the local data
+   */
+  private ConsistencyLevel consistencyLevel = ConsistencyLevel.MID_CONSISTENCY;
 
   public int getSelectorNumOfClientPool() {
     return selectorNumOfClientPool;
@@ -200,5 +212,13 @@ public class ClusterConfig {
 
   public void setLogDeleteCheckIntervalSecond(int logDeleteCheckIntervalSecond) {
     this.logDeleteCheckIntervalSecond = logDeleteCheckIntervalSecond;
+  }
+
+  public ConsistencyLevel getConsistencyLevel() {
+    return consistencyLevel;
+  }
+
+  public void setConsistencyLevel(ConsistencyLevel consistencyLevel) {
+    this.consistencyLevel = consistencyLevel;
   }
 }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -223,6 +223,11 @@ public class ClusterDescriptor {
         .getProperty("LOG_DELETION_CHECK_INTERVAL_SECOND",
             String.valueOf(config.getLogDeleteCheckIntervalSecond()))));
 
+    String consistencyLevel = properties.getProperty("CONSISTENCY_LEVEL");
+    if (consistencyLevel != null) {
+      config.setConsistencyLevel(ConsistencyLevel.getConsistencyLevel(consistencyLevel));
+    }
+
     String seedUrls = properties.getProperty("SEED_NODES");
     if (seedUrls != null) {
       List<String> urlList = getSeedUrlList(seedUrls);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ConsistencyLevel.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ConsistencyLevel.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.cluster.config;
+
+
+public enum ConsistencyLevel {
+  /**
+   * Strong consistency means the server will first try to synchronize with the leader to get the
+   * newest meta data, if failed(timeout), directly report an error to the user;
+   */
+  STRONG_CONSISTENCY("strong"),
+
+  /**
+   * mid consistency means the server will first try to synchronize with the leader, but if
+   * failed(timeout), it will give up and just use current data it has cached before;
+   */
+  MID_CONSISTENCY("mid"),
+
+  /**
+   * weak consistency do not synchronize with the leader and simply use the local data
+   */
+  WEAK_CONSISTENCY("weak"),
+  ;
+
+  private String consistencyLevel;
+
+  ConsistencyLevel(String consistencyLevel) {
+    this.consistencyLevel = consistencyLevel;
+  }
+
+
+  public static ConsistencyLevel getConsistencyLevel(String consistencyLevel) {
+    if (consistencyLevel == null) {
+      return ConsistencyLevel.MID_CONSISTENCY;
+    }
+    switch (consistencyLevel.toLowerCase()) {
+      case "strong":
+        return ConsistencyLevel.STRONG_CONSISTENCY;
+      case "mid":
+        return ConsistencyLevel.MID_CONSISTENCY;
+      case "weak":
+        return ConsistencyLevel.WEAK_CONSISTENCY;
+      default:
+        return ConsistencyLevel.MID_CONSISTENCY;
+    }
+  }
+
+}

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ConsistencyLevel.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ConsistencyLevel.java
@@ -19,6 +19,9 @@
 package org.apache.iotdb.cluster.config;
 
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public enum ConsistencyLevel {
   /**
    * Strong consistency means the server will first try to synchronize with the leader to get the
@@ -39,11 +42,11 @@ public enum ConsistencyLevel {
   ;
 
   private String consistencyLevel;
+  private static final Logger logger = LoggerFactory.getLogger(ConsistencyLevel.class);
 
   ConsistencyLevel(String consistencyLevel) {
     this.consistencyLevel = consistencyLevel;
   }
-
 
   public static ConsistencyLevel getConsistencyLevel(String consistencyLevel) {
     if (consistencyLevel == null) {
@@ -57,6 +60,8 @@ public enum ConsistencyLevel {
       case "weak":
         return ConsistencyLevel.WEAK_CONSISTENCY;
       default:
+        logger.warn("Unsupported consistency level={}, use default consistency level={}",
+            consistencyLevel, ConsistencyLevel.MID_CONSISTENCY.consistencyLevel);
         return ConsistencyLevel.MID_CONSISTENCY;
     }
   }

--- a/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/exception/CheckConsistencyException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.cluster.exception;
+
+/**
+ * Raised when check consistency failed, now only happens if there is a strong-consistency and
+ * syncLeader failed
+ */
+public class CheckConsistencyException extends Exception {
+
+  public CheckConsistencyException(String errMag) {
+    super(String.format("check consistency failed, error message=%s ", errMag));
+  }
+
+  public static CheckConsistencyException CHECK_STRONG_CONSISTENCY_EXCEPTION = new CheckConsistencyException(
+      "strong consistency, sync with leader failed");
+}

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/BaseApplier.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/BaseApplier.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.cluster.log.applier;
 
 import java.util.Collections;
 import java.util.List;
+import org.apache.iotdb.cluster.exception.CheckConsistencyException;
 import org.apache.iotdb.cluster.log.LogApplier;
 import org.apache.iotdb.cluster.query.ClusterPlanExecutor;
 import org.apache.iotdb.cluster.server.member.MetaGroupMember;
@@ -62,7 +63,11 @@ abstract class BaseApplier implements LogApplier {
         getQueryExecutor().processNonQuery(plan);
       } catch (QueryProcessException e) {
         if (e.getCause() instanceof StorageGroupNotSetException) {
-          metaGroupMember.syncLeader();
+          try {
+            metaGroupMember.syncLeaderWithConsistencyCheck();
+          } catch (CheckConsistencyException ce) {
+            throw new QueryProcessException(ce.getMessage());
+          }
           getQueryExecutor().processNonQuery(plan);
         } else {
           throw e;
@@ -101,7 +106,11 @@ abstract class BaseApplier implements LogApplier {
         }
         getQueryExecutor().processNonQuery(plan);
       } else if (causedByStorageGroupNotSet) {
-        metaGroupMember.syncLeader();
+        try {
+          metaGroupMember.syncLeaderWithConsistencyCheck();
+        } catch (CheckConsistencyException ce) {
+          throw new QueryProcessException(ce.getMessage());
+        }
         getQueryExecutor().processNonQuery(plan);
       } else {
         throw e;

--- a/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/DataLogApplier.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/log/applier/DataLogApplier.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.cluster.log.applier;
 
 import org.apache.iotdb.cluster.config.ClusterConstant;
+import org.apache.iotdb.cluster.exception.CheckConsistencyException;
 import org.apache.iotdb.cluster.log.Log;
 import org.apache.iotdb.cluster.log.logtypes.CloseFileLog;
 import org.apache.iotdb.cluster.log.logtypes.PhysicalPlanLog;
@@ -99,7 +100,11 @@ public class DataLogApplier extends BaseApplier {
     } catch (StorageGroupNotSetException e) {
       // the sg may not exist because the node does not catch up with the leader, retry after
       // synchronization
-      metaGroupMember.syncLeader();
+      try {
+        metaGroupMember.syncLeaderWithConsistencyCheck();
+      } catch (CheckConsistencyException ce) {
+        throw new QueryProcessException(ce.getMessage());
+      }
       if (plan instanceof InsertPlan) {
         InsertPlan insertPlan = (InsertPlan) plan;
         sg = MManager.getInstance().getStorageGroupName(insertPlan.getDeviceId());

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/DataGroupMember.java
@@ -1073,8 +1073,7 @@ public class DataGroupMember extends RaftMember implements TSDataService.AsyncIf
 
   /**
    * Create an IPointReader of "path" with “timeFilter” and "valueFilter". A synchronization with
-   * the leader will be performed first to preserve strong consistency. TODO-Cluster: also support
-   * weak consistency
+   * the leader will be performed according to consistency level
    *
    * @param path
    * @param dataType
@@ -1102,8 +1101,7 @@ public class DataGroupMember extends RaftMember implements TSDataService.AsyncIf
 
   /**
    * Create an IBatchReader of "path" with “timeFilter” and "valueFilter". A synchronization with
-   * the leader will be performed first to preserve strong consistency. TODO-Cluster: also support
-   * weak consistency
+   * the leader will be performed according to consistency level
    *
    * @param path
    * @param dataType
@@ -1159,7 +1157,7 @@ public class DataGroupMember extends RaftMember implements TSDataService.AsyncIf
 
   /**
    * Create an IReaderByTimestamp of "path". A synchronization with the leader will be performed
-   * first to preserve strong consistency. TODO-Cluster: also support weak consistency
+   * according to consistency level
    *
    * @param path
    * @param dataType

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -47,7 +47,6 @@ import org.apache.iotdb.cluster.client.async.MetaClient;
 import org.apache.iotdb.cluster.client.sync.SyncClientAdaptor;
 import org.apache.iotdb.cluster.config.ClusterConfig;
 import org.apache.iotdb.cluster.config.ClusterDescriptor;
-import org.apache.iotdb.cluster.config.ConsistencyLevel;
 import org.apache.iotdb.cluster.exception.CheckConsistencyException;
 import org.apache.iotdb.cluster.exception.LeaderUnknownException;
 import org.apache.iotdb.cluster.exception.LogExecutionException;
@@ -140,11 +139,6 @@ public abstract class RaftMember implements RaftService.AsyncIface {
   // know if this node is synchronized with the leader
   private Object syncLock = new Object();
   private ExecutorService appendLogThreadPool;
-
-  /**
-   * consistency level, now three consistency levels are supported: strong, mid and weak.
-   */
-  private ConsistencyLevel consistencyLevel = config.getConsistencyLevel();
 
   public RaftMember() {
   }
@@ -1096,7 +1090,6 @@ public abstract class RaftMember implements RaftService.AsyncIface {
     }
   }
 
-
   /**
    * according to the consistency configuration, decide whether to execute syncLeader or not and
    * throws exception when failed
@@ -1104,7 +1097,7 @@ public abstract class RaftMember implements RaftService.AsyncIface {
    * @throws CheckConsistencyException
    */
   public void syncLeaderWithConsistencyCheck() throws CheckConsistencyException {
-    switch (consistencyLevel) {
+    switch (ClusterDescriptor.getInstance().getConfig().getConsistencyLevel()) {
       case STRONG_CONSISTENCY:
         if (!syncLeader()) {
           throw CheckConsistencyException.CHECK_STRONG_CONSISTENCY_EXCEPTION;
@@ -1119,7 +1112,9 @@ public abstract class RaftMember implements RaftService.AsyncIface {
         return;
       default:
         // this should not happen in theory
-        throw new CheckConsistencyException("unknown consistency" + consistencyLevel.name());
+        throw new CheckConsistencyException(
+            "unknown consistency=" + ClusterDescriptor.getInstance().getConfig()
+                .getConsistencyLevel().name());
     }
   }
 

--- a/cluster/src/test/java/org/apache/iotdb/cluster/log/applier/DataLogApplierTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/log/applier/DataLogApplierTest.java
@@ -165,11 +165,12 @@ public class DataLogApplierTest extends IoTDBTest {
     insertPlan.setDeviceId(TestUtils.getTestSg(1));
     insertPlan.setTime(1);
     insertPlan.setInferType(true);
-    insertPlan.setMeasurements(new String[] {TestUtils.getTestMeasurement(0)});
+    insertPlan.setMeasurements(new String[]{TestUtils.getTestMeasurement(0)});
     insertPlan.setTypes(new TSDataType[insertPlan.getMeasurements().length]);
-    insertPlan.setValues(new Object[] {"1.0"});
+    insertPlan.setValues(new Object[]{"1.0"});
     insertPlan.setInferType(true);
-    insertPlan.setSchemasAndTransferType(new MeasurementSchema[] {TestUtils.getTestMeasurementSchema(0)});
+    insertPlan
+        .setSchemasAndTransferType(new MeasurementSchema[]{TestUtils.getTestMeasurementSchema(0)});
 
     applier.apply(log);
     QueryDataSet dataSet = query(Collections.singletonList(TestUtils.getTestSeries(1, 0)), null);
@@ -197,7 +198,9 @@ public class DataLogApplierTest extends IoTDBTest {
       applier.apply(log);
       fail("exception should be thrown");
     } catch (QueryProcessException e) {
-      assertEquals("org.apache.iotdb.db.exception.metadata.PathNotExistException: Path [root.test5.s0] does not exist", e.getMessage());
+      assertEquals(
+          "org.apache.iotdb.db.exception.metadata.PathNotExistException: Path [root.test5.s0] does not exist",
+          e.getMessage());
     }
 
     // this storage group is not even set
@@ -206,7 +209,9 @@ public class DataLogApplierTest extends IoTDBTest {
       applier.apply(log);
       fail("exception should be thrown");
     } catch (QueryProcessException e) {
-      assertEquals("org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException: Storage group is not set for current seriesPath: [root.test6.s0]", e.getMessage());
+      assertEquals(
+          "org.apache.iotdb.db.exception.metadata.StorageGroupNotSetException: Storage group is not set for current seriesPath: [root.test6.s0]",
+          e.getMessage());
     }
   }
 
@@ -221,7 +226,7 @@ public class DataLogApplierTest extends IoTDBTest {
     int cnt = 0;
     while (dataSet.hasNext()) {
       RowRecord record = dataSet.next();
-      assertEquals(cnt + 51L , record.getTimestamp());
+      assertEquals(cnt + 51L, record.getTimestamp());
       assertEquals((cnt + 51) * 1.0, record.getFields().get(0).getDoubleV(), 0.00001);
       cnt++;
     }


### PR DESCRIPTION
This pr is going to support three consistency levels strong, mid and weak. Strong consistency means the server will first try to synchronize with the leader to get the newest meta data, if failed(timeout), directly report an error to the user; While mid consistency means the server will first try to synchronize with the leader, but if failed(timeout), it will give up and just use current data it has cached before; Weak consistency do not synchronize with the leader and simply use the local data.