### PR TITLE
[To rel/0.10] fix null pointer bug in reading TimeseriesMetadata

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/cache/TimeSeriesMetadataCache.java
@@ -160,7 +160,11 @@ public class TimeSeriesMetadataCache {
         }
       }
     }
-    return new TimeseriesMetadata(timeseriesMetadata);
+    if (timeseriesMetadata == null) {
+      return null;
+    } else {
+      return new TimeseriesMetadata(timeseriesMetadata);
+    }
   }
 
 

--- a/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/TSServiceImpl.java
@@ -593,6 +593,9 @@ public class TSServiceImpl implements TSIService.Iface, ServerContext {
       }
 
       return resp;
+    } catch (NullPointerException e) {
+      e.printStackTrace();
+      return RpcUtils.getTSExecuteStatementResp(TSStatusCode.INTERNAL_SERVER_ERROR, e.getMessage());
     } catch (Exception e) {
       logger.error("{}: Internal server error: ", IoTDBConstant.GLOBAL_DB_NAME, e);
       if (queryId != -1) {

--- a/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSimpleQueryIT.java
+++ b/server/src/test/java/org/apache/iotdb/db/integration/IoTDBSimpleQueryIT.java
@@ -317,4 +317,24 @@ public class IoTDBSimpleQueryIT {
     }
   }
 
+  @Test
+  public void testTimeseriesMetadataCache() throws ClassNotFoundException {
+    Class.forName(Config.JDBC_DRIVER_NAME);
+    try (Connection connection = DriverManager
+        .getConnection(Config.IOTDB_URL_PREFIX + "127.0.0.1:6667/",
+            "root", "root");
+        Statement statement = connection.createStatement()) {
+      statement.execute("SET STORAGE GROUP TO root.sg1");
+      for (int i = 0; i < 10000; i++) {
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s"+ i + " WITH DATATYPE=INT32,ENCODING=PLAIN");
+      }
+      for (int i = 1; i < 10000; i++) {
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s" + i + ") VALUES (1000, 1)");
+      }
+      statement.execute("flush");
+      statement.executeQuery("select s0 from root.sg1.d0");
+    } catch (SQLException e) {
+      fail();
+    }
+  }
 }


### PR DESCRIPTION
This bug is introduced in 0.10.1-SNAPSHOT. We'd better fix it before releasing 0.10.1

![image](https://user-images.githubusercontent.com/7240743/89150889-3509d600-d592-11ea-949c-e3627cefacf4.png)
