### PR TITLE
[IOTDB-904] fix update last cache NullPointerException

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -106,10 +106,10 @@ public abstract class AbstractMemTable implements IMemTable {
       }
 
       Object value = insertRowPlan.getValues()[i];
-      memSize += MemUtils.getRecordSize(insertRowPlan.getSchemas()[i].getType(), value);
+      memSize += MemUtils.getRecordSize(insertRowPlan.getMNodes()[i].getSchema().getType(), value);
 
       write(insertRowPlan.getDeviceId().getFullPath(), insertRowPlan.getMeasurements()[i],
-          insertRowPlan.getSchemas()[i], insertRowPlan.getTime(), value);
+          insertRowPlan.getMNodes()[i].getSchema(), insertRowPlan.getTime(), value);
     }
 
     totalPointsNum += insertRowPlan.getMeasurements().length - insertRowPlan.getFailedMeasurementNumber();
@@ -143,7 +143,7 @@ public abstract class AbstractMemTable implements IMemTable {
         continue;
       }
       IWritableMemChunk memSeries = createIfNotExistAndGet(insertTabletPlan.getDeviceId().getFullPath(),
-          insertTabletPlan.getMeasurements()[i], insertTabletPlan.getSchemas()[i]);
+          insertTabletPlan.getMeasurements()[i], insertTabletPlan.getMNodes()[i].getSchema());
       memSeries.write(insertTabletPlan.getTimes(), insertTabletPlan.getColumns()[i],
           insertTabletPlan.getDataTypes()[i], start, end);
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/memtable/AbstractMemTable.java
@@ -106,10 +106,10 @@ public abstract class AbstractMemTable implements IMemTable {
       }
 
       Object value = insertRowPlan.getValues()[i];
-      memSize += MemUtils.getRecordSize(insertRowPlan.getMNodes()[i].getSchema().getType(), value);
+      memSize += MemUtils.getRecordSize(insertRowPlan.getMeasurementMNodes()[i].getSchema().getType(), value);
 
       write(insertRowPlan.getDeviceId().getFullPath(), insertRowPlan.getMeasurements()[i],
-          insertRowPlan.getMNodes()[i].getSchema(), insertRowPlan.getTime(), value);
+          insertRowPlan.getMeasurementMNodes()[i].getSchema(), insertRowPlan.getTime(), value);
     }
 
     totalPointsNum += insertRowPlan.getMeasurements().length - insertRowPlan.getFailedMeasurementNumber();
