### PR TITLE
[IOTDB-827] Fix no permissions for operation LAST

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
+++ b/server/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
@@ -127,6 +127,7 @@ public class AuthorityChecker {
       case INDEXQUERY:
       case MERGEQUERY:
       case AGGREGATION:
+      case LAST:
         return PrivilegeType.READ_TIMESERIES.ordinal();
       case DELETE:
         return PrivilegeType.DELETE_TIMESERIES.ordinal();

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBAuthorizationIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBAuthorizationIT.java
@@ -517,6 +517,8 @@ public class IoTDBAuthorizationIT {
     adminStmt.execute("GRANT USER tempuser PRIVILEGES 'READ_TIMESERIES' on root.a");
     userStmt.execute("SELECT * from root.a");
     userStmt.getResultSet().close();
+    userStmt.execute("SELECT LAST b from root.a");
+    userStmt.getResultSet().close();
 
     // revoke privilege to query
     adminStmt.execute("REVOKE USER tempuser PRIVILEGES 'READ_TIMESERIES' on root.a");


### PR DESCRIPTION
As is pointed in issue #1571 , after granting `READ_TIMESERIES` privilege, user still could not use LAST.