### PR TITLE
[IOTDB-784]Update rpc protocol to V3

### DIFF
--- a/client-py/src/client_example.py
+++ b/client-py/src/client_example.py
@@ -239,10 +239,10 @@ if __name__ == '__main__':
 
     # insert a single row
     values = [1, 11, 1.1, 11.1, True, "\'text0\'"]
-    dataTypes = [TSDataType['INT32'], TSDataType['INT32'], TSDataType['FLOAT'],
+    dataTypes = [TSDataType['INT64'], TSDataType['INT32'], TSDataType['DOUBLE'],
                  TSDataType['FLOAT'], TSDataType['BOOLEAN'], TSDataType['TEXT']]
     
-    value_pack_str = '>5ififibi7s'
+    value_pack_str = '>hqhihdhfh?hi' + str(len(values[5])) + 's'
     encoding = 'utf-8'
     valueByte = bytearray()
     
@@ -251,7 +251,7 @@ if __name__ == '__main__':
                                              dataTypes[2], values[2],
                                              dataTypes[3], values[3],
                                              dataTypes[4], values[4],
-                                             dataTypes[5], bytes(values[5], encoding)))
+                                             dataTypes[5], len(values[5]), bytes(values[5], encoding)))
     timestamp = 1
     
     status = client.insertRecord(TSInsertRecordReq(sessionId, deviceId, measurements, valueByte, timestamp))
@@ -262,8 +262,7 @@ if __name__ == '__main__':
     times = bytearray()
 
     rowCnt = 3
-    dataTypes = [TSDataType['INT64'], TSDataType['INT32'], TSDataType['DOUBLE'],
-                 TSDataType['FLOAT'], TSDataType['BOOLEAN'], TSDataType['TEXT']]
+
     # the first 3 belong to 's1', the second 3 belong to 's2'... the last 3
     # belong to 's6'
     # to transfer a string, you must first send its length and then its bytes

--- a/client-py/src/client_example.py
+++ b/client-py/src/client_example.py
@@ -178,7 +178,7 @@ if __name__ == '__main__':
     transport.open()
 
     # Authentication
-    clientProtocol = TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V2
+    clientProtocol = TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V3
     resp = client.openSession(TSOpenSessionReq(client_protocol=clientProtocol,
                                                username=username,
                                                password=password))

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
 public class IoTDBConnection implements Connection {
 
   private static final Logger logger = LoggerFactory.getLogger(IoTDBConnection.class);
-  private static final TSProtocolVersion protocolVersion = TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V2;
+  private static final TSProtocolVersion protocolVersion = TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V3;
   private TSIService.Iface client = null;
   private long sessionId = -1;
   private IoTDBConnectionParams params;

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -154,6 +154,9 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
   // When the client abnormally exits, we can still know who to disconnect
   private ThreadLocal<Long> currSessionId = new ThreadLocal<>();
 
+  public static final TSProtocolVersion CURRENT_RPC_VERSION = TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V3;
+
+
   public TSServiceImpl() throws QueryProcessException {
     processor = new Planner();
     executor = new PlanExecutor();
@@ -190,7 +193,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
         tsStatus = RpcUtils.getStatus(TSStatusCode.INCOMPATIBLE_VERSION,
             "The version is incompatible, please upgrade to " + IoTDBConstant.VERSION);
         TSOpenSessionResp resp = new TSOpenSessionResp(tsStatus,
-            TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V2);
+            CURRENT_RPC_VERSION);
         resp.setSessionId(sessionId);
         return resp;
       }
@@ -206,7 +209,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
     }
     auditLogger.info("User {} opens Session-{}", req.getUsername(), sessionId);
     TSOpenSessionResp resp = new TSOpenSessionResp(tsStatus,
-        TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V2);
+        CURRENT_RPC_VERSION);
     resp.setSessionId(sessionId);
     logger.info(
         "{}: Login status: {}. User : {}", IoTDBConstant.GLOBAL_DB_NAME, tsStatus.message,
@@ -216,7 +219,7 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
   }
 
   private boolean checkCompatibility(TSProtocolVersion version) {
-    return version.equals(TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V2);
+    return version.equals(CURRENT_RPC_VERSION);
   }
 
   @Override

--- a/service-rpc/rpc-changelist.md
+++ b/service-rpc/rpc-changelist.md
@@ -21,7 +21,8 @@
 
 # 0.10.x (version-2) -> 0.11.x (version-3)
 
-Last Updated on 2020-6-15 by Tian Jiang.
+Last Updated on 2020-6-29 by Xiangdong Huang.
+
 
 ## 1. Delete Old
 
@@ -30,14 +31,21 @@ Last Updated on 2020-6-15 by Tian Jiang.
 | Remove TSBatchExecuteStatementResp            | Tian Jiang         |
 
 
-
 ## 2. Add New
+
+| Latest Changes                                               | Related Committers     |
+| ------------------------------------------------------------ | ---------------------- |
+| set the input/output as TFramedTransport      |  Tian Jiang        |
+
 
 ## 3. Update
 
 | Latest Changes                                               | Related Committers     |
 | ------------------------------------------------------------ | ---------------------- |
 | Add sub-status in TSStatus  | Tian Jiang  |
+| Change the result of executeBatchStatement  as   TSStatus    | Tian Jiang  |
+
+
 
 
 # 0.9.x (version-1) -> 0.10.x (version-2)
@@ -62,6 +70,7 @@ Last Updated on 2020-5-25 by Kaifeng Xue.
 | Add struct TSInsertTabletsReq                            | Jialin Qiao|
 | Add method insertTablets                            | Jialin Qiao|
 | Add method testInsertTablets                            | Xiangdong Huang |
+| add new field `inferType` in TSInsertRecordReq  | Jialin Qiao      |
 
 ## 3. Update
 

--- a/service-rpc/src/main/thrift/rpc.thrift
+++ b/service-rpc/src/main/thrift/rpc.thrift
@@ -43,6 +43,7 @@ struct TSExecuteStatementResp {
 enum TSProtocolVersion {
   IOTDB_SERVICE_PROTOCOL_V1,
   IOTDB_SERVICE_PROTOCOL_V2,//V2 is the first version that we can check version compatibility
+  IOTDB_SERVICE_PROTOCOL_V3,//V3 is incompatible with V2
 }
 
 struct TSOpenSessionResp {
@@ -61,7 +62,7 @@ struct TSOpenSessionResp {
 // OpenSession()
 // Open a session (connection) on the server against which operations may be executed.
 struct TSOpenSessionReq {
-  1: required TSProtocolVersion client_protocol = TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V2
+  1: required TSProtocolVersion client_protocol = TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V3
   2: optional string username
   3: optional string password
   4: optional map<string, string> configuration

--- a/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
 public class Session {
 
   private static final Logger logger = LoggerFactory.getLogger(Session.class);
-  private final TSProtocolVersion protocolVersion = TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V2;
+  private final TSProtocolVersion protocolVersion = TSProtocolVersion.IOTDB_SERVICE_PROTOCOL_V3;
   private String host;
   private int port;
   private String username;


### PR DESCRIPTION
As in 0.11.x  we are using TFastFrameTransport and incompatible with v0.10, we have to upgrade the RPC protocol version from V2 to V3.