@@ -143,7 +143,7 @@ public abstract class AbstractMemTable implements IMemTable {
         continue;
       }
       IWritableMemChunk memSeries = createIfNotExistAndGet(insertTabletPlan.getDeviceId().getFullPath(),
-          insertTabletPlan.getMeasurements()[i], insertTabletPlan.getMNodes()[i].getSchema());
+          insertTabletPlan.getMeasurements()[i], insertTabletPlan.getMeasurementMNodes()[i].getSchema());
       memSeries.write(insertTabletPlan.getTimes(), insertTabletPlan.getColumns()[i],
           insertTabletPlan.getDataTypes()[i], start, end);
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -791,18 +791,18 @@ public class StorageGroupProcessor {
   }
 
   private void tryToUpdateBatchInsertLastCache(InsertTabletPlan plan, Long latestFlushedTime) {
-    MeasurementMNode[] mNodes = plan.getMNodes();
+    MeasurementMNode[] mNodes = plan.getMeasurementMNodes();
     for (int i = 0; i < mNodes.length; i++) {
       if (plan.getColumns()[i] == null) {
         continue;
       }
       // Update cached last value with high priority
       if (mNodes[i] != null) {
-        // in stand alone version, the seriesPath is not needed, just use mNodes[i] to update last cache
+        // in stand alone version, the seriesPath is not needed, just use measurementMNodes[i] to update last cache
         IoTDB.metaManager.updateLastCache(null,
             plan.composeLastTimeValuePair(i), true, latestFlushedTime, mNodes[i]);
       } else {
-        // mNodes[i] is null, use the path to update remote cache
+        // measurementMNodes[i] is null, use the path to update remote cache
         IoTDB.metaManager
             .updateLastCache(plan.getDeviceId().concatNode(plan.getMeasurements()[i]),
                 plan.composeLastTimeValuePair(i), true, latestFlushedTime, null);
@@ -843,14 +843,14 @@ public class StorageGroupProcessor {
   }
 
   private void tryToUpdateInsertLastCache(InsertRowPlan plan, Long latestFlushedTime) {
-    MeasurementMNode[] mNodes = plan.getMNodes();
+    MeasurementMNode[] mNodes = plan.getMeasurementMNodes();
     for (int i = 0; i < mNodes.length; i++) {
       if (plan.getValues()[i] == null) {
         continue;
       }
       // Update cached last value with high priority
       if (mNodes[i] != null) {
-        // in stand alone version, the seriesPath is not needed, just use mNodes[i] to update last cache
+        // in stand alone version, the seriesPath is not needed, just use measurementMNodes[i] to update last cache
         IoTDB.metaManager.updateLastCache(null,
             plan.composeTimeValuePair(i), true, latestFlushedTime, mNodes[i]);
       } else {

--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/StorageGroupProcessor.java
@@ -791,28 +791,21 @@ public class StorageGroupProcessor {
   }
 
   private void tryToUpdateBatchInsertLastCache(InsertTabletPlan plan, Long latestFlushedTime) {
-    MNode node = plan.getDeviceMNode();
-    String[] measurementList = plan.getMeasurements();
-    for (int i = 0; i < measurementList.length; i++) {
+    MeasurementMNode[] mNodes = plan.getMNodes();
+    for (int i = 0; i < mNodes.length; i++) {
       if (plan.getColumns()[i] == null) {
         continue;
       }
       // Update cached last value with high priority
-      MeasurementMNode tmpMeasurementNode = null;
-      if (node != null) {
-        tmpMeasurementNode = (MeasurementMNode) node.getChild(measurementList[i]);
-      }
-      if (tmpMeasurementNode != null) {
-        // just for performance, because in single node version, we do not need the full path of measurement
-        // so, we want to avoid concat the device and measurement string in single node version
-        IoTDB.metaManager.updateLastCache(node.getPartialPath(),
-            plan.composeLastTimeValuePair(i), true, latestFlushedTime, tmpMeasurementNode);
+      if (mNodes[i] != null) {
+        // in stand alone version, the seriesPath is not needed, just use mNodes[i] to update last cache
+        IoTDB.metaManager.updateLastCache(null,
+            plan.composeLastTimeValuePair(i), true, latestFlushedTime, mNodes[i]);
       } else {
-        if (node != null) {
-          IoTDB.metaManager
-              .updateLastCache(node.getPartialPath().concatNode(measurementList[i]),
-                  plan.composeLastTimeValuePair(i), true, latestFlushedTime, tmpMeasurementNode);
-        }
+        // mNodes[i] is null, use the path to update remote cache
+        IoTDB.metaManager
+            .updateLastCache(plan.getDeviceId().concatNode(plan.getMeasurements()[i]),
+                plan.composeLastTimeValuePair(i), true, latestFlushedTime, null);
       }
     }
   }
@@ -850,28 +843,20 @@ public class StorageGroupProcessor {
   }
 
   private void tryToUpdateInsertLastCache(InsertRowPlan plan, Long latestFlushedTime) {
-    MNode node = plan.getDeviceMNode();
-    String[] measurementList = plan.getMeasurements();
-    for (int i = 0; i < measurementList.length; i++) {
+    MeasurementMNode[] mNodes = plan.getMNodes();
+    for (int i = 0; i < mNodes.length; i++) {
       if (plan.getValues()[i] == null) {
         continue;
       }
       // Update cached last value with high priority
-      MeasurementMNode tmpMeasurementNode = null;
-      if (node != null) {
-        tmpMeasurementNode = (MeasurementMNode) node.getChild(measurementList[i]);
-      }
-      if (tmpMeasurementNode != null) {
-        // just for performance, because in single node version, we do not need the full path of measurement
-        // so, we want to avoid concat the device and measurement string in single node version
-        IoTDB.metaManager.updateLastCache(node.getPartialPath(),
-            plan.composeTimeValuePair(i), true, latestFlushedTime, tmpMeasurementNode);
+      if (mNodes[i] != null) {
+        // in stand alone version, the seriesPath is not needed, just use mNodes[i] to update last cache
+        IoTDB.metaManager.updateLastCache(null,
+            plan.composeTimeValuePair(i), true, latestFlushedTime, mNodes[i]);
       } else {
-        if (node != null) {
-          IoTDB.metaManager
-              .updateLastCache(node.getPartialPath().concatNode(measurementList[i]),
-                  plan.composeTimeValuePair(i), true, latestFlushedTime, tmpMeasurementNode);
-        }
+        IoTDB.metaManager
+            .updateLastCache(plan.getDeviceId().concatNode(plan.getMeasurements()[i]),
+                plan.composeTimeValuePair(i), true, latestFlushedTime, null);
       }
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/executor/PlanExecutor.java
@@ -912,7 +912,7 @@ public class PlanExecutor implements IPlanExecutor {
     }
   }
 
-  protected MeasurementSchema[] getSeriesSchemas(InsertPlan insertPlan)
+  protected MeasurementMNode[] getSeriesSchemas(InsertPlan insertPlan)
       throws MetadataException {
     return mManager
         .getSeriesSchemasAndReadLockDevice(insertPlan.getDeviceId(), insertPlan.getMeasurements(),
@@ -922,8 +922,8 @@ public class PlanExecutor implements IPlanExecutor {
   @Override
   public void insert(InsertRowPlan insertRowPlan) throws QueryProcessException {
     try {
-      MeasurementSchema[] schemas = getSeriesSchemas(insertRowPlan);
-      insertRowPlan.setSchemasAndTransferType(schemas);
+      MeasurementMNode[] mNodes = getSeriesSchemas(insertRowPlan);
+      insertRowPlan.setMNodesAndTransferType(mNodes);
       StorageEngine.getInstance().insert(insertRowPlan);
       if (insertRowPlan.getFailedMeasurements() != null) {
         throw new StorageEngineException(
@@ -939,8 +939,8 @@ public class PlanExecutor implements IPlanExecutor {
   @Override
   public void insertTablet(InsertTabletPlan insertTabletPlan) throws QueryProcessException {
     try {
-      MeasurementSchema[] schemas = getSeriesSchemas(insertTabletPlan);
-      insertTabletPlan.setSchemas(schemas);
+      MeasurementMNode[] mNodes = getSeriesSchemas(insertTabletPlan);
+      insertTabletPlan.setMeasurementMNodes(mNodes);
       StorageEngine.getInstance().insertTablet(insertTabletPlan);
       if (insertTabletPlan.getFailedMeasurements() != null) {
         throw new StorageEngineException(

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
@@ -22,19 +22,17 @@ package org.apache.iotdb.db.qp.physical.crud;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.db.metadata.PartialPath;
-import org.apache.iotdb.db.metadata.mnode.MNode;
 import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 abstract public class InsertPlan extends PhysicalPlan {
 
   protected PartialPath deviceId;
   protected String[] measurements;
   protected TSDataType[] dataTypes;
-  protected MeasurementMNode[] mNodes;
+  protected MeasurementMNode[] measurementMNodes;
 
   // record the failed measurements
   protected List<String> failedMeasurements;
@@ -68,12 +66,12 @@ abstract public class InsertPlan extends PhysicalPlan {
     this.dataTypes = dataTypes;
   }
 
-  public MeasurementMNode[] getMNodes() {
-    return mNodes;
+  public MeasurementMNode[] getMeasurementMNodes() {
+    return measurementMNodes;
   }
 
   public void setMeasurementMNodes(MeasurementMNode[] mNodes) {
-    this.mNodes = mNodes;
+    this.measurementMNodes = mNodes;
   }
 
   public List<String> getFailedMeasurements() {

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertPlan.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.iotdb.db.metadata.PartialPath;
 import org.apache.iotdb.db.metadata.mnode.MNode;
+import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.physical.PhysicalPlan;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -33,10 +34,7 @@ abstract public class InsertPlan extends PhysicalPlan {
   protected PartialPath deviceId;
   protected String[] measurements;
   protected TSDataType[] dataTypes;
-  protected MeasurementSchema[] schemas;
-
-  // for updating last cache
-  private MNode deviceMNode;
+  protected MeasurementMNode[] mNodes;
 
   // record the failed measurements
   protected List<String> failedMeasurements;
@@ -70,12 +68,12 @@ abstract public class InsertPlan extends PhysicalPlan {
     this.dataTypes = dataTypes;
   }
 
-  public MeasurementSchema[] getSchemas() {
-    return schemas;
+  public MeasurementMNode[] getMNodes() {
+    return mNodes;
   }
 
-  public void setSchemas(MeasurementSchema[] schemas) {
-    this.schemas = schemas;
+  public void setMeasurementMNodes(MeasurementMNode[] mNodes) {
+    this.mNodes = mNodes;
   }
 
   public List<String> getFailedMeasurements() {
@@ -84,14 +82,6 @@ abstract public class InsertPlan extends PhysicalPlan {
 
   public int getFailedMeasurementNumber() {
     return failedMeasurements == null ? 0 : failedMeasurements.size();
-  }
-
-  public MNode getDeviceMNode() {
-    return deviceMNode;
-  }
-
-  public void setDeviceMNode(MNode deviceMNode) {
-    this.deviceMNode = deviceMNode;
   }
 
   /**

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowPlan.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.metadata.PathNotExistException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.PartialPath;
+import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
 import org.apache.iotdb.db.qp.logical.Operator;
 import org.apache.iotdb.db.qp.logical.Operator.OperatorType;
 import org.apache.iotdb.db.utils.CommonUtils;
@@ -101,13 +102,14 @@ public class InsertRowPlan extends InsertPlan {
     this.deviceId = new PartialPath(tsRecord.deviceId);
     this.time = tsRecord.time;
     this.measurements = new String[tsRecord.dataPointList.size()];
-    this.schemas = new MeasurementSchema[tsRecord.dataPointList.size()];
+    this.mNodes = new MeasurementMNode[tsRecord.dataPointList.size()];
     this.dataTypes = new TSDataType[tsRecord.dataPointList.size()];
     this.values = new Object[tsRecord.dataPointList.size()];
     for (int i = 0; i < tsRecord.dataPointList.size(); i++) {
       measurements[i] = tsRecord.dataPointList.get(i).getMeasurementId();
-      schemas[i] = new MeasurementSchema(measurements[i], tsRecord.dataPointList.get(i).getType(),
-          TSEncoding.PLAIN);
+      mNodes[i] = new MeasurementMNode(null, measurements[i],
+          new MeasurementSchema(measurements[i], tsRecord.dataPointList.get(i).getType(),
+              TSEncoding.PLAIN), null);
       dataTypes[i] = tsRecord.dataPointList.get(i).getType();
       values[i] = tsRecord.dataPointList.get(i).getValue();
     }
@@ -158,11 +160,11 @@ public class InsertRowPlan extends InsertPlan {
    * Double, Binary)
    */
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
-  public void setSchemasAndTransferType(MeasurementSchema[] schemas) throws QueryProcessException {
-    this.schemas = schemas;
+  public void setMNodesAndTransferType(MeasurementMNode[] mNodes) throws QueryProcessException {
+    this.mNodes = mNodes;
     if (isNeedInferType) {
-      for (int i = 0; i < schemas.length; i++) {
-        if (schemas[i] == null) {
+      for (int i = 0; i < mNodes.length; i++) {
+        if (mNodes[i] == null) {
           if (IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert()) {
             markFailedMeasurementInsertion(i);
           } else {
@@ -171,7 +173,7 @@ public class InsertRowPlan extends InsertPlan {
           }
           continue;
         }
-        dataTypes[i] = schemas[i].getType();
+        dataTypes[i] = mNodes[i].getSchema().getType();
         try {
           values[i] = CommonUtils.parseValue(dataTypes[i], values[i].toString());
         } catch (Exception e) {
@@ -179,7 +181,7 @@ public class InsertRowPlan extends InsertPlan {
               measurements[i], values[i], dataTypes[i]);
           if (IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert()) {
             markFailedMeasurementInsertion(i);
-            schemas[i] = null;
+            mNodes[i] = null;
           } else {
             throw e;
           }
@@ -430,6 +432,6 @@ public class InsertRowPlan extends InsertPlan {
     }
     Object value = values[measurementIndex];
     return new TimeValuePair(time,
-        TsPrimitiveType.getByType(schemas[measurementIndex].getType(), value));
+        TsPrimitiveType.getByType(mNodes[measurementIndex].getSchema().getType(), value));
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowPlan.java
+++ b/server/src/main/java/org/apache/iotdb/db/qp/physical/crud/InsertRowPlan.java
@@ -102,12 +102,12 @@ public class InsertRowPlan extends InsertPlan {
     this.deviceId = new PartialPath(tsRecord.deviceId);
     this.time = tsRecord.time;
     this.measurements = new String[tsRecord.dataPointList.size()];
-    this.mNodes = new MeasurementMNode[tsRecord.dataPointList.size()];
+    this.measurementMNodes = new MeasurementMNode[tsRecord.dataPointList.size()];
     this.dataTypes = new TSDataType[tsRecord.dataPointList.size()];
     this.values = new Object[tsRecord.dataPointList.size()];
     for (int i = 0; i < tsRecord.dataPointList.size(); i++) {
       measurements[i] = tsRecord.dataPointList.get(i).getMeasurementId();
-      mNodes[i] = new MeasurementMNode(null, measurements[i],
+      measurementMNodes[i] = new MeasurementMNode(null, measurements[i],
           new MeasurementSchema(measurements[i], tsRecord.dataPointList.get(i).getType(),
               TSEncoding.PLAIN), null);
       dataTypes[i] = tsRecord.dataPointList.get(i).getType();
@@ -161,7 +161,7 @@ public class InsertRowPlan extends InsertPlan {
    */
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public void setMNodesAndTransferType(MeasurementMNode[] mNodes) throws QueryProcessException {
-    this.mNodes = mNodes;
+    this.measurementMNodes = mNodes;
     if (isNeedInferType) {
       for (int i = 0; i < mNodes.length; i++) {
         if (mNodes[i] == null) {
@@ -432,6 +432,6 @@ public class InsertRowPlan extends InsertPlan {
     }
     Object value = values[measurementIndex];
     return new TimeValuePair(time,
-        TsPrimitiveType.getByType(mNodes[measurementIndex].getSchema().getType(), value));
+        TsPrimitiveType.getByType(measurementMNodes[measurementIndex].getSchema().getType(), value));
   }
 }

--- a/server/src/test/java/org/apache/iotdb/db/engine/cache/ChunkMetadataCacheTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/cache/ChunkMetadataCacheTest.java
@@ -92,13 +92,6 @@ public class ChunkMetadataCacheTest {
     record.addTuple(DataPoint.getDataPoint(TSDataType.DOUBLE, measurementId3, String.valueOf(num)));
     record.addTuple(DataPoint.getDataPoint(TSDataType.BOOLEAN, measurementId4, "True"));
     InsertRowPlan insertRowPlan = new InsertRowPlan(record);
-    MNode mNode = new MNode(null, storageGroup);
-    mNode.addChild(measurementId0, new MeasurementMNode(null, null, null, null));
-    mNode.addChild(measurementId1, new MeasurementMNode(null, null, null, null));
-    mNode.addChild(measurementId2, new MeasurementMNode(null, null, null, null));
-    mNode.addChild(measurementId3, new MeasurementMNode(null, null, null, null));
-    mNode.addChild(measurementId4, new MeasurementMNode(null, null, null, null));
-    insertRowPlan.setDeviceMNode(mNode);
     storageGroupProcessor.insert(insertRowPlan);
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionFileNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionFileNodeTest.java
@@ -66,7 +66,6 @@ public class DeletionFileNodeTest {
   private static String[] measurements = new String[10];
   private TSDataType dataType = TSDataType.DOUBLE;
   private TSEncoding encoding = TSEncoding.PLAIN;
-  private MNode deviceMNode = null;
 
   static {
     for (int i = 0; i < 10; i++) {
@@ -78,10 +77,8 @@ public class DeletionFileNodeTest {
   public void setup() throws MetadataException {
     EnvironmentUtils.envSetUp();
 
-    deviceMNode = new MNode(null, processorName);
     IoTDB.metaManager.setStorageGroup(new PartialPath(processorName));
     for (int i = 0; i < 10; i++) {
-      deviceMNode.addChild(measurements[i], new MeasurementMNode(null, null, null, null));
       IoTDB.metaManager.createTimeseries(new PartialPath(processorName + TsFileConstant.PATH_SEPARATOR + measurements[i]), dataType,
           encoding, TSFileDescriptor.getInstance().getConfig().getCompressor(), Collections.emptyMap());
     }
@@ -95,7 +92,6 @@ public class DeletionFileNodeTest {
   private void insertToStorageEngine(TSRecord record)
       throws StorageEngineException, IllegalPathException {
     InsertRowPlan insertRowPlan = new InsertRowPlan(record);
-    insertRowPlan.setDeviceMNode(deviceMNode);
     StorageEngine.getInstance().insert(insertRowPlan);
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionQueryTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/modification/DeletionQueryTest.java
@@ -58,7 +58,7 @@ public class DeletionQueryTest {
   private TSDataType dataType = TSDataType.DOUBLE;
   private TSEncoding encoding = TSEncoding.PLAIN;
   private QueryRouter router = new QueryRouter();
-  private MNode deviceMNode = null;
+
 
   static {
     for (int i = 0; i < 10; i++) {
@@ -69,10 +69,8 @@ public class DeletionQueryTest {
   @Before
   public void setup() throws MetadataException {
     EnvironmentUtils.envSetUp();
-    deviceMNode = new MNode(null, processorName);
     IoTDB.metaManager.setStorageGroup(new PartialPath(processorName));
     for (int i = 0; i < 10; i++) {
-      deviceMNode.addChild(measurements[i], new MeasurementMNode(null, null, null, null));
       IoTDB.metaManager.createTimeseries(new PartialPath(processorName + TsFileConstant.PATH_SEPARATOR + measurements[i]), dataType,
           encoding, TSFileDescriptor.getInstance().getConfig().getCompressor(), Collections.emptyMap());
     }
@@ -86,7 +84,6 @@ public class DeletionQueryTest {
   private void insertToStorageEngine(TSRecord record)
       throws StorageEngineException, IllegalPathException {
     InsertRowPlan insertRowPlan = new InsertRowPlan(record);
-    insertRowPlan.setDeviceMNode(deviceMNode);
     StorageEngine.getInstance().insert(insertRowPlan);
   }
 

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TTLTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/TTLTest.java
@@ -82,7 +82,6 @@ public class TTLTest {
   private String g1s1 = sg1 + IoTDBConstant.PATH_SEPARATOR + s1;
   private long prevPartitionInterval;
 
-  private MNode deviceMNode = null;
 
   @Before
   public void setUp()
@@ -91,8 +90,6 @@ public class TTLTest {
     IoTDBDescriptor.getInstance().getConfig().setPartitionInterval(86400);
     EnvironmentUtils.envSetUp();
     createSchemas();
-    deviceMNode = new MNode(null, sg1);
-    deviceMNode.addChild(s1, new MeasurementMNode(null, null, null, null));
   }
 
   @After
@@ -104,7 +101,6 @@ public class TTLTest {
 
   private void insertToStorageGroupProcessor(InsertRowPlan insertPlan)
       throws WriteProcessException {
-    insertPlan.setDeviceMNode(deviceMNode);
     storageGroupProcessor.insert(insertPlan);
   }
 
@@ -149,8 +145,8 @@ public class TTLTest {
     plan.setMeasurements(new String[]{"s1"});
     plan.setDataTypes(new TSDataType[]{TSDataType.INT64});
     plan.setValues(new Object[]{1L});
-    plan.setSchemasAndTransferType(
-        new MeasurementSchema[]{new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.PLAIN)});
+    plan.setMNodesAndTransferType(new MeasurementMNode[]{new MeasurementMNode(null, null,
+            new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.PLAIN), null)});
 
     // ok without ttl
     insertToStorageGroupProcessor(plan);
@@ -177,8 +173,8 @@ public class TTLTest {
     plan.setMeasurements(new String[]{"s1"});
     plan.setDataTypes(new TSDataType[]{TSDataType.INT64});
     plan.setValues(new Object[]{1L});
-    plan.setSchemasAndTransferType(
-        new MeasurementSchema[]{new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.PLAIN)});
+    plan.setMNodesAndTransferType(new MeasurementMNode[]{new MeasurementMNode(null, null,
+            new MeasurementSchema("s1", TSDataType.INT64, TSEncoding.PLAIN), null)});
 
     long initTime = System.currentTimeMillis();
     // sequence data

--- a/server/src/test/java/org/apache/iotdb/db/writelog/recover/LogReplayerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/writelog/recover/LogReplayerTest.java
@@ -44,7 +44,6 @@ import org.apache.iotdb.db.exception.metadata.IllegalPathException;
 import org.apache.iotdb.db.exception.metadata.MetadataException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.metadata.PartialPath;
-import org.apache.iotdb.db.metadata.mnode.MNode;
 import org.apache.iotdb.db.metadata.mnode.MeasurementMNode;
 import org.apache.iotdb.db.qp.physical.crud.DeletePlan;
 import org.apache.iotdb.db.qp.physical.crud.InsertRowPlan;
@@ -58,8 +57,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.read.TimeValuePair;
 import org.apache.iotdb.tsfile.read.reader.IPointReader;
-import org.apache.iotdb.tsfile.write.record.Tablet;
-import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -204,9 +201,9 @@ public class LogReplayerTest {
 
     String deviceId = "root.sg.device5";
 
-    MNode deviceMNode = new MNode(null, deviceId);
-    deviceMNode.addChild("sensor0", new MeasurementMNode(null, null, null, null));
-    deviceMNode.addChild("sensor1", new MeasurementMNode(null, null, null, null));
+    MeasurementMNode[] mNodes = new MeasurementMNode[2];
+    mNodes[0] = new MeasurementMNode(null, "sensor0", null, null);
+    mNodes[0] = new MeasurementMNode(null, "sensor1", null, null);
 
     InsertTabletPlan insertTabletPlan = new InsertTabletPlan(new PartialPath(deviceId), measurements, dataTypes);
 
@@ -223,7 +220,7 @@ public class LogReplayerTest {
     insertTabletPlan.setTimes(times);
     insertTabletPlan.setColumns(columns);
     insertTabletPlan.setRowCount(times.length);
-    insertTabletPlan.setDeviceMNode(deviceMNode);
+    insertTabletPlan.setMeasurementMNodes(mNodes);
     insertTabletPlan.setStart(0);
     insertTabletPlan.setEnd(100);
 


### PR DESCRIPTION
In previous, the deviceMNode is cached in the InsertPlan.  Actually we could cache the MeasurementMNode directly instead of the MeasurementSchema and deviceMNode.