### PR TITLE
fix boolean batch serialization

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertTabletPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertTabletPlan.java
@@ -24,11 +24,9 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.db.utils.QueryDataSetUtils;
-import org.apache.iotdb.db.utils.TestOnly;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
@@ -305,7 +303,7 @@ public class InsertTabletPlan extends PhysicalPlan {
       case BOOLEAN:
         boolean[] boolValues = (boolean[]) column;
         for (int j = start; j < end; j++) {
-          buffer.putInt(BytesUtils.boolToByte(boolValues[j]));
+          buffer.put(BytesUtils.boolToByte(boolValues[j]));
         }
         break;
       case TEXT:

--- a/server/src/test/java/org/apache/iotdb/db/writelog/WriteLogNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/WriteLogNodeTest.java
@@ -38,6 +38,7 @@ import org.apache.iotdb.db.writelog.node.ExclusiveWriteLogNode;
 import org.apache.iotdb.db.writelog.node.WriteLogNode;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Path;
+import org.apache.iotdb.tsfile.utils.Binary;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -84,13 +85,13 @@ public class WriteLogNodeTest {
     Object[] columns = new Object[4];
     columns[0] = new double[4];
     columns[1] = new long[4];
-    columns[2] = new String[4];
+    columns[2] = new Binary[4];
     columns[3] = new boolean[4];
 
     for (int r = 0; r < 4; r++) {
       ((double[]) columns[0])[r] = 1.0;
       ((long[]) columns[1])[r] = 1;
-      ((String[]) columns[2])[r] = "hh" + r;
+      ((Binary[]) columns[2])[r] = new Binary("hh" + r);
       ((boolean[]) columns[3])[r] = false;
     }
 
@@ -102,7 +103,7 @@ public class WriteLogNodeTest {
     tabletPlan.setStart(0);
     tabletPlan.setEnd(4);
 
-    tabletPlan.markMeasurementInsertionFailed(2);
+    tabletPlan.markMeasurementInsertionFailed(1);
 
     logNode.write(bwInsertPlan);
     logNode.write(deletePlan);

--- a/server/src/test/java/org/apache/iotdb/db/writelog/WriteLogNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/WriteLogNodeTest.java
@@ -99,6 +99,8 @@ public class WriteLogNodeTest {
     tabletPlan.setTimes(times);
     tabletPlan.setColumns(columns);
     tabletPlan.setRowCount(times.length);
+    tabletPlan.setStart(0);
+    tabletPlan.setEnd(4);
 
     tabletPlan.markMeasurementInsertionFailed(2);
 


### PR DESCRIPTION
The serialization of boolean data in batch (tablet) is using is inconsistent with corresponding deserialization.
