### PR TITLE
[Distributed] Fix a timeout bug

### DIFF
--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/DataClusterServer.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/DataClusterServer.java
@@ -517,6 +517,8 @@ public class DataClusterServer extends RaftServer implements TSDataService.Async
       value.stop();
     }
     headerGroupMap.clear();
+    asyncServiceMap.clear();
+    syncServiceMap.clear();
 
     List<PartitionGroup> partitionGroups = partitionTable.getLocalGroups();
     for (PartitionGroup partitionGroup : partitionGroups) {

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/heartbeat/HeartbeatThread.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/heartbeat/HeartbeatThread.java
@@ -89,6 +89,7 @@ public class HeartbeatThread implements Runnable {
               // the leader is considered dead, an election will be started in the next loop
               logger.info("{}: The leader {} timed out", memberName, localMember.getLeader());
               localMember.setCharacter(NodeCharacter.ELECTOR);
+              localMember.setLeader(null);
             } else {
               logger.debug("{}: Heartbeat from leader {} is still valid", memberName,
                   localMember.getLeader());
@@ -97,7 +98,6 @@ public class HeartbeatThread implements Runnable {
             break;
           case ELECTOR:
           default:
-            localMember.setLeader(null);
             logger.info("{}: Start elections", memberName);
             startElections();
             logger.info("{}: End elections", memberName);

--- a/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/server/member/RaftMember.java
@@ -1357,7 +1357,6 @@ public abstract class RaftMember {
    * Tell the requester the current commit index if the local node is the leader of the group headed
    * by header. Or forward it to the leader. Otherwise report an error.
    *
-   * @param header        to determine the DataGroupMember in data groups
    * @return Long.MIN_VALUE if the node is not a leader, or the commitIndex
    */
   public long requestCommitIndex() {


### PR DESCRIPTION
clear service map after rebuilding datagroups to avoid read old leader from old datamember which may be wrong