### PR TITLE
fix maven warning about losing some plugin versions

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -89,6 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.version}</version>
                 <executions>
                     <!-- Package binaries-->
                     <execution>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -34,6 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.version}</version>
                 <executions>
                     <!-- Package binaries-->
                     <execution>

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -55,6 +55,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${felix.version}</version>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -86,7 +87,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven.assembly.version}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -133,7 +134,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven.assembly.version}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/hive-connector/pom.xml
+++ b/hive-connector/pom.xml
@@ -133,7 +133,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven.assembly.version}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -116,7 +116,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
+                <version>${felix.version}</version>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -148,7 +148,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven.assembly.version}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.assembly.version>2.5.5</maven.assembly.version>
+        <maven.assembly.version>3.1.0</maven.assembly.version>
         <scala.version>2.11.12</scala.version>
         <hadoop2.version>2.7.3</hadoop2.version>
         <hive2.version>2.3.6</hive2.version>
@@ -129,6 +129,7 @@
         <jetty.version>9.4.24.v20191120</jetty.version>
         <metrics.version>3.2.6</metrics.version>
         <javax.xml.bind.version>2.4.0-b180725.0427</javax.xml.bind.version>
+        <felix.version>4.2.1</felix.version>
         <!-- URL of the ASF SonarQube server -->
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>apache</sonar.organization>
@@ -944,6 +945,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-assembly-plugin</artifactId>
+                        <version>${maven.assembly.version}</version>
                         <executions>
                             <execution>
                                 <id>source-release-assembly</id>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -217,6 +217,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.version}</version>
                 <executions>
                     <!-- Package binaries-->
                     <execution>

--- a/service-rpc/pom.xml
+++ b/service-rpc/pom.xml
@@ -55,6 +55,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${felix.version}</version>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -86,7 +87,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven.assembly.version}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/session/pom.xml
+++ b/session/pom.xml
@@ -38,7 +38,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven.assembly.version}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/thrift/pom.xml
+++ b/thrift/pom.xml
@@ -44,6 +44,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${felix.version}</version>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -75,7 +76,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven.assembly.version}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/tsfile/pom.xml
+++ b/tsfile/pom.xml
@@ -62,6 +62,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${felix.version}</version>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -93,7 +94,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven.assembly.version}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>


### PR DESCRIPTION
Jenkins build fails but do not know why...

we can fix some warning issues :

![image](https://user-images.githubusercontent.com/1021782/86533372-3f896f00-bf03-11ea-9c73-5200f7d25692.png)

For more info, read https://builds.apache.org/job/IoTDB-Pipeline/job/master/412/execution/node/67/log/