### PR TITLE
[IOTDB-872] Use system timezone in CLI

### DIFF
--- a/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
+++ b/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
@@ -537,8 +537,6 @@ public abstract class AbstractCli {
     } catch (SQLException e) {
       println(String.format("Failed to import from %s because %s",
           cmd.split(" ")[1], e.getMessage()));
-    } catch (TException e) {
-      println("Cannot connect to server");
     }
   }
 

--- a/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
+++ b/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
@@ -467,6 +467,13 @@ public abstract class AbstractCli {
     println("Time display type has set to " + cmd.split("=")[1].trim());
   }
 
+  /**
+   * if cli has not specified a zondId, it will be set to cli's system timezone by default
+   * otherwise for insert and query accuracy cli should set timezone the same for all sessions
+   * @param specialCmd
+   * @param cmd
+   * @param connection
+   */
   private static void setTimeZone(String specialCmd, String cmd, IoTDBConnection connection) {
     String[] values = specialCmd.split("=");
     if (values.length != 2) {
@@ -537,6 +544,8 @@ public abstract class AbstractCli {
     } catch (SQLException e) {
       println(String.format("Failed to import from %s because %s",
           cmd.split(" ")[1], e.getMessage()));
+    } catch (TException e) {
+      println("Cannot connect to server");
     }
   }
 

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -490,18 +490,12 @@ public class IoTDBConnection implements Connection {
     return flag;
   }
 
-  public String getTimeZone() throws TException, IoTDBSQLException {
+  public String getTimeZone() {
     if (zoneId != null) {
       return zoneId.toString();
     }
-
-    TSGetTimeZoneResp resp = getClient().getTimeZone(sessionId);
-    try {
-      RpcUtils.verifySuccess(resp.getStatus());
-    } catch (StatementExecutionException e) {
-      throw new IoTDBSQLException(e.getMessage(), resp.getStatus());
-    }
-    return resp.getTimeZone();
+    zoneId = ZoneId.systemDefault();
+    return zoneId.toString();
   }
 
   public void setTimeZone(String zoneId) throws TException, IoTDBSQLException {

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -490,12 +490,11 @@ public class IoTDBConnection implements Connection {
     return flag;
   }
 
-  public String getTimeZone() {
+  public String getTimeZone() throws TException, IoTDBSQLException {
     if (zoneId != null) {
       return zoneId.toString();
     }
-    zoneId = ZoneId.systemDefault();
-    return zoneId.toString();
+    return ZoneId.systemDefault().getId();
   }
 
   public void setTimeZone(String zoneId) throws TException, IoTDBSQLException {

--- a/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -38,7 +38,6 @@ import java.time.ZoneId;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
-import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.*;

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBConnectionTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBConnectionTest.java
@@ -21,6 +21,9 @@ package org.apache.iotdb.jdbc;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
+
+import java.awt.SystemTray;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.rpc.RpcUtils;
@@ -52,7 +55,7 @@ public class IoTDBConnectionTest {
   }
 
   @Test
-  public void testSetTimeZone() throws TException, IoTDBSQLException {
+  public void testSetTimeZone() throws IoTDBSQLException, TException {
     String timeZone = "Asia/Shanghai";
     when(client.setTimeZone(any(TSSetTimeZoneReq.class)))
         .thenReturn(new TSStatus(successStatus));
@@ -63,7 +66,7 @@ public class IoTDBConnectionTest {
 
   @Test
   public void testGetTimeZone() throws IoTDBSQLException, TException {
-    String timeZone = "GMT+:08:00";
+    String timeZone = "Asia/Shanghai";
     sessionId = connection.getSessionId();
     when(client.getTimeZone(sessionId)).thenReturn(new TSGetTimeZoneResp(successStatus, timeZone));
     connection.setClient(client);

--- a/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBConnectionTest.java
+++ b/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBConnectionTest.java
@@ -21,13 +21,17 @@ package org.apache.iotdb.jdbc;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
 import java.awt.SystemTray;
+>>>>>>> 93c25111b... Update IoTDBConnectionTest.java
+=======
+>>>>>>> 86860fd29... fixed tests, add comments
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.rpc.RpcUtils;
-import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.*;
 import org.apache.thrift.TException;
 import org.junit.After;
@@ -66,7 +70,7 @@ public class IoTDBConnectionTest {
 
   @Test
   public void testGetTimeZone() throws IoTDBSQLException, TException {
-    String timeZone = "Asia/Shanghai";
+    String timeZone = ZoneId.systemDefault().toString();
     sessionId = connection.getSessionId();
     when(client.getTimeZone(sessionId)).thenReturn(new TSGetTimeZoneResp(successStatus, timeZone));
     connection.setClient(client);


### PR DESCRIPTION
cli timezone will be set to cli local timezone by default, instead of server timezone 