### PR TITLE
[IOTDB-836] Fix merging statistics failed when endFile

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/StorageEngine.java
@@ -361,6 +361,19 @@ public class StorageEngine implements IService {
   }
 
   /**
+   * delete data of timeseries "{deviceId}.{measurementId}"
+   */
+  public void deleteTimeseries(String deviceId, String measurementId)
+      throws StorageEngineException {
+    StorageGroupProcessor storageGroupProcessor = getProcessor(deviceId);
+    try {
+      storageGroupProcessor.delete(deviceId, measurementId, Long.MAX_VALUE);
+    } catch (IOException e) {
+      throw new StorageEngineException(e.getMessage());
+    }
+  }
+
+  /**
    * query data.
    */
   public QueryDataSource query(SingleSeriesExpression seriesExpression, QueryContext context,

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileProcessor.java
@@ -244,6 +244,13 @@ public class TsFileProcessor {
         workMemTable
             .delete(deletion.getDevice(), deletion.getMeasurement(), deletion.getTimestamp());
       }
+
+      // clear ChunkMetaData of the deleted timeseries
+      if (deletion.getTimestamp() == Long.MAX_VALUE) {
+        writer.deleteMeasurementFromChunkGroupMetadataList(deletion.getDevice(),
+            deletion.getMeasurement());
+      }
+
       // flushing memTables are immutable, only record this deletion in these memTables for query
       for (IMemTable memTable : flushingMemTables) {
         memTable.delete(deletion);

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -1246,11 +1246,17 @@ public class PlanExecutor implements IPlanExecutor {
    */
   private void deleteDataOfTimeSeries(List<Path> pathList)
       throws QueryProcessException, StorageGroupNotSetException, StorageEngineException {
-    for (Path p : pathList) {
-      DeletePlan deletePlan = new DeletePlan();
-      deletePlan.addPath(p);
-      deletePlan.setDeleteTime(Long.MAX_VALUE);
-      processNonQuery(deletePlan);
+    for (Path path : pathList) {
+      try {
+        if (!mManager.isPathExist(path.getFullPath())) {
+          throw new QueryProcessException(
+              String.format("Time series %s does not exist.", path.getFullPath()));
+        }
+        mManager.getStorageGroupName(path.getFullPath());
+        StorageEngine.getInstance().deleteTimeseries(path.getDevice(), path.getMeasurement());
+      } catch (MetadataException | StorageEngineException e) {
+        throw new QueryProcessException(e);
+      }
     }
   }
 

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkGroupMetadata.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/ChunkGroupMetadata.java
@@ -41,4 +41,9 @@ public class ChunkGroupMetadata {
   public List<ChunkMetadata> getChunkMetadataList() {
     return chunkMetadataList;
   }
+
+  public void setChunkMetadataList(
+      List<ChunkMetadata> chunkMetadataList) {
+    this.chunkMetadataList = chunkMetadataList;
+  }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -335,6 +335,21 @@ public class TsFileIOWriter {
     return deviceChunkMetadataMap;
   }
 
+  public void deleteMeasurementFromChunkGroupMetadataList(String deviceId, String measurementId) {
+    for (ChunkGroupMetadata chunkGroupMetadata : chunkGroupMetadataList) {
+      VersionUtils.applyVersion(chunkGroupMetadata.getChunkMetadataList(), versionInfo);
+      if (chunkGroupMetadata.getDevice().equals(deviceId)) {
+        List<ChunkMetadata> filteredChunkMetadataList = new ArrayList<>();
+        for (ChunkMetadata chunkMetadata : chunkGroupMetadata.getChunkMetadataList()) {
+          if (!chunkMetadata.getMeasurementUid().equals(measurementId)) {
+            filteredChunkMetadataList.add(chunkMetadata);
+          }
+        }
+        chunkGroupMetadata.setChunkMetadataList(filteredChunkMetadataList);
+      }
+    }
+  }
+
   public boolean canWrite() {
     return canWrite;
   }


### PR DESCRIPTION
Clear the chunkGroupMetadataList when perform a delete timeseries operation to avoid merging statistics failed when endFile:
```
org.apache.iotdb.tsfile.exception.filter.StatisticsClassException: Statistics classes mismatched: class org.apache.iotdb.tsfile.file.metadata.statistics.LongStatistics vs. class org.apache.iotdb.tsfile.file.metadata.statistics.DoubleStatistics
at org.apache.iotdb.tsfile.file.metadata.statistics.Statistics.mergeStatistics(Statistics.java:164)
at org.apache.iotdb.tsfile.write.writer.TsFileIOWriter.flushMetadataIndex(TsFileIOWriter.java:304)
at org.apache.iotdb.tsfile.write.writer.TsFileIOWriter.endFile(TsFileIOWriter.java:239)
...
```