### PR TITLE
[IOTDB-835] [To rel/0.10] Fix delete timeseries and change data type then write failed

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -230,6 +230,9 @@ public abstract class AbstractMemTable implements IMemTable {
       if (chunk == null) {
         return;
       }
+      if (timestamp == Long.MAX_VALUE) {
+        deviceMap.remove(measurementId);
+      }
       int deletedPointsNumber = chunk.delete(timestamp);
       totalPointsNum -= deletedPointsNumber;
     }


### PR DESCRIPTION
SQL:
```
create timeseries root.turbine1.d1.s2 with datatype=INT64, encoding=PLAIN, compression=SNAPPY
create timeseries root.turbine1.d1.s3 with datatype=INT64, encoding=PLAIN, compression=SNAPPY
insert into root.turbine1.d1(timestamp,s2,s3) values(1,2,3);
delete timeseries root.turbine1.d1.s2
create timeseries root.turbine1.d1.s2 with datatype=FLOAT, encoding=PLAIN, compression=SNAPPY
insert into root.turbine1.d1(timestamp,s2,s3) values(2,2.1,3);
```
Error:
```
java.lang.ClassCastException: java.lang.Float cannot be cast to java.lang.Long
at org.apache.iotdb.db.engine.memtable.WritableMemChunk.write(WritableMemChunk.java:47)
at org.apache.iotdb.db.engine.memtable.AbstractMemTable.write(AbstractMemTable.java:134)
at org.apache.iotdb.db.engine.memtable.AbstractMemTable.insert(AbstractMemTable.java:110)
at org.apache.iotdb.db.engine.storagegroup.TsFileProcessor.insert(TsFileProcessor.java:164)
at org.apache.iotdb.db.engine.storagegroup.StorageGroupProcessor.insertToTsFileProcessor(StorageGroupProcessor.java:767)
at org.apache.iotdb.db.engine.storagegroup.StorageGroupProcessor.insert(StorageGroupProcessor.java:596)
at org.apache.iotdb.db.engine.StorageEngine.insert(StorageEngine.java:273)
at org.apache.iotdb.db.qp.executor.PlanExecutor.insert(PlanExecutor.java:924)
at org.apache.iotdb.db.qp.executor.PlanExecutor.processNonQuery(PlanExecutor.java:200)
at org.apache.iotdb.db.service.TSServiceImpl.executeNonQuery(TSServiceImpl.java:973)
at org.apache.iotdb.db.service.TSServiceImpl.executePlan(TSServiceImpl.java:1436)
at org.apache.iotdb.db.service.TSServiceImpl.executeUpdateStatement(TSServiceImpl.java:960)
at org.apache.iotdb.db.service.TSServiceImpl.executeStatement(TSServiceImpl.java:473)
at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$executeStatement.getResult(TSIService.java:1833)
at org.apache.iotdb.service.rpc.thrift.TSIService$Processor$executeStatement.getResult(TSIService.java:1813)
at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:313)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)
```