### PR TITLE
server log_info.log does not contain INFO level log

### DIFF
--- a/server/src/assembly/resources/conf/logback.xml
+++ b/server/src/assembly/resources/conf/logback.xml
@@ -192,7 +192,7 @@
         <appender-ref ref="FILEDEBUG"/>
         <appender-ref ref="FILEWARN"/>
         <appender-ref ref="FILEERROR"/>
-        <appender-ref ref="FILEALL"/>
+        <appender-ref ref="FILEINFO"/>
         <appender-ref ref="stdout"/>
     </root>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">

--- a/server/src/assembly/resources/conf/logback.xml
+++ b/server/src/assembly/resources/conf/logback.xml
@@ -193,6 +193,7 @@
         <appender-ref ref="FILEWARN"/>
         <appender-ref ref="FILEERROR"/>
         <appender-ref ref="FILEINFO"/>
+        <appender-ref ref="FILEALL"/>
         <appender-ref ref="stdout"/>
     </root>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">


### PR DESCRIPTION
when using log.info method, the result is output to log_all file, now updated to log_info file 