### PR TITLE
[Distributed] Remove unnecessary persistence

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/utils/nodetool/function/LogView.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/utils/nodetool/function/LogView.java
@@ -42,9 +42,9 @@ public class LogView implements Runnable {
   public void run() {
     SyncLogDequeSerializer logDequeSerializer = new SyncLogDequeSerializer(path);
 
-    LogManagerMeta managerMeta = logDequeSerializer.recoverMeta();
+    List<Log> logs = logDequeSerializer.getAllEntries();
     HardState state = logDequeSerializer.getHardState();
-    List<Log> logs = logDequeSerializer.recoverLog();
+    LogManagerMeta managerMeta = logDequeSerializer.getMeta();
 
     Printer.msgPrintln("-------------------LOG META-------------------------");
     Printer.msgPrintln(managerMeta.toString());

--- a/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
+++ b/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
@@ -19,7 +19,6 @@
 package org.apache.iotdb.rpc;
 
 import java.lang.reflect.Proxy;
-import java.util.Arrays;
 import java.util.List;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementResp;
 import org.apache.iotdb.service.rpc.thrift.TSFetchResultsResp;
@@ -90,17 +89,6 @@ public class RpcUtils {
   public static TSStatus getStatus(int code, String message) {
     TSStatus status = new TSStatus(code);
     status.setMessage(message);
-    return status;
-  }
-
-  /**
-   *
-   * @param length
-   * @return A TSStatusArray of given length, each element will be a SUCCESS_STATUS.
-   */
-  public static TSStatus[] getStatus(int length) {
-    TSStatus[] status = new TSStatus[length];
-    Arrays.fill(status, RpcUtils.SUCCESS_STATUS);
     return status;
   }
 


### PR DESCRIPTION
I found that it's unnecessary to persist meta after log's persistence in `SyncLogDequeSerializer`. Persisting meta is for security purposes.However, it is expensive to trigger the persistence meta every time a log is persisted, as this function only affects lastLogIndex, lastLogTerm, commitLogIndex and commitLogTerm, which can be inferred from the logs on disk under the current persistence policy. 

I tested this change with iotdb-benchmark, you can see a 27 to 66 percent performance improvement.Since the disk on my test machine was SSD, the impact of random writes was not so great. If it was HDD, the performance improvement would be more significant.

## benchmark config:
CLIENT_NUMBER=5
GROUP_NUMBER=20
DEVICE_NUMBER=20
SENSOR_NUMBER=20
BATCH_SIZE=50
LOOP=10

## session performance
### new version
![image](https://user-images.githubusercontent.com/32640567/85659221-e04b8380-b6e6-11ea-9ae6-d9979731a0ad.png)
### old version
![image](https://user-images.githubusercontent.com/32640567/85658898-759a4800-b6e6-11ea-9225-7002435da5b0.png)


## jdbc performance
### new version
![image](https://user-images.githubusercontent.com/32640567/85659451-243e8880-b6e7-11ea-85c3-171746183ca0.png)
### old version
![image](https://user-images.githubusercontent.com/32640567/85658936-8054dd00-b6e6-11ea-9d63-4f0fc76c57a2.png)



