### PR TITLE
[IOTDB-777]Missing dot between deviceId and sensorId in chunkMetadaCache

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/ChunkMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/ChunkMetadataCache.java
@@ -125,7 +125,7 @@ public class ChunkMetadataCache {
     }
 
     AccountableString key = new AccountableString(filePath + IoTDBConstant.PATH_SEPARATOR
-        + seriesPath.getDevice() + seriesPath.getMeasurement());
+        + seriesPath.getDevice() + IoTDBConstant.PATH_SEPARATOR + seriesPath.getMeasurement());
 
     cacheRequestNum.incrementAndGet();
 


### PR DESCRIPTION
Issue description: https://issues.apache.org/jira/browse/IOTDB-777

In ChunkMetadataCache, key of this map LRULinkedHashMap<AccountableString, List<ChunkMetadata>> lruCache should be "file path dot deviceId dot sensorId", which the key of chunkMetadataCache was missing the separator between deviceId and sensorId.