### PR TITLE
Python method "set_time_zone" exception message

### DIFF
--- a/client-py/src/Session.py
+++ b/client-py/src/Session.py
@@ -451,6 +451,6 @@ class Session(object):
             status = self.__client.setTimeZone(request)
             print("setting time zone_id as {}, message: {}".format(zone_id, status.message))
         except TTransport.TException as e:
-            print("Could not get time zone because: ", e)
+            print("Could not set time zone because: ", e)
             raise Exception
         self.__zone_id = zone_id


### PR DESCRIPTION
The method `set_time_zone` of the :snake: client threw an exception with a message mentioning `get time zone`. I guess that's a typo, so I fixed it :sunglasses:

Are there tests for this client? I couldn't find any :worried: