### PR TITLE
[IOTDB-869] Failed to insert data via Windows CLI

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -186,6 +186,12 @@
             <artifactId>oauth2-oidc-sdk</artifactId>
             <version>8.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>8.5.15</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -123,14 +123,10 @@ public class IoTDBDescriptor {
     // If the url doesn't start with "file:" or other protocols, it's provided as a normal path.
     // If valid, we return a URL converted from this file path.
     File confFile = new File(urlString);
-    if (confFile.exists()) {
-      try {
-        return confFile.toURI().toURL();
-      } catch (MalformedURLException e) {
-        return null;
-      }
-    }
     try {
+      if (confFile.exists()) {
+        return confFile.toURI().toURL();
+      }
       return new URL(urlString);
     } catch (MalformedURLException e) {
       return null;
@@ -142,11 +138,6 @@ public class IoTDBDescriptor {
    */
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   private void loadProps() {
-    try {
-      Thread.sleep(3000);
-    } catch (Exception e) {
-
-    }
     URL url = getPropsUrl();
     if(url == null) {
       logger.warn("Couldn't load the configuration from any of the known sources.");

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.time.ZoneId;
 import java.util.Properties;
@@ -118,10 +119,16 @@ public class IoTDBDescriptor {
     else if(!urlString.endsWith(".properties")) {
       urlString += (File.separatorChar + IoTDBConfig.CONFIG_NAME);
     }
-    // If the url doesn't start with "file:" it's provided as a normal path.
-    // So we need to add it to make it a real URL.
-    if(!urlString.startsWith("file:")) {
-      urlString = "file:" + urlString;
+
+    // If the url doesn't start with "file:" or other protocols, it's provided as a normal path.
+    // If valid, we return a URL converted from this file path.
+    File confFile = new File(urlString);
+    if (confFile.exists()) {
+      try {
+        return confFile.toURI().toURL();
+      } catch (MalformedURLException e) {
+        return null;
+      }
     }
     try {
       return new URL(urlString);
@@ -135,6 +142,11 @@ public class IoTDBDescriptor {
    */
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   private void loadProps() {
+    try {
+      Thread.sleep(3000);
+    } catch (Exception e) {
+
+    }
     URL url = getPropsUrl();
     if(url == null) {
       logger.warn("Couldn't load the configuration from any of the known sources.");

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -120,13 +120,12 @@ public class IoTDBDescriptor {
       urlString += (File.separatorChar + IoTDBConfig.CONFIG_NAME);
     }
 
-    // If the url doesn't start with "file:" or other protocols, it's provided as a normal path.
-    // If valid, we return a URL converted from this file path.
-    File confFile = new File(urlString);
+    // If the url doesn't start with "file:" it's provided as a normal path.
+    // So we need to add it to make it a real URL.
+    if(!urlString.startsWith("file:") && !urlString.startsWith("classpath:")) {
+      urlString = "file:" + urlString;
+    }
     try {
-      if (confFile.exists()) {
-        return confFile.toURI().toURL();
-      }
       return new URL(urlString);
     } catch (MalformedURLException e) {
       return null;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -120,7 +120,7 @@ public class IoTDBDescriptor {
       urlString += (File.separatorChar + IoTDBConfig.CONFIG_NAME);
     }
 
-    // If the url doesn't start with "file:" it's provided as a normal path.
+    // If the url doesn't start with "file:" or "classpath:", it's provided as a normal path.
     // So we need to add it to make it a real URL.
     if(!urlString.startsWith("file:") && !urlString.startsWith("classpath:")) {
       urlString = "file:" + urlString;

--- a/server/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.conf;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+
+public class IoTDBDescriptorTest {
+  private final String confPath = System.getProperty(IoTDBConstant.IOTDB_CONF, null);
+
+  @Before
+  public void init() {
+  }
+
+  @After
+  public void clear() {
+    if (confPath != null) {
+      System.setProperty(IoTDBConstant.IOTDB_CONF, confPath);
+    } else {
+      System.clearProperty(IoTDBConstant.IOTDB_CONF);
+    }
+  }
+
+  @Test
+  public void testConfigURLWithFileProtocol() {
+    IoTDBDescriptor desc = IoTDBDescriptor.getInstance();
+    String pathString = "file:/usr/local/bin";
+
+    System.setProperty(IoTDBConstant.IOTDB_CONF, pathString);
+    URL confURL = desc.getPropsUrl();
+    Assert.assertEquals(confURL.toString(), pathString + File.separatorChar + IoTDBConfig.CONFIG_NAME);
+  }
+
+  @Test
+  public void testConfigURLWithOtherProtocol() {
+    IoTDBDescriptor desc = IoTDBDescriptor.getInstance();
+
+    String pathString = "ftp://root/path";
+    System.setProperty(IoTDBConstant.IOTDB_CONF, pathString);
+    URL confURL = desc.getPropsUrl();
+    Assert.assertEquals(confURL.toString(), pathString + File.separatorChar + IoTDBConfig.CONFIG_NAME);
+
+    pathString = "https://github.com/apache/incubator-iotdb.git";
+    System.setProperty(IoTDBConstant.IOTDB_CONF, pathString);
+    confURL = desc.getPropsUrl();
+    Assert.assertEquals(confURL.toString(), pathString + File.separatorChar + IoTDBConfig.CONFIG_NAME);
+  }
+
+  @Test
+  public void testConfigURLWithPlainFilePath() {
+    IoTDBDescriptor desc = IoTDBDescriptor.getInstance();
+    URL path = IoTDBConfig.class.getResource("/" + IoTDBConfig.CONFIG_NAME);
+    // filePath is a plain path string
+    String filePath = path.getFile();
+    System.setProperty(IoTDBConstant.IOTDB_CONF, filePath);
+    URL confURL = desc.getPropsUrl();
+    Assert.assertEquals(confURL.toString(), path.toString());
+  }
+
+  @Test
+  public void testConfigURLWithDefaultPath() {
+    IoTDBDescriptor desc = IoTDBDescriptor.getInstance();
+    URL path = IoTDBConfig.class.getResource("/" + IoTDBConfig.CONFIG_NAME);
+    URL confURL = desc.getPropsUrl();
+    Assert.assertEquals(confURL.toString(), path.toString());
+  }
+
+}

--- a/server/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorTest.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class IoTDBDescriptorTest {
   private final String confPath = System.getProperty(IoTDBConstant.IOTDB_CONF, null);
@@ -49,7 +51,7 @@ public class IoTDBDescriptorTest {
 
     System.setProperty(IoTDBConstant.IOTDB_CONF, pathString);
     URL confURL = desc.getPropsUrl();
-    Assert.assertEquals(confURL.toString(), pathString + File.separatorChar + IoTDBConfig.CONFIG_NAME);
+    Assert.assertTrue(confURL.toString().startsWith(pathString));
   }
 
   @Test
@@ -59,12 +61,12 @@ public class IoTDBDescriptorTest {
     String pathString = "ftp://root/path";
     System.setProperty(IoTDBConstant.IOTDB_CONF, pathString);
     URL confURL = desc.getPropsUrl();
-    Assert.assertEquals(confURL.toString(), pathString + File.separatorChar + IoTDBConfig.CONFIG_NAME);
+    Assert.assertTrue(confURL.toString().startsWith(pathString));
 
     pathString = "https://github.com/apache/incubator-iotdb.git";
     System.setProperty(IoTDBConstant.IOTDB_CONF, pathString);
     confURL = desc.getPropsUrl();
-    Assert.assertEquals(confURL.toString(), pathString + File.separatorChar + IoTDBConfig.CONFIG_NAME);
+    Assert.assertTrue(confURL.toString().startsWith(pathString));
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorTest.java
@@ -23,16 +23,14 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class IoTDBDescriptorTest {
   private final String confPath = System.getProperty(IoTDBConstant.IOTDB_CONF, null);
 
   @Before
   public void init() {
+    org.apache.catalina.webresources.TomcatURLStreamHandlerFactory.getInstance();
   }
 
   @After
@@ -55,17 +53,12 @@ public class IoTDBDescriptorTest {
   }
 
   @Test
-  public void testConfigURLWithOtherProtocol() {
+  public void testConfigURLWithClasspathProtocol() {
     IoTDBDescriptor desc = IoTDBDescriptor.getInstance();
 
-    String pathString = "ftp://root/path";
+    String pathString = "classpath:/root/path";
     System.setProperty(IoTDBConstant.IOTDB_CONF, pathString);
     URL confURL = desc.getPropsUrl();
-    Assert.assertTrue(confURL.toString().startsWith(pathString));
-
-    pathString = "https://github.com/apache/incubator-iotdb.git";
-    System.setProperty(IoTDBConstant.IOTDB_CONF, pathString);
-    confURL = desc.getPropsUrl();
     Assert.assertTrue(confURL.toString().startsWith(pathString));
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/conf/IoTDBDescriptorTest.java
@@ -78,12 +78,4 @@ public class IoTDBDescriptorTest {
     Assert.assertEquals(confURL.toString(), path.toString());
   }
 
-  @Test
-  public void testConfigURLWithDefaultPath() {
-    IoTDBDescriptor desc = IoTDBDescriptor.getInstance();
-    URL path = IoTDBConfig.class.getResource("/" + IoTDBConfig.CONFIG_NAME);
-    URL confURL = desc.getPropsUrl();
-    Assert.assertEquals(confURL.toString(), path.toString());
-  }
-
 }


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/IOTDB-869

This issue occurs because IoTDB failed to load "iotdb-engine.properties" when starting on Windows.
When the file path is in the format of "D:/path" on WinOS, it will not be recognized as valid protocol when creating a URL object. 