### PR TITLE
Enable iotdb to set useasyncserver and useasyncapplier through configuration files

### DIFF
--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -107,11 +107,11 @@ enable_auto_create_schema=true
 # Weak consistency do not synchronize with the leader and simply use the local data
 consistency_level=mid
 
-#is use async server
+#Whether to use an asynchronous server
 is_use_async_server=true
 
-#is use sync applier
-is_use_async_applier=true
+#Whether to use asynchronous applications
+is_use_async_applier=false
 
 # is raft log persistence enabled
 is_enable_raft_log_persistence=true

--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -107,10 +107,10 @@ enable_auto_create_schema=true
 # Weak consistency do not synchronize with the leader and simply use the local data
 consistency_level=mid
 
-#Whether to use an asynchronous server
+# Whether to use asynchronous server
 is_use_async_server=true
 
-#Whether to use asynchronous applier
+# Whether to use asynchronous applier
 is_use_async_applier=false
 
 # is raft log persistence enabled

--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -107,6 +107,12 @@ enable_auto_create_schema=true
 # Weak consistency do not synchronize with the leader and simply use the local data
 consistency_level=mid
 
+#is use async server
+is_use_async_server=true
+
+#is use sync applier
+is_use_async_applier=true
+
 # is raft log persistence enabled
 is_enable_raft_log_persistence=true
 

--- a/cluster/src/assembly/resources/conf/iotdb-cluster.properties
+++ b/cluster/src/assembly/resources/conf/iotdb-cluster.properties
@@ -110,7 +110,7 @@ consistency_level=mid
 #Whether to use an asynchronous server
 is_use_async_server=true
 
-#Whether to use asynchronous applications
+#Whether to use asynchronous applier
 is_use_async_applier=false
 
 # is raft log persistence enabled

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -247,12 +247,10 @@ public class ClusterDescriptor {
     config.setUseAsyncServer(
             Boolean.parseBoolean(properties.getProperty("is_use_async_server",
                     String.valueOf(config.isUseAsyncServer()))));
-    logger.info("server+{}",config.isUseAsyncServer());
 
     config.setUseAsyncApplier(
             Boolean.parseBoolean(properties.getProperty("is_use_async_applier",
                     String.valueOf(config.isUseAsyncApplier()))));
-    logger.info("app+{}",config.isUseAsyncApplier());
 
     config.setEnableRaftLogPersistence(
         Boolean.parseBoolean(properties.getProperty("is_enable_raft_log_persistence",

--- a/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
+++ b/cluster/src/main/java/org/apache/iotdb/cluster/config/ClusterDescriptor.java
@@ -244,6 +244,16 @@ public class ClusterDescriptor {
         .getProperty("enable_auto_create_schema",
             String.valueOf(config.isEnableAutoCreateSchema()))));
 
+    config.setUseAsyncServer(
+            Boolean.parseBoolean(properties.getProperty("is_use_async_server",
+                    String.valueOf(config.isUseAsyncServer()))));
+    logger.info("server+{}",config.isUseAsyncServer());
+
+    config.setUseAsyncApplier(
+            Boolean.parseBoolean(properties.getProperty("is_use_async_applier",
+                    String.valueOf(config.isUseAsyncApplier()))));
+    logger.info("app+{}",config.isUseAsyncApplier());
+
     config.setEnableRaftLogPersistence(
         Boolean.parseBoolean(properties.getProperty("is_enable_raft_log_persistence",
             String.valueOf(config.isEnableRaftLogPersistence()))));


### PR DESCRIPTION
It is convenient to change the corresponding variables in the code by modifying the configuration file during testing. It is not necessary to change the code and recompile before each test.