### PR TITLE
[IOTDB-837] ArrayIndexOutOfBoundsException if the measurementId size is not consistent with the value size

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.LogicalOperatorException;
 import org.apache.iotdb.db.exception.query.LogicalOptimizeException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
+import org.apache.iotdb.db.exception.runtime.SQLParserException;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.constant.SQLConstant;
 import org.apache.iotdb.db.qp.logical.Operator;
@@ -105,12 +106,16 @@ import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.utils.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Used to convert logical operator to physical plan
  */
 public class PhysicalGenerator {
+
+  private static Logger logger = LoggerFactory.getLogger(PhysicalGenerator.class);
 
   public PhysicalPlan transformToPhysicalPlan(Operator operator) throws QueryProcessException {
     List<PartialPath> paths;
@@ -171,13 +176,9 @@ public class PhysicalGenerator {
       case INSERT:
         InsertOperator insert = (InsertOperator) operator;
         paths = insert.getSelectedPaths();
-        if (paths.size() != 1) {
-          throw new LogicalOperatorException(
-              "For Insert command, cannot specified more than one seriesPath: " + paths);
-        }
 
         if (insert.getMeasurementList().length != insert.getValueList().length) {
-          throw new ArrayIndexOutOfBoundsException(
+          throw new SQLParserException(
               String.format(
                   "the measurementList's size %d is not consistent with the valueList's size %d",
                   insert.getMeasurementList().length, insert.getValueList().length));

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -176,6 +176,13 @@ public class PhysicalGenerator {
               "For Insert command, cannot specified more than one seriesPath: " + paths);
         }
 
+        if (insert.getMeasurementList().length != insert.getValueList().length) {
+          throw new ArrayIndexOutOfBoundsException(
+              String.format(
+                  "the measurementList's size %d is not consistent with the valueList's size %d",
+                  insert.getMeasurementList().length, insert.getValueList().length));
+        }
+
         return new InsertRowPlan(paths.get(0), insert.getTime(),
             insert.getMeasurementList(), insert.getValueList());
       case MERGE:

--- a/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/strategy/PhysicalGenerator.java
@@ -106,16 +106,12 @@ import org.apache.iotdb.db.utils.SchemaUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.expression.IExpression;
 import org.apache.iotdb.tsfile.utils.Pair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * Used to convert logical operator to physical plan
  */
 public class PhysicalGenerator {
-
-  private static Logger logger = LoggerFactory.getLogger(PhysicalGenerator.class);
 
   public PhysicalPlan transformToPhysicalPlan(Operator operator) throws QueryProcessException {
     List<PartialPath> paths;
@@ -176,7 +172,6 @@ public class PhysicalGenerator {
       case INSERT:
         InsertOperator insert = (InsertOperator) operator;
         paths = insert.getSelectedPaths();
-
         if (insert.getMeasurementList().length != insert.getValueList().length) {
           throw new SQLParserException(
               String.format(

--- a/server/src/test/java/org/apache/iotdb/db/qp/PlannerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/qp/PlannerTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Collections;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
+import org.apache.iotdb.db.exception.runtime.SQLParserException;
 import org.apache.iotdb.db.metadata.MManager;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
@@ -147,6 +148,15 @@ public class PlannerTest {
     String queryStatement2 = "select windDirection10min from root.national.4.5.585.9_6666.9_333.88_9";
     PhysicalPlan plan13 = processor.parseSQLToPhysicalPlan(queryStatement2);
     assertEquals(OperatorType.QUERY, plan13.getOperatorType());
+
+    String insertStatementException = "insert into root.vehicle.d0(timestamp,s0,s1) values(10,100)";
+    try {
+      processor.parseSQLToPhysicalPlan(insertStatementException);
+    } catch (Exception e) {
+      assertEquals(new SQLParserException(
+          "the measurementList's size 2 is not consistent with the valueList's size 1")
+          .getMessage(), e.getMessage());
+    }
   }
 
   @Test(expected = ParseCancellationException.class)


### PR DESCRIPTION
ArrayIndexOutOfBoundsException if the measurementId size is not consistent with the value size