### PR TITLE
Fix sync bug

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/sync/receiver/transfer/SyncServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/receiver/transfer/SyncServiceImpl.java
@@ -210,8 +210,9 @@ public class SyncServiceImpl implements SyncService.Iface {
   @Override
   public SyncStatus syncData(ByteBuffer buff) {
     try {
+      int pos = buff.position();
       currentFileWriter.get().write(buff);
-      buff.flip();
+      buff.position(pos);
       messageDigest.get().update(buff);
     } catch (IOException e) {
       logger.error("Can not sync data for file {}", currentFile.get().getAbsoluteFile(), e);

--- a/server/src/main/java/org/apache/iotdb/db/sync/sender/manage/SyncFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/sync/sender/manage/SyncFileManager.java
@@ -100,12 +100,16 @@ public class SyncFileManager implements ISyncFileManager {
       allSGs.putIfAbsent(sgFolder.getName(), new HashSet<>());
       currentAllLocalFiles.putIfAbsent(sgFolder.getName(), new HashMap<>());
       for (File timeRangeFolder : sgFolder.listFiles()) {
-        Long timeRangeId = Long.parseLong(timeRangeFolder.getName());
-        currentAllLocalFiles.get(sgFolder.getName()).putIfAbsent(timeRangeId, new HashSet<>());
-        File[] files = timeRangeFolder.listFiles();
-        Arrays.stream(files)
-            .forEach(file -> currentAllLocalFiles.get(sgFolder.getName()).get(timeRangeId)
-                .add(new File(timeRangeFolder.getAbsolutePath(), file.getName())));
+        try {
+          Long timeRangeId = Long.parseLong(timeRangeFolder.getName());
+          currentAllLocalFiles.get(sgFolder.getName()).putIfAbsent(timeRangeId, new HashSet<>());
+          File[] files = timeRangeFolder.listFiles();
+          Arrays.stream(files)
+              .forEach(file -> currentAllLocalFiles.get(sgFolder.getName()).get(timeRangeId)
+                  .add(new File(timeRangeFolder.getAbsolutePath(), file.getName())));
+        } catch (Exception e) {
+          LOGGER.error("Invalid time range folder: {}", timeRangeFolder.getAbsolutePath(), e);
+        }
       }
     }
 


### PR DESCRIPTION
In some scenario, the thrift put some bytes in the ByteBuffer, so record its position and reset it could avoid this error